### PR TITLE
US2081 Mgmt thread should not exit if there is an error on any of the…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,11 +48,12 @@ jobs:
             make -j4;
             cd ../zfs
             sh autogen.sh
-            ./configure --with-config=user --enable-code-coverage=yes --enable-debug --enable-uzfs=yes --with-jemalloc --with-fio=$PWD/../fio || true;
+            ./configure --with-config=user --enable-code-coverage=yes --enable-debug --enable-uzfs=yes --with-jemalloc --with-fio=$PWD/../fio
             make -j4;
             make cstyle;
+            sudo sh -c 'echo "/tmp/core.%e.%p.%h.%t" > /proc/sys/kernel/core_pattern';
             export FIO_SRCDIR=$PWD/../fio;
-            sudo -E bash ./tests/cbtest/script/test_uzfs.sh -T all || true;
+            sudo -E bash ./tests/cbtest/script/test_uzfs.sh -T all
             bash <(curl -s https://codecov.io/bash)
   build_tag_1:
     machine: 
@@ -68,24 +69,11 @@ jobs:
             sudo apt-get install --yes -qq gcc-6 g++-6
             sudo apt-get install --yes -qq build-essential autoconf libtool gawk alien fakeroot linux-headers-$(uname -r) libaio-dev
             sudo apt-get install --yes -qq zlib1g-dev uuid-dev libattr1-dev libblkid-dev libselinux-dev libudev-dev libssl-dev
-            sudo apt-get install --yes -qq lcov libjemalloc-dev
-            sudo apt-get install --yes -qq parted lsscsi ksh attr acl nfs-kernel-server fio
-            sudo apt-get install --yes -qq libgtest-dev cmake
+            sudo apt-get install --yes -qq lcov
+            sudo apt-get install --yes -qq parted lsscsi ksh attr acl nfs-kernel-server
             sudo apt-get install gdb
             sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-6 /usr/bin/gcc
             sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-6 /usr/bin/g++
-            pushd .
-            cd /usr/src/gtest
-            sudo cmake CMakeLists.txt
-            sudo make -j4
-            sudo cp *.a /usr/lib
-            popd
-            cd ..
-            git clone https://github.com/axboe/fio
-            cd fio
-            git checkout fio-3.7
-            ./configure
-            make -j4
             cd ..
             git clone https://github.com/openebs/spl
             cd spl
@@ -96,12 +84,13 @@ jobs:
             sudo dpkg -i *.deb;
             cd ../zfs
             sh autogen.sh
-            ./configure --enable-code-coverage=yes --enable-debug || true;
-            make --no-print-directory -s pkg-utils pkg-kmod || true;
+            ./configure --enable-code-coverage=yes --enable-debug
+            make --no-print-directory -s pkg-utils pkg-kmod
             sudo dpkg -i *.deb || true;
             make cstyle;
             sudo modprobe zfs;
-            ztest || true;
+            sudo sh -c 'echo "/tmp/core.%e.%p.%h.%t" > /proc/sys/kernel/core_pattern';
+            ztest
 workflows:
   version: 2
   TAGS:

--- a/print_debug_info.sh
+++ b/print_debug_info.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-while sleep 30; do
+while sleep 300; do
     echo "=====[ $SECONDS seconds still running ]=====";
     ps -auxwww;
     netstat -nap;


### PR DESCRIPTION
… fd related to volume.

Rationale: All file descriptor errors are handled gracefully in mgmt code from the day one. What was not handled well up until now were failing epoll_* calls (i.e. removing FD from epoll set, changing subscribed events for fd in epoll set, etc.). There is no legitimate reason why these should fail (except EINTR in some cases) unless there is a bug - programming mistake - in the code (i.e. trying to modify FD which is no longer in epoll set, etc.). The appropriate reaction to such situation if it happens is to "crash" the whole process (like assert in debug mode or NULL pointer dereference and such). And this is exactly what has changed with this fix. Previously we logged error and exited mgmt thread but the zrepl process continued to run. k8s has no way to react to such situation because the process continues to run and everything seems to be fine. By logging error and terminating the process we give a chance for recovery because k8s can restart the container in such case and admin can investigate why container has "crashed" after that happens. I hope it makes sense :-)