### PR TITLE
Unit testing for connection acceptor thread / uzfs_zvol_rebuild_dw_replica

### DIFF
--- a/cmd/zrepl/zrepl.c
+++ b/cmd/zrepl/zrepl.c
@@ -18,7 +18,6 @@
 #include "mgmt_conn.h"
 #include "data_conn.h"
 
-#define	MAXEVENTS 64
 #define	ZAP_UPDATE_TIME_INTERVAL 2
 
 extern unsigned long zfs_arc_max;
@@ -432,172 +431,6 @@ exit:
 }
 
 /*
- * One thread per replica. Responsible for accepting
- * IO connections. This thread will accept a connection
- * and spawn a new thread for each new connection req.
- */
-static void
-uzfs_zvol_io_conn_acceptor(void)
-{
-	int			io_sfd, efd;
-	intptr_t		new_fd;
-	int			rebuild_fd;
-	int			rc, i, n;
-	uint32_t		flags;
-#ifdef DEBUG
-	char			*hbuf;
-	char			*sbuf;
-#endif
-	kthread_t		*thrd_info;
-	socklen_t		in_len;
-	struct sockaddr		in_addr;
-	struct epoll_event	event;
-	struct epoll_event	*events = NULL;
-
-	io_sfd = rebuild_fd = efd = -1;
-	flags = EPOLLIN | EPOLLET | EPOLLERR | EPOLLHUP | EPOLLRDHUP;
-	/* Create IO connection acceptor fd first */
-	io_sfd = create_and_bind(IO_SERVER_PORT, B_TRUE, B_TRUE);
-	if (io_sfd == -1) {
-		goto exit;
-	}
-
-	rc = listen(io_sfd, SOMAXCONN);
-	if (rc == -1) {
-		LOG_ERRNO("listen on IO FD in acceptor failed");
-		goto exit;
-	}
-
-	rebuild_fd = create_and_bind(REBUILD_IO_SERVER_PORT, B_TRUE, B_TRUE);
-	if (rebuild_fd == -1) {
-		goto exit;
-	}
-
-	rc = listen(rebuild_fd, SOMAXCONN);
-	if (rc == -1) {
-		LOG_ERRNO("listen on rebuild FD in acceptor failed");
-		goto exit;
-	}
-
-	efd = epoll_create1(0);
-	if (efd == -1) {
-		LOG_ERRNO("epoll_create1 failed");
-		goto exit;
-	}
-
-	event.data.fd = io_sfd;
-	event.events = flags;
-	rc = epoll_ctl(efd, EPOLL_CTL_ADD, io_sfd, &event);
-	if (rc == -1) {
-		LOG_ERRNO("epoll_ctl on IO FD failed");
-		goto exit;
-	}
-
-	event.data.fd = rebuild_fd;
-	event.events = flags;
-	rc = epoll_ctl(efd, EPOLL_CTL_ADD, rebuild_fd, &event);
-	if (rc == -1) {
-		LOG_ERRNO("epoll_ctl on rebuild FD failed");
-		goto exit;
-	}
-
-	/* Buffer where events are returned */
-	events = calloc(MAXEVENTS, sizeof (event));
-
-	prctl(PR_SET_NAME, "acceptor", 0, 0, 0);
-
-	/* The event loop */
-	while (1) {
-		n = epoll_wait(efd, events, MAXEVENTS, -1);
-		/*
-		 * EINTR err can come when signal handler
-		 * interrupt epoll_wait system call. It
-		 * should be okay to continue in that case.
-		 */
-		if ((n < 0) && (errno == EINTR)) {
-			continue;
-		} else if (n < 0) {
-			goto exit;
-		}
-
-		for (i = 0; i < n; i++) {
-			/*
-			 * An error has occured on this fd, or
-			 * the socket is not ready for reading
-			 * (why were we notified then?)
-			 */
-			if (!(events[i].events & EPOLLIN)) {
-				LOG_ERRNO("epoll failed");
-				if (events[i].data.fd == io_sfd) {
-					io_sfd = -1;
-				} else {
-					rebuild_fd = -1;
-				}
-				close(events[i].data.fd);
-				/*
-				 * TODO:We have choosen to exit
-				 * instead of continuing here.
-				 */
-				goto exit;
-			}
-			/*
-			 * We have a notification on the listening
-			 * socket, which means one or more incoming
-			 * connections.
-			 */
-			in_len = sizeof (in_addr);
-			new_fd = accept(events[i].data.fd, &in_addr, &in_len);
-			if (new_fd == -1) {
-				LOG_ERRNO("accept failed");
-				goto exit;
-			}
-#ifdef DEBUG
-			hbuf = kmem_alloc(sizeof (NI_MAXHOST), KM_SLEEP);
-			sbuf = kmem_alloc(sizeof (NI_MAXSERV), KM_SLEEP);
-			rc = getnameinfo(&in_addr, in_len, hbuf, sizeof (hbuf),
-			    sbuf, sizeof (sbuf), NI_NUMERICHOST |
-			    NI_NUMERICSERV);
-			if (rc == 0) {
-				LOG_DEBUG("Accepted connection from %s:%s",
-				    hbuf, sbuf);
-			}
-
-			kmem_free(hbuf, sizeof (NI_MAXHOST));
-			kmem_free(sbuf, sizeof (NI_MAXSERV));
-#endif
-			if (events[i].data.fd == io_sfd) {
-				thrd_info = zk_thread_create(NULL, 0,
-				    (thread_func_t)uzfs_zvol_io_receiver,
-				    (void *)new_fd, 0, NULL, TS_RUN, 0,
-				    PTHREAD_CREATE_DETACHED);
-			} else {
-				LOG_INFO("Connection req for rebuild");
-				thrd_info = zk_thread_create(NULL, 0,
-				    uzfs_zvol_rebuild_scanner,
-				    (void *)new_fd, 0, NULL, TS_RUN, 0,
-				    PTHREAD_CREATE_DETACHED);
-			}
-			VERIFY3P(thrd_info, !=, NULL);
-		}
-	}
-exit:
-	if (events != NULL)
-		free(events);
-
-	if (io_sfd != -1)
-		close(io_sfd);
-
-	if (rebuild_fd != -1)
-		close(rebuild_fd);
-
-	if (efd != -1)
-		close(efd);
-
-	LOG_DEBUG("uzfs_zvol_io_conn_acceptor thread exiting");
-	zk_thread_exit();
-}
-
-/*
  * This func takes care of sending potentially multiple read blocks each
  * prefixed by metainfo.
  */
@@ -789,12 +622,12 @@ void
 zrepl_svc_run(void)
 {
 	mgmt_conn_thread = zk_thread_create(NULL, 0,
-	    (thread_func_t)uzfs_zvol_mgmt_thread, NULL, 0, NULL,
+	    uzfs_zvol_mgmt_thread, NULL, 0, NULL,
 	    TS_RUN, 0, PTHREAD_CREATE_DETACHED);
 	VERIFY3P(mgmt_conn_thread, !=, NULL);
 
 	conn_accpt_thread = zk_thread_create(NULL, 0,
-	    (thread_func_t)uzfs_zvol_io_conn_acceptor, NULL, 0, NULL, TS_RUN,
+	    uzfs_zvol_io_conn_acceptor, NULL, 0, NULL, TS_RUN,
 	    0, PTHREAD_CREATE_DETACHED);
 	VERIFY3P(conn_accpt_thread, !=, NULL);
 
@@ -886,6 +719,13 @@ main(int argc, char **argv)
 
 	zinfo_create_hook = &zinfo_create_cb;
 	zinfo_destroy_hook = &zinfo_destroy_cb;
+
+	io_server_port = IO_SERVER_PORT;
+	rebuild_io_server_port = REBUILD_IO_SERVER_PORT;
+
+	io_receiver = uzfs_zvol_io_receiver;
+	rebuild_scanner = uzfs_zvol_rebuild_scanner;
+
 	rc = uzfs_init();
 	if (rc != 0) {
 		LOG_ERR("initialization errored: %d", rc);

--- a/include/data_conn.h
+++ b/include/data_conn.h
@@ -40,6 +40,22 @@ typedef struct rebuild_thread_arg {
 	uint16_t	port;
 } rebuild_thread_arg_t;
 
+typedef struct conn_acceptors {
+	int io_fd;
+	int rebuild_fd;
+} conn_acceptors_t;
+
+thread_func_t io_receiver;
+thread_func_t rebuild_scanner;
+
+extern void (*io_receiver)(void *arg);
+extern void (*rebuild_scanner)(void *arg);
+
+extern uint16_t io_server_port;
+extern uint16_t rebuild_io_server_port;
+
+int uzfs_zvol_get_ip(char *host);
+void uzfs_zvol_io_conn_acceptor(void *arg);
 void init_zrepl(void);
 void remove_pending_cmds_to_ack(int fd, zvol_info_t *zinfo);
 zvol_io_cmd_t *zio_cmd_alloc(zvol_io_hdr_t *hdr, int fd);

--- a/include/data_conn.h
+++ b/include/data_conn.h
@@ -53,6 +53,7 @@ extern void (*rebuild_scanner)(void *arg);
 
 extern uint16_t io_server_port;
 extern uint16_t rebuild_io_server_port;
+extern uint64_t zvol_rebuild_step_size;
 
 int uzfs_zvol_get_ip(char *host);
 void uzfs_zvol_io_conn_acceptor(void *arg);

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -40,8 +40,8 @@ extern "C" {
 #define	uZFS_ZVOL_WORKERS_DEFAULT 6
 #define	ZFS_PROP_TARGET_IP	"io.openebs:targetip"
 
-#define	REBUILD_IO_SERVER_PORT	"3233"
-#define	IO_SERVER_PORT	"3232"
+#define	REBUILD_IO_SERVER_PORT	3233
+#define	IO_SERVER_PORT	3232
 
 enum zrepl_log_level {
 	LOG_LEVEL_DEBUG,

--- a/lib/libzrepl/mgmt_conn.c
+++ b/lib/libzrepl/mgmt_conn.c
@@ -410,7 +410,7 @@ reply_data(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp, void *buf, int size)
 /*
  * Get IP address of first external network interface we encounter.
  */
-static int
+int
 uzfs_zvol_get_ip(char *host)
 {
 	struct ifaddrs *ifaddr, *ifa;
@@ -477,8 +477,8 @@ uzfs_zvol_mgmt_do_handshake(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 	}
 
 	strncpy(mgmt_ack.volname, name, sizeof (mgmt_ack.volname));
-	mgmt_ack.port = atoi((hdrp->opcode == ZVOL_OPCODE_PREPARE_FOR_REBUILD) ?
-	    REBUILD_IO_SERVER_PORT : IO_SERVER_PORT);
+	mgmt_ack.port = (hdrp->opcode == ZVOL_OPCODE_PREPARE_FOR_REBUILD) ?
+	    REBUILD_IO_SERVER_PORT : IO_SERVER_PORT;
 	mgmt_ack.pool_guid = spa_guid(zv->zv_spa);
 
 	/*

--- a/tests/cbtest/gtest/Makefile.am
+++ b/tests/cbtest/gtest/Makefile.am
@@ -1,6 +1,6 @@
 include $(top_srcdir)/config/Rules.am
 
-AM_CPPFLAGS += $(DEBUG_STACKFLAGS) $(FRAME_LARGER_THAN)
+AM_CPPFLAGS += $(DEBUG_STACKFLAGS)
 
 DEFAULT_INCLUDES += \
 	-I$(top_srcdir)/include \

--- a/tests/cbtest/gtest/Makefile.am
+++ b/tests/cbtest/gtest/Makefile.am
@@ -1,5 +1,7 @@
 include $(top_srcdir)/config/Rules.am
 
+AM_CPPFLAGS += $(DEBUG_STACKFLAGS) $(FRAME_LARGER_THAN)
+
 DEFAULT_INCLUDES += \
 	-I$(top_srcdir)/include \
 	-I$(top_srcdir)/lib/libspl/include


### PR DESCRIPTION
This PR is to do unit testing for thread that accepts connections from target and other replicas.
Changes included in this are:
- moving code from zrepl binary to zrepl library
- creating blocking sockets for listeners
- adding in level-triggered mode of listeners to epoll
- exiting the binary in case of any error in bind/listen/epoll_* APIs
- doing continue in case of error in accept call instead of breaking from loop
- change in the error condition check from `!(events & EPOLL_IN)` to `((events & ~EPOLL_IN) != 0)`
- parameterized callback functions
- updated makefile config options for gtest in debug build
- added few debug and info logs

This PR also have unit testing for uzfs_zvol_rebuild_dw_replica API, which does rebuilding with the help of another replica.
- fixed error condition in uzfs_zvol_socket_read and uzfs_zvol_socket_write
- added so_linger option on fd to receive error when read/write operation is performed on broken connection
Signed-off-by: Vishnu Itta <vitta@mayadata.io>