### PR TITLE
US2035 add logs in replica for listed scenarios to debug volume read-…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 *.swp
 *.gcno
 *.gcda
+*.ur-safe
 .deps
 .libs
 .dirstamp

--- a/README.markdown
+++ b/README.markdown
@@ -85,7 +85,7 @@ etc. Explanation of the two mounted volumes follows:
 ```bash
 sudo docker build -t my-cstor .
 sudo mkdir /tmp/cstor
-sudo docker run --privileged -it -v /dev:/dev --mount source=cstortmp,target=/tmp my-cstor
+sudo docker run --privileged -it -v /dev:/dev -v /run/udev:/run/udev --mount source=cstortmp,target=/tmp my-cstor
 sudo docker exec -it <container-id> /bin/bash
 ```
 
@@ -95,6 +95,30 @@ You could also run local image repo and upload the test image there:
 sudo docker run -d -p 5000:5000 --restart=always --name registry registry:2
 sudo docker build -t localhost:5000/my-cstor .
 sudo docker push localhost:5000/my-cstor
+```
+
+# Troubleshooting
+
+In order to print debug messages start zrepl with `-l debug` argument. If
+running zrepl in container with standard entrypoint.sh script, set env
+variable LOGLEVEL=debug. To do the same when running zrepl on k8s cluster
+use patch command to insert the same env variable to pod definition.
+Details differ based on how zrepl container was deployed on k8s cluster:
+
+```bash
+kubectl patch deployment cstor-deployment-name --patch "$(cat patch.yaml)"
+```
+
+where patch.yaml content is:
+```
+spec:
+  template:
+    spec:
+      containers:
+      - name: cstor-container-name
+        env:
+        - name: LOGLEVEL
+          value: "debug"
 ```
 
 # Caveats

--- a/cmd/zrepl/Makefile.am
+++ b/cmd/zrepl/Makefile.am
@@ -13,7 +13,8 @@ DEFAULT_INCLUDES += \
 sbin_PROGRAMS = zrepl
 
 zrepl_SOURCES = \
-	zrepl.c
+	zrepl.c \
+	zfs_events.c
 
 zrepl_LDADD = \
 	$(top_builddir)/lib/libnvpair/libnvpair.la \

--- a/cmd/zrepl/zfs_events.c
+++ b/cmd/zrepl/zfs_events.c
@@ -1,0 +1,138 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright (c) 2018 Cloudbyte. All rights reserved.
+ */
+
+#include <sys/fm/util.h>
+#include <sys/fm/protocol.h>
+#include <sys/fm/fs/zfs.h>
+#include <libzfs.h>
+#include <zrepl_mgmt.h>
+
+#include "zfs_events.h"
+
+/*
+ * Print vdev state change event in user friendly way.
+ */
+static void
+print_state_change(nvlist_t *event)
+{
+	char	*pool_name;
+	char	*vdev_name;
+	uint64_t new_state, old_state;
+
+	if (nvlist_lookup_string(event,
+	    FM_EREPORT_PAYLOAD_ZFS_POOL, &pool_name) != 0 ||
+	    nvlist_lookup_string(event,
+	    FM_EREPORT_PAYLOAD_ZFS_VDEV_PATH, &vdev_name) != 0 ||
+	    nvlist_lookup_uint64(event,
+	    FM_EREPORT_PAYLOAD_ZFS_VDEV_STATE, &new_state) != 0 ||
+	    nvlist_lookup_uint64(event,
+	    FM_EREPORT_PAYLOAD_ZFS_VDEV_LASTSTATE, &old_state) != 0) {
+		LOG_ERR("Invalid content of ZFS state change event");
+	} else {
+		LOG_INFO("Vdev %s in pool %s changed state: %s -> %s",
+		    vdev_name, pool_name,
+		    zpool_state_to_name(old_state, VDEV_AUX_NONE),
+		    zpool_state_to_name(new_state, VDEV_AUX_NONE));
+	}
+}
+
+/*
+ * Print the event in raw form to stderr.
+ */
+static void
+print_zfs_event(nvlist_t *event)
+{
+	enum zrepl_log_level lvl = LOG_LEVEL_ERR;
+	boolean_t skip = B_FALSE;
+	char	*class;
+
+	if (nvlist_lookup_string(event, FM_CLASS, &class) != 0) {
+		LOG_ERR("Missing class in zfs ereport");
+		nvlist_free(event);
+		return;
+	}
+
+	if (strcmp(class, FM_EREPORT_CLASS "." ZFS_ERROR_CLASS "."
+	    FM_EREPORT_ZFS_CONFIG_CACHE_WRITE) == 0) {
+		/*
+		 * This event is generated upon every spa configuration
+		 * change because zrepl does not have a cache file.
+		 */
+		skip = B_TRUE;
+	} else if (strcmp(class, FM_RSRC_RESOURCE "." ZFS_ERROR_CLASS "."
+	    FM_RESOURCE_REMOVED) == 0) {
+		lvl = LOG_LEVEL_INFO;
+	} else if (strcmp(class, FM_RSRC_RESOURCE "." ZFS_ERROR_CLASS "."
+	    FM_RESOURCE_AUTOREPLACE) == 0) {
+		lvl = LOG_LEVEL_INFO;
+	} else if (strcmp(class, FM_RSRC_RESOURCE "." ZFS_ERROR_CLASS "."
+	    FM_RESOURCE_STATECHANGE) == 0) {
+		print_state_change(event);
+		skip = B_TRUE;
+	}
+
+	if (!skip) {
+		zrepl_log(lvl, "ZFS event:");
+		fm_nvprint(event);
+	}
+	nvlist_free(event);
+}
+
+/*
+ * Endless loop in which we wait for new zfs events being generated and print
+ * them.
+ */
+void
+zrepl_monitor_errors(void)
+{
+	zfs_zevent_t	*ze;
+	nvlist_t	*event = NULL;
+	uint64_t	size, dropped;
+	int		rc;
+
+	zfs_zevent_init(&ze);
+
+	while (1) {
+		// There is no limit for event size because we are not going to
+		// copy it to a preallocated buffer
+		size = -1;
+		dropped = 0;
+		rc = zfs_zevent_next(ze, &event, &size, &dropped);
+		if (dropped > 0) {
+			LOG_ERR("Dropped %lu zfs events", dropped);
+		}
+		if (event != NULL) {
+			print_zfs_event(event);
+			event = NULL;
+		}
+		if (rc != 0) {
+			if (rc == ENOENT) {
+				zfs_zevent_wait(ze);
+			} else {
+				LOG_ERR("Failed to get zfs events: %d", rc);
+			}
+		}
+	}
+	zfs_zevent_destroy(ze);
+}

--- a/cmd/zrepl/zfs_events.h
+++ b/cmd/zrepl/zfs_events.h
@@ -1,0 +1,30 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright (c) 2018 Cloudbyte. All rights reserved.
+ */
+
+#ifndef	ZFS_EVENTS_H
+#define	ZFS_EVENTS_H
+
+void zrepl_monitor_errors(void);
+
+#endif	/* ZFS_EVENTS_H */

--- a/include/sys/fm/util.h
+++ b/include/sys/fm/util.h
@@ -30,6 +30,7 @@
 extern "C" {
 #endif
 
+#include <sys/zfs_context.h>
 #include <sys/nvpair.h>
 
 /*
@@ -69,8 +70,6 @@ typedef struct erpt_dump {
 	} ed_tod_base;
 } erpt_dump_t;
 
-#ifdef _KERNEL
-
 #define	ZEVENT_SHUTDOWN		0x1
 
 typedef void zevent_cb_t(nvlist_t *, nvlist_t *);
@@ -96,20 +95,17 @@ extern void fm_nvprint(nvlist_t *);
 extern void zfs_zevent_post_cb(nvlist_t *nvl, nvlist_t *detector);
 extern int zfs_zevent_post(nvlist_t *, nvlist_t *, zevent_cb_t *);
 extern void zfs_zevent_drain_all(int *);
+#ifdef _KERNEL
 extern int zfs_zevent_fd_hold(int, minor_t *, zfs_zevent_t **);
 extern void zfs_zevent_fd_rele(int);
+#endif
 extern int zfs_zevent_next(zfs_zevent_t *, nvlist_t **, uint64_t *, uint64_t *);
 extern int zfs_zevent_wait(zfs_zevent_t *);
+#ifdef _KERNEL
 extern int zfs_zevent_seek(zfs_zevent_t *, uint64_t);
+#endif
 extern void zfs_zevent_init(zfs_zevent_t **);
 extern void zfs_zevent_destroy(zfs_zevent_t *);
-
-#else
-
-static inline void fm_init(void) { }
-static inline void fm_fini(void) { }
-
-#endif  /* _KERNEL */
 
 #ifdef	__cplusplus
 }

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -798,6 +798,9 @@ extern fstrans_cookie_t spl_fstrans_mark(void);
 extern void spl_fstrans_unmark(fstrans_cookie_t);
 extern int __spl_pf_fstrans_check(void);
 
+#define	console_printf(args...)	fprintf(stderr, args)
+#define	console_vprintf(fmt, ap)	vfprintf(stderr, fmt, ap)
+#define	schedule()	pthread_yield()
 #ifdef	__cplusplus
 }
 #endif

--- a/lib/libzrepl/mgmt_conn.c
+++ b/lib/libzrepl/mgmt_conn.c
@@ -909,7 +909,7 @@ process_message(uzfs_mgmt_conn_t *conn)
 		if (zinfo->mgmt_conn != conn) {
 			uzfs_zinfo_drop_refcnt(zinfo, B_FALSE);
 			LOGERRCONN(conn, "Target used invalid connection for "
-			    "zvol %s\n", zvol_name);
+			    "zvol %s", zvol_name);
 			rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED,
 			    hdrp->opcode, hdrp->io_seq);
 			break;
@@ -967,7 +967,7 @@ process_message(uzfs_mgmt_conn_t *conn)
 		if (zinfo->mgmt_conn != conn) {
 			uzfs_zinfo_drop_refcnt(zinfo, B_FALSE);
 			LOGERRCONN(conn, "Target used invalid connection for "
-			    "zvol %s\n", zvol_name);
+			    "zvol %s", zvol_name);
 			rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED,
 			    hdrp->opcode, hdrp->io_seq);
 			break;
@@ -1001,7 +1001,7 @@ process_message(uzfs_mgmt_conn_t *conn)
 		if (zinfo->mgmt_conn != conn) {
 			uzfs_zinfo_drop_refcnt(zinfo, B_FALSE);
 			LOGERRCONN(conn, "Target used invalid connection for "
-			    "zvol %s\n", zvol_name);
+			    "zvol %s", zvol_name);
 			rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED,
 			    hdrp->opcode, hdrp->io_seq);
 			break;


### PR DESCRIPTION
Instructions from the ticket:
```
- case when target (mgmt or data) connection disconnects
- case when replica disconnects itself due to error or destroy of volume
- IOs are not served by replica in case of non-empty queues
- Log the IOs details that are in queue
- Log the IOs details that got failed if any
- logs to debug disk related issues
- logs to track longer execution cycles of sync txg and quiesce txg
- state change in replica from degraded to healthy
- rebuild status change in replica
```
Current log messages and messages added in this PR cover all requirements except slow txg, but that is to large degree covered by standard slow vdev IO ereport. Ereports are standard part of ZFS. Originally they were meant to be processed by FMA on Solaris. Linux has its own minimalistic implementation of FMA called ZED. These components are able to do analysis of incoming ereports and based on them generate faults and needless to say that they work only with kernel version of ZFS. It is out of scope to provide ZED implementation for ZFS running in container, but at least what we can do is to print generated ereports to a log file. If this should work well, then ereport must not be too frequent not to flood the log file. So how ereports are printed to log file? They are printed in raw form (raw nvlist), which contains all information about the error which the system knows about. Example for vdev state change is:

```
2018-07-03/12:03:29.147 ERROR ZFS event:

resource.fs.zfs.statechange version=0x0 pool="rplcpool" pool_guid=
 0x3d271ad920a0340b pool_state=0x0 pool_context=0x0 vdev_guid=
 0x42afb51ac060c3f1 vdev_state=0x2 vdev_path="/tmp/vdev2" vdev_laststate=0x7
 time=[ 0x5b3b49f1 0x0 ] eid=0x2

...
```
All the information is there, however it is difficult to read. Hence we can provide specialized functions which print human friendly error messages for certain ereports. Just now such friendly message has been implemented only for vdev state change event above:
```
2018-07-03/12:03:29.147 Vdev /tmp/vdev2 in pool rplcpool changed state: ONLINE -> OFFLINE
```
The list of all generated reports by zfs:

 * vdev state change
 * disk auto-replace
 * checksum errors
 * device probe failure
 * slow vdev IO
 * IO failure
 * pool load failure

Future directions are, providing human friendly error messages for most frequent cases of errors above. More distant goal substituting all this work would be to make ZED to work with userspace ZFS and run them in the same pod, each zfs instance having its own ZED. Taking advantage of current ZED code for automatic disk replacement etc.

There are some loosely related  documentation changes describing how to change replica log level in various environments.