### PR TITLE
Use reuseaddr socket option to avoid bind failures during zrepl restart

### DIFF
--- a/lib/fio/replica.c
+++ b/lib/fio/replica.c
@@ -649,6 +649,7 @@ static enum fio_q_status fio_repl_queue(struct thread_data *td,
 		hdr.opcode = ZVOL_OPCODE_READ;
 	} else {
 		hdr.opcode = ZVOL_OPCODE_SYNC;
+		hdr.len = 0;
 	}
 
 	if (write_to_socket(io_u->file->fd, &hdr, sizeof (hdr), 0) != 0) {

--- a/lib/libzpool/zrepl_mgmt.c
+++ b/lib/libzpool/zrepl_mgmt.c
@@ -95,6 +95,7 @@ create_and_bind(const char *port, int bind_needed, boolean_t nonblock)
 
 	for (rp = result; rp != NULL; rp = rp->ai_next) {
 		int flags = rp->ai_socktype;
+		int enable = 1;
 
 		if (nonblock)
 			flags |= SOCK_NONBLOCK;
@@ -105,6 +106,10 @@ create_and_bind(const char *port, int bind_needed, boolean_t nonblock)
 
 		if (bind_needed == 0) {
 			break;
+		}
+		if (setsockopt(sfd, SOL_SOCKET, SO_REUSEADDR, &enable,
+		    sizeof (int)) < 0) {
+			perror("setsockopt(SO_REUSEADDR) failed");
 		}
 		s = bind(sfd, rp->ai_addr, rp->ai_addrlen);
 		if (s == 0) {


### PR DESCRIPTION
and put some more debug info into travis.