### PR TITLE
[US1530]Volume resize cmd for uzfs.

### DIFF
--- a/include/sys/zvol.h
+++ b/include/sys/zvol.h
@@ -45,11 +45,13 @@ extern int zvol_check_volsize(uint64_t volsize, uint64_t blocksize);
 extern int zvol_check_volblocksize(const char *name, uint64_t volblocksize);
 extern int zvol_get_stats(objset_t *os, nvlist_t *nv);
 
-#ifdef _KERNEL
 typedef struct zvol_state zvol_state_t;
-
-extern boolean_t zvol_is_zvol(const char *);
+extern int zvol_update_volsize(uint64_t volsize, objset_t *os);
+extern void zvol_size_changed(zvol_state_t *zv, uint64_t volsize);
 extern int zvol_set_volsize(const char *, uint64_t);
+
+#ifdef _KERNEL
+extern boolean_t zvol_is_zvol(const char *);
 extern int zvol_set_volblocksize(const char *, uint64_t);
 extern int zvol_set_snapdev(const char *, zprop_source_t, uint64_t);
 extern int zvol_set_volmode(const char *, zprop_source_t, uint64_t);

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -2579,10 +2579,10 @@ zfs_prop_set_special(const char *dsname, zprop_source_t source,
 	case ZFS_PROP_REFRESERVATION:
 		err = dsl_dataset_set_refreservation(dsname, source, intval);
 		break;
-#ifdef _KERNEL
 	case ZFS_PROP_VOLSIZE:
 		err = zvol_set_volsize(dsname, intval);
 		break;
+#ifdef _KERNEL
 	case ZFS_PROP_SNAPDEV:
 		err = zvol_set_snapdev(dsname, source, intval);
 		break;


### PR DESCRIPTION
Signed-off-by: satbir <satbir.chhikara@gmail.com>

Volume resize command implementation in uzfs space.
Unit tested by creating a volume with size 1G then using new resize command changed the volume size to 3G. Confirmed with zfs list output.