### PR TITLE
TA1636 bugs reported by coverity in zrepl mgmt code and tests

### DIFF
--- a/include/sys/zfs_ioctl.h
+++ b/include/sys/zfs_ioctl.h
@@ -28,7 +28,6 @@
 #ifndef	_SYS_ZFS_IOCTL_H
 #define	_SYS_ZFS_IOCTL_H
 
-#include <sys/cred.h>
 #include <sys/dmu.h>
 #include <sys/zio.h>
 #include <sys/dsl_deleg.h>
@@ -36,6 +35,7 @@
 #include <sys/zfs_stat.h>
 
 #ifdef _KERNEL
+#include <sys/cred.h>
 #include <sys/nvpair.h>
 #endif	/* _KERNEL */
 

--- a/tests/cbtest/gtest/Makefile.am
+++ b/tests/cbtest/gtest/Makefile.am
@@ -9,7 +9,7 @@ DEFAULT_INCLUDES += \
 sbin_PROGRAMS = test_uzfsserver test_uzfs test_zfs test_zrepl_prot
 
 test_uzfsserver_SOURCES = test_uzfsserver.cc
-test_uzfs_SOURCES = test_uzfs.cc
+test_uzfs_SOURCES = test_uzfs.cc gtest_utils.cc
 test_zrepl_prot_SOURCES = test_zrepl_prot.cc gtest_utils.cc
 test_zfs_SOURCES = test_zfs.cc gtest_utils.cc
 

--- a/tests/cbtest/gtest/test_uzfs.cc
+++ b/tests/cbtest/gtest/test_uzfs.cc
@@ -39,6 +39,8 @@
 #include <uzfs_mgmt.h>
 #include <sys/epoll.h>
 
+#include "gtest_utils.h"
+
 char *ds_name;
 char *ds_name2;
 char *pool;
@@ -240,12 +242,12 @@ TEST(uZFS, Setup) {
 	path = (char *)malloc(MAXNAMELEN);
 	pool = (char *)malloc(MAXNAMELEN);
 
-	strncpy(path, "/tmp/uztest.1a", MAXNAMELEN);
-	strncpy(pool, "pool1", MAXNAMELEN);
-	strncpy(ds_name, "vol1", MAXNAMELEN);
-	strncpy(ds_name2, "vol3", MAXNAMELEN);
-	strncpy(pool_ds, "pool1/vol1", MAXNAMELEN);
-	strncpy(pool_ds2, "pool1/vol3", MAXNAMELEN);
+	GtestUtils::strlcpy(path, "/tmp/uztest.1a", MAXNAMELEN);
+	GtestUtils::strlcpy(pool, "pool1", MAXNAMELEN);
+	GtestUtils::strlcpy(ds_name, "vol1", MAXNAMELEN);
+	GtestUtils::strlcpy(ds_name2, "vol3", MAXNAMELEN);
+	GtestUtils::strlcpy(pool_ds, "pool1/vol1", MAXNAMELEN);
+	GtestUtils::strlcpy(pool_ds2, "pool1/vol3", MAXNAMELEN);
 	signal(SIGPIPE, SIG_IGN);
 
 	uzfs_init();
@@ -412,31 +414,31 @@ TEST(uZFS, TestZInfoRefcnt) {
 	uzfs_zinfo_drop_refcnt(zinfo, B_FALSE);
 	EXPECT_EQ(1, zinfo->refcnt);
 
-	strncpy(ds1, "vol1 ", MAXNAMELEN);
+	GtestUtils::strlcpy(ds1, "vol1 ", MAXNAMELEN);
 	zinfo1 = uzfs_zinfo_lookup(ds1);
 	EXPECT_EQ(NULL, zinfo1);
 
-	strncpy(ds1, "vol2", MAXNAMELEN);
+	GtestUtils::strlcpy(ds1, "vol2", MAXNAMELEN);
 	zinfo1 = uzfs_zinfo_lookup(ds1);
 	EXPECT_EQ(NULL, zinfo1);
 
-	strncpy(ds1, "vol", MAXNAMELEN);
+	GtestUtils::strlcpy(ds1, "vol", MAXNAMELEN);
 	zinfo1 = uzfs_zinfo_lookup(ds1);
 	EXPECT_EQ(NULL, zinfo1);
 
-	strncpy(ds1, "pool1/vol", MAXNAMELEN);
+	GtestUtils::strlcpy(ds1, "pool1/vol", MAXNAMELEN);
 	zinfo1 = uzfs_zinfo_lookup(ds1);
 	EXPECT_EQ(NULL, zinfo1);
 
-	strncpy(ds1, "pool1/vol1 ", MAXNAMELEN);
+	GtestUtils::strlcpy(ds1, "pool1/vol1 ", MAXNAMELEN);
 	zinfo1 = uzfs_zinfo_lookup(ds1);
 	EXPECT_EQ(NULL, zinfo1);
 
-	strncpy(ds1, "pool1/vol1/", MAXNAMELEN);
+	GtestUtils::strlcpy(ds1, "pool1/vol1/", MAXNAMELEN);
 	zinfo1 = uzfs_zinfo_lookup(ds1);
 	EXPECT_EQ(NULL, zinfo1);
 
-	strncpy(ds1, "pool1/vol1", MAXNAMELEN);
+	GtestUtils::strlcpy(ds1, "pool1/vol1", MAXNAMELEN);
 	zinfo1 = uzfs_zinfo_lookup(ds1);
 	EXPECT_EQ(NULL, !zinfo1);
 	EXPECT_EQ(2, zinfo->refcnt);
@@ -444,7 +446,7 @@ TEST(uZFS, TestZInfoRefcnt) {
 	zinfo1 = uzfs_zinfo_lookup(NULL);
 	EXPECT_EQ(NULL, zinfo1);
 
-	strncpy(ds1, "vol1", MAXNAMELEN);
+	GtestUtils::strlcpy(ds1, "vol1", MAXNAMELEN);
 	zinfo1 = uzfs_zinfo_lookup(ds1);
 	EXPECT_EQ(NULL, !zinfo1);
 	EXPECT_EQ(3, zinfo->refcnt);
@@ -456,15 +458,15 @@ TEST(uZFS, TestZInfoRefcnt) {
 void
 set_start_rebuild_mgmt_ack(mgmt_ack_t *mack, const char *dw_name, const char *volname)
 {
-	strncpy(mack->dw_volname, dw_name, MAXNAMELEN);
+	GtestUtils::strlcpy(mack->dw_volname, dw_name, MAXNAMELEN);
 	if (volname != NULL)
-		strncpy(mack->volname, volname, MAXNAMELEN);
+		GtestUtils::strlcpy(mack->volname, volname, MAXNAMELEN);
 }
 
 void
 set_mgmt_ack_ip_port(mgmt_ack_t *mack, const char *ip, uint16_t port)
 {
-	strncpy(mack->ip, ip, MAX_IP_LEN);
+	GtestUtils::strlcpy(mack->ip, ip, MAX_IP_LEN);
 	mack->port = port;
 }
 
@@ -629,7 +631,7 @@ create_rebuild_args(rebuild_thread_arg_t **r)
 	rc = uzfs_zvol_get_ip(rebuild_args->ip, MAX_IP_LEN);
 	EXPECT_NE(rc, -1);
 	
-	strncpy(rebuild_args->zvol_name, "vol2", MAXNAMELEN);
+	GtestUtils::strlcpy(rebuild_args->zvol_name, "vol2", MAXNAMELEN);
 	*r = rebuild_args;
 }
 

--- a/tests/cbtest/gtest/test_zrepl_prot.cc
+++ b/tests/cbtest/gtest/test_zrepl_prot.cc
@@ -73,14 +73,13 @@ static int ready_for_read(int fd, int timeout) {
  */
 static void do_handshake(std::string zvol_name, std::string &host,
     uint16_t &port, uint64_t *ionum, int control_fd, int res) {
-	zvol_io_hdr_t hdr_out, hdr_in;
+	zvol_io_hdr_t hdr_in, hdr_out = {0};
 	int rc;
 	mgmt_ack_t mgmt_ack;
+
 	hdr_out.version = REPLICA_VERSION;
 	hdr_out.opcode = ZVOL_OPCODE_HANDSHAKE;
 	hdr_out.status = ZVOL_OP_STATUS_OK;
-	hdr_out.io_seq = 0;
-	hdr_out.offset = 0;
 	hdr_out.len = zvol_name.length() + 1;
 
 	rc = write(control_fd, &hdr_out, sizeof (hdr_out));
@@ -100,7 +99,7 @@ static void do_handshake(std::string zvol_name, std::string &host,
 	rc = read(control_fd, &mgmt_ack, sizeof (mgmt_ack));
 	ASSERT_EQ(rc, sizeof (mgmt_ack));
 	EXPECT_STREQ(mgmt_ack.volname, zvol_name.c_str());
-	host = std::string(mgmt_ack.ip);
+	host = std::string(mgmt_ack.ip, sizeof (mgmt_ack.ip));
 	port = mgmt_ack.port;
 	if (ionum != NULL)
 		*ionum = hdr_in.checkpointed_io_seq;
@@ -112,16 +111,14 @@ static void do_handshake(std::string zvol_name, std::string &host,
  * NOTE: Return value must be void otherwise we could not use asserts
  * (pecularity of gtest framework).
  */
-static void do_data_connection(int &data_fd, std::string host, uint16_t port,
+static void do_data_connection(int data_fd, std::string host, uint16_t port,
     std::string zvol_name, int bs=4096, int timeout=120,
     int res=ZVOL_OP_STATUS_OK) {
 	struct sockaddr_in addr;
-	zvol_io_hdr_t hdr_out, hdr_in;
+	zvol_io_hdr_t hdr_in, hdr_out = {0};
 	zvol_op_open_data_t open_data;
 	int rc;
 
-	data_fd = socket(AF_INET, SOCK_STREAM, 0);
-	ASSERT_TRUE(data_fd >= 0);
 	memset(&addr, 0, sizeof (addr));
 	addr.sin_family = AF_INET;
 	addr.sin_port = htons(port);
@@ -136,8 +133,6 @@ static void do_data_connection(int &data_fd, std::string host, uint16_t port,
 	hdr_out.version = REPLICA_VERSION;
 	hdr_out.opcode = ZVOL_OPCODE_OPEN;
 	hdr_out.status = ZVOL_OP_STATUS_OK;
-	hdr_out.io_seq = 0;
-	hdr_out.offset = 0;
 	hdr_out.len = sizeof (open_data);
 
 	rc = write(data_fd, &hdr_out, sizeof (hdr_out));
@@ -145,7 +140,7 @@ static void do_data_connection(int &data_fd, std::string host, uint16_t port,
 
 	open_data.tgt_block_size = bs;
 	open_data.timeout = timeout;
-	strncpy(open_data.volname, zvol_name.c_str(),
+	GtestUtils::strlcpy(open_data.volname, zvol_name.c_str(),
 	    sizeof (open_data.volname));
 	rc = write(data_fd, &open_data, hdr_out.len);
 
@@ -162,7 +157,7 @@ static void do_data_connection(int &data_fd, std::string host, uint16_t port,
  * len is real length - including metadata headers.
  */
 static void write_data_start(int data_fd, int &ioseq, size_t offset, int len) {
-	zvol_io_hdr_t hdr_out;
+	zvol_io_hdr_t hdr_out = {0};
 	int rc;
 
 	hdr_out.version = REPLICA_VERSION;
@@ -171,7 +166,6 @@ static void write_data_start(int data_fd, int &ioseq, size_t offset, int len) {
 	hdr_out.io_seq = ++ioseq;
 	hdr_out.offset = offset;
 	hdr_out.len = len;
-	hdr_out.flags = 0;
 
 	rc = write(data_fd, &hdr_out, sizeof (hdr_out));
 	ASSERT_EQ(rc, sizeof (hdr_out));
@@ -199,7 +193,7 @@ static void write_data(int data_fd, int &ioseq, void *buf, size_t offset,
  */
 static void read_data_start(int data_fd, int &ioseq, size_t offset, int len,
     zvol_io_hdr_t *hdr_inp, int flags = 0) {
-	zvol_io_hdr_t hdr_out;
+	zvol_io_hdr_t hdr_out = {0};
 	int rc;
 
 	hdr_out.version = REPLICA_VERSION;
@@ -340,16 +334,14 @@ static void write_data_and_verify_resp(int data_fd, int &ioseq, size_t offset,
 static void get_zvol_status(std::string zvol_name, int &ioseq, int control_fd,
     int state, int rebuild_status)
 {
-	zvol_io_hdr_t hdr_out, hdr_in;
+	zvol_io_hdr_t hdr_in, hdr_out = {0};
 	struct zrepl_status_ack status;
 	int rc;
 	hdr_out.version = REPLICA_VERSION;
 	hdr_out.opcode = ZVOL_OPCODE_REPLICA_STATUS;
 	hdr_out.status = ZVOL_OP_STATUS_OK;
 	hdr_out.io_seq = ++ioseq;
-	hdr_out.offset = 0;
 	hdr_out.len = zvol_name.length() + 1;
-	hdr_out.flags = 0;
 	rc = write(control_fd, &hdr_out, sizeof (hdr_out));
 	ASSERT_ERRNO("write", rc >= 0);
 	ASSERT_EQ(rc, sizeof (hdr_out));
@@ -373,25 +365,21 @@ static void get_zvol_status(std::string zvol_name, int &ioseq, int control_fd,
 static void transition_zvol_to_online(int &ioseq, int control_fd,
     std::string zvol_name)
 {
-	zvol_io_hdr_t hdr_in, hdr_out;
-	struct mgmt_ack mgmt_ack;
+	zvol_io_hdr_t hdr_in, hdr_out = {0};
+	struct mgmt_ack mgmt_ack = {0};
 	int rc;
+
 	hdr_out.version = REPLICA_VERSION;
 	hdr_out.opcode = ZVOL_OPCODE_START_REBUILD;
 	hdr_out.status = ZVOL_OP_STATUS_OK;
 	hdr_out.io_seq = ++ioseq;
-	hdr_out.offset = 0;
 	hdr_out.len = sizeof (mgmt_ack);
-	hdr_out.flags = 0;
 	rc = write(control_fd, &hdr_out, sizeof (hdr_out));
 	ASSERT_ERRNO("write", rc >= 0);
 	ASSERT_EQ(rc, sizeof (hdr_out));
 	// Hack to tell the replica that it is the only replica
 	//  -> rebuild will immediately finish
-	mgmt_ack.volname[0] = '\0';
-	mgmt_ack.ip[0] = '\0';
-	mgmt_ack.port = 0;
-	strncpy(mgmt_ack.dw_volname, zvol_name.c_str(),
+	GtestUtils::strlcpy(mgmt_ack.dw_volname, zvol_name.c_str(),
 	    sizeof (mgmt_ack.dw_volname));
 	rc = write(control_fd, &mgmt_ack, sizeof (mgmt_ack));
 	ASSERT_ERRNO("write", rc >= 0);
@@ -461,8 +449,13 @@ public:
 			perror("socket");
 			return (-1);
 		}
-		setsockopt(m_listenfd, SOL_SOCKET, SO_REUSEADDR, (void *) &opt,
+		rc = setsockopt(m_listenfd, SOL_SOCKET, SO_REUSEADDR, (void *) &opt,
 		    sizeof (opt));
+		if (rc != 0) {
+			perror("setsockopt");
+			close(m_listenfd);
+			return (-1);
+		}
 		memset(&addr, 0, sizeof (addr));
 		addr.sin_family = AF_INET;
 		addr.sin_addr.s_addr = htonl(INADDR_ANY);
@@ -503,7 +496,7 @@ public:
 		}
 		if (rc > 0) {
 			fd = ::accept(m_listenfd, NULL, NULL);
-			if (rc < 0) {
+			if (fd < 0) {
 				perror("accept");
 				return (-1);
 			}
@@ -559,7 +552,7 @@ TestPool *ZreplHandshakeTest::m_pool = nullptr;
 std::string ZreplHandshakeTest::m_zvol_name = "";
 
 TEST_F(ZreplHandshakeTest, HandshakeOk) {
-	zvol_io_hdr_t hdr_out, hdr_in;
+	zvol_io_hdr_t hdr_in, hdr_out = {0};
 	std::string output;
 	mgmt_ack_t mgmt_ack;
 	int rc;
@@ -567,8 +560,6 @@ TEST_F(ZreplHandshakeTest, HandshakeOk) {
 	hdr_out.version = REPLICA_VERSION;
 	hdr_out.opcode = ZVOL_OPCODE_HANDSHAKE;
 	hdr_out.status = ZVOL_OP_STATUS_OK;
-	hdr_out.io_seq = 0;
-	hdr_out.offset = 0;
 	hdr_out.len = m_zvol_name.length() + 1;
 
 	rc = write(m_control_fd, &hdr_out, sizeof (hdr_out));
@@ -596,27 +587,24 @@ TEST_F(ZreplHandshakeTest, HandshakeOk) {
 }
 
 TEST_F(ZreplHandshakeTest, HandshakeWrongVersion) {
-	zvol_io_hdr_t hdr_out, hdr_in;
+	zvol_io_hdr_t hdr_in, hdr_out = {0};
+	// use unique ptr to implicitly dealloc mem when exiting from func
+	std::unique_ptr<char[]> msgp(new char[sizeof (hdr_out) + m_zvol_name.length() + 1]);
 	int rc;
-	char *msg;
 
 	hdr_out.version = REPLICA_VERSION + 1;
 	hdr_out.opcode = ZVOL_OPCODE_HANDSHAKE;
 	hdr_out.status = ZVOL_OP_STATUS_OK;
-	hdr_out.io_seq = 0;
-	hdr_out.offset = 0;
 	hdr_out.len = m_zvol_name.length() + 1;
 
 	/*
 	 * It must be set in one chunk so that server does not close the
 	 * connection after sending header but before sending zvol name.
 	 */
-	msg = (char *)malloc(sizeof (hdr_out) + hdr_out.len);
-	memcpy(msg, &hdr_out, sizeof (hdr_out));
-	memcpy(msg + sizeof (hdr_out), m_zvol_name.c_str(), hdr_out.len);
-	rc = write(m_control_fd, msg, sizeof (hdr_out) + hdr_out.len);
+	memcpy(msgp.get(), &hdr_out, sizeof (hdr_out));
+	memcpy(msgp.get() + sizeof (hdr_out), m_zvol_name.c_str(), hdr_out.len);
+	rc = write(m_control_fd, msgp.get(), sizeof (hdr_out) + hdr_out.len);
 	ASSERT_EQ(rc, sizeof (hdr_out) + hdr_out.len);
-	free(msg);
 
 	rc = read(m_control_fd, &hdr_in, sizeof (hdr_in));
 	ASSERT_EQ(rc, sizeof (hdr_in));
@@ -629,15 +617,13 @@ TEST_F(ZreplHandshakeTest, HandshakeWrongVersion) {
 }
 
 TEST_F(ZreplHandshakeTest, HandshakeUnknownZvol) {
-	zvol_io_hdr_t hdr_out, hdr_in;
+	zvol_io_hdr_t hdr_in, hdr_out = {0};
 	int rc;
 	const char *volname = "handshake/unknown";
 
 	hdr_out.version = REPLICA_VERSION;
 	hdr_out.opcode = ZVOL_OPCODE_HANDSHAKE;
 	hdr_out.status = ZVOL_OP_STATUS_OK;
-	hdr_out.io_seq = 0;
-	hdr_out.offset = 0;
 	hdr_out.len = strlen(volname) + 1;
 
 	rc = write(m_control_fd, &hdr_out, sizeof (hdr_out));
@@ -659,14 +645,12 @@ TEST_F(ZreplHandshakeTest, HandshakeUnknownZvol) {
 }
 
 TEST_F(ZreplHandshakeTest, UnknownOpcode) {
-	zvol_io_hdr_t hdr_out, hdr_in;
+	zvol_io_hdr_t hdr_in, hdr_out = {0};
 	int rc;
 
 	hdr_out.version = REPLICA_VERSION;
 	hdr_out.opcode = (zvol_op_code_t) 255;
 	hdr_out.status = ZVOL_OP_STATUS_OK;
-	hdr_out.io_seq = 0;
-	hdr_out.offset = 0;
 	hdr_out.len = m_zvol_name.length() + 1;
 
 	rc = write(m_control_fd, &hdr_out, sizeof (hdr_out));
@@ -699,7 +683,6 @@ protected:
 	 * the setup hook should be simplified to minimum again.
 	 */
 	static void SetUpTestCase() {
-		zvol_io_hdr_t hdr_out, hdr_in;
 		Target target1, target2;
 		m_pool1 = new TestPool("ihandshake");
 		m_pool2 = new TestPool("handshake");
@@ -758,8 +741,6 @@ protected:
 	}
 
 	ZreplDataTest() {
-		m_data_fd1 = -1;
-		m_data_fd2 = -1;
 		m_ioseq1 = 0;
 		m_ioseq2 = 0;
 	}
@@ -768,13 +749,13 @@ protected:
 	 * Create data connection and send handshake msg for the zvol.
 	 */
 	virtual void SetUp() override {
-		do_data_connection(m_data_fd1, m_host1, m_port1, m_zvol_name1);
-		do_data_connection(m_data_fd2, m_host2, m_port2, m_zvol_name2);
+		do_data_connection(m_datasock1.fd(), m_host1, m_port1, m_zvol_name1);
+		do_data_connection(m_datasock2.fd(), m_host2, m_port2, m_zvol_name2);
 	}
 
 	virtual void TearDown() override {
-		graceful_close(m_data_fd1);
-		graceful_close(m_data_fd2);
+		m_datasock1.graceful_close();
+		m_datasock2.graceful_close();
 	}
 
 	static int	m_control_fd1;
@@ -789,8 +770,8 @@ protected:
 	static std::string m_zvol_name1;
 	static std::string m_zvol_name2;
 
-	int	m_data_fd1;
-	int	m_data_fd2;
+	SocketFd m_datasock1;
+	SocketFd m_datasock2;
 	int	m_ioseq1;
 	int	m_ioseq2;
 };
@@ -812,13 +793,13 @@ Zrepl *ZreplDataTest::m_zrepl = nullptr;
  * and test that read returns two metadata chunks.
  */
 TEST_F(ZreplDataTest, WriteAndReadBlocksWithIonum) {
-	write_data_and_verify_resp(m_data_fd1, m_ioseq1, 0, 123);
-	write_two_chunks_and_verify_resp(m_data_fd1, m_ioseq1, 4096);
-	read_data_and_verify_resp(m_data_fd1, m_ioseq1);
+	write_data_and_verify_resp(m_datasock1.fd(), m_ioseq1, 0, 123);
+	write_two_chunks_and_verify_resp(m_datasock1.fd(), m_ioseq1, 4096);
+	read_data_and_verify_resp(m_datasock1.fd(), m_ioseq1);
 
-	write_data_and_verify_resp(m_data_fd2, m_ioseq2, 0, 123);
-	write_two_chunks_and_verify_resp(m_data_fd2, m_ioseq2, 4096);
-	read_data_and_verify_resp(m_data_fd2, m_ioseq2);
+	write_data_and_verify_resp(m_datasock2.fd(), m_ioseq2, 0, 123);
+	write_two_chunks_and_verify_resp(m_datasock2.fd(), m_ioseq2, 4096);
+	read_data_and_verify_resp(m_datasock2.fd(), m_ioseq2);
 }
 
 /* Read two blocks without metadata from the end of zvol */
@@ -830,16 +811,16 @@ TEST_F(ZreplDataTest, ReadBlockWithoutMeta) {
 	size_t offset = ZVOL_SIZE - 2 * sizeof (buf);
 
 	for (int i = 0; i < 2; i++) {
-		read_data_start(m_data_fd1, m_ioseq1, offset, sizeof (buf), &hdr_in);
+		read_data_start(m_datasock1.fd(), m_ioseq1, offset, sizeof (buf), &hdr_in);
 		ASSERT_EQ(hdr_in.status, ZVOL_OP_STATUS_OK);
 		ASSERT_EQ(hdr_in.len, sizeof (read_hdr) + sizeof (buf));
 
-		rc = read(m_data_fd1, &read_hdr, sizeof (read_hdr));
+		rc = read(m_datasock1.fd(), &read_hdr, sizeof (read_hdr));
 		ASSERT_ERRNO("read", rc >= 0);
 		ASSERT_EQ(rc, sizeof (read_hdr));
 		ASSERT_EQ(read_hdr.io_num, 0);
 		ASSERT_EQ(read_hdr.len, sizeof (buf));
-		rc = read(m_data_fd1, buf, read_hdr.len);
+		rc = read(m_datasock1.fd(), buf, read_hdr.len);
 		ASSERT_ERRNO("read", rc >= 0);
 		ASSERT_EQ(rc, read_hdr.len);
 		offset += sizeof (buf);
@@ -851,13 +832,13 @@ TEST_F(ZreplDataTest, ReadBlockWithoutMeta) {
  * sync'd but at least we test the basic command flow.
  */
 TEST_F(ZreplDataTest, WriteAndSync) {
-	zvol_io_hdr_t hdr_out, hdr_in;
+	zvol_io_hdr_t hdr_in, hdr_out = {0};
 	char buf[4096];
 	int rc;
 
 	init_buf(buf, sizeof (buf), "cStor-data");
-	write_data(m_data_fd1, m_ioseq1, buf, 0, sizeof (buf), ++m_ioseq1);
-	rc = read(m_data_fd1, &hdr_in, sizeof (hdr_in));
+	write_data(m_datasock1.fd(), m_ioseq1, buf, 0, sizeof (buf), ++m_ioseq1);
+	rc = read(m_datasock1.fd(), &hdr_in, sizeof (hdr_in));
 	ASSERT_ERRNO("read", rc >= 0);
 	ASSERT_EQ(rc, sizeof (hdr_in));
 	EXPECT_EQ(hdr_in.opcode, ZVOL_OPCODE_WRITE);
@@ -868,15 +849,12 @@ TEST_F(ZreplDataTest, WriteAndSync) {
 	hdr_out.opcode = ZVOL_OPCODE_SYNC;
 	hdr_out.status = ZVOL_OP_STATUS_OK;
 	hdr_out.io_seq = ++m_ioseq1;
-	hdr_out.offset = 0;
-	hdr_out.len = 0;
-	hdr_out.flags = 0;
 
-	rc = write(m_data_fd1, &hdr_out, sizeof (hdr_out));
+	rc = write(m_datasock1.fd(), &hdr_out, sizeof (hdr_out));
 	ASSERT_ERRNO("write", rc >= 0);
 	ASSERT_EQ(rc, sizeof (hdr_out));
 
-	rc = read(m_data_fd1, &hdr_in, sizeof (hdr_in));
+	rc = read(m_datasock1.fd(), &hdr_in, sizeof (hdr_in));
 	ASSERT_ERRNO("read", rc >= 0);
 	ASSERT_EQ(rc, sizeof (hdr_in));
 	EXPECT_EQ(hdr_in.opcode, ZVOL_OPCODE_SYNC);
@@ -887,16 +865,13 @@ TEST_F(ZreplDataTest, WriteAndSync) {
 }
 
 TEST_F(ZreplDataTest, UnknownOpcode) {
-	zvol_io_hdr_t hdr_out, hdr_in;
+	zvol_io_hdr_t hdr_in, hdr_out = {0};
 	int rc;
 
 	hdr_out.version = REPLICA_VERSION;
 	hdr_out.opcode = (zvol_op_code_t) 255;
 	hdr_out.status = ZVOL_OP_STATUS_OK;
 	hdr_out.io_seq = ++m_ioseq1;
-	hdr_out.offset = 0;
-	hdr_out.len = 0;
-	hdr_out.flags = 0;
 
 	rc = write(m_control_fd1, &hdr_out, sizeof (hdr_out));
 	ASSERT_ERRNO("write", rc >= 0);
@@ -915,12 +890,12 @@ TEST_F(ZreplDataTest, ReadInvalidOffset) {
 	int rc;
 
 	// unaligned offset
-	read_data_start(m_data_fd1, m_ioseq1, 33, 4096, &hdr_in);
+	read_data_start(m_datasock1.fd(), m_ioseq1, 33, 4096, &hdr_in);
 	ASSERT_EQ(hdr_in.status, ZVOL_OP_STATUS_FAILED);
 	ASSERT_EQ(hdr_in.len, 0);
 
 	// offset past the end of zvol
-	read_data_start(m_data_fd1, m_ioseq1, ZVOL_SIZE + 4096, 4096, &hdr_in);
+	read_data_start(m_datasock1.fd(), m_ioseq1, ZVOL_SIZE + 4096, 4096, &hdr_in);
 	ASSERT_EQ(hdr_in.status, ZVOL_OP_STATUS_FAILED);
 	ASSERT_EQ(hdr_in.len, 0);
 }
@@ -930,12 +905,12 @@ TEST_F(ZreplDataTest, ReadInvalidLength) {
 	int rc;
 
 	// unaligned length
-	read_data_start(m_data_fd1, m_ioseq1, 0, 4097, &hdr_in);
+	read_data_start(m_datasock1.fd(), m_ioseq1, 0, 4097, &hdr_in);
 	ASSERT_EQ(hdr_in.status, ZVOL_OP_STATUS_FAILED);
 	ASSERT_EQ(hdr_in.len, 0);
 
 	// length past the end of zvol
-	read_data_start(m_data_fd1, m_ioseq1, ZVOL_SIZE - 4096, 2 * 4096, &hdr_in);
+	read_data_start(m_datasock1.fd(), m_ioseq1, ZVOL_SIZE - 4096, 2 * 4096, &hdr_in);
 	ASSERT_EQ(hdr_in.status, ZVOL_OP_STATUS_FAILED);
 	ASSERT_EQ(hdr_in.len, 0);
 }
@@ -947,8 +922,8 @@ TEST_F(ZreplDataTest, WriteInvalidOffset) {
 
 	// Writing last block of zvol should succeed
 	init_buf(buf, sizeof (buf), "cStor-data");
-	write_data(m_data_fd1, m_ioseq1, buf, ZVOL_SIZE - sizeof (buf), sizeof (buf), 333);
-	rc = read(m_data_fd1, &hdr_in, sizeof (hdr_in));
+	write_data(m_datasock1.fd(), m_ioseq1, buf, ZVOL_SIZE - sizeof (buf), sizeof (buf), 333);
+	rc = read(m_datasock1.fd(), &hdr_in, sizeof (hdr_in));
 	ASSERT_ERRNO("read", rc >= 0);
 	ASSERT_EQ(rc, sizeof (hdr_in));
 	EXPECT_EQ(hdr_in.opcode, ZVOL_OPCODE_WRITE);
@@ -956,8 +931,8 @@ TEST_F(ZreplDataTest, WriteInvalidOffset) {
 	EXPECT_EQ(hdr_in.status, ZVOL_OP_STATUS_OK);
 
 	// Writing past the end of zvol should fail
-	write_data(m_data_fd1, m_ioseq1, buf, ZVOL_SIZE, sizeof (buf), 334);
-	rc = read(m_data_fd1, &hdr_in, sizeof (hdr_in));
+	write_data(m_datasock1.fd(), m_ioseq1, buf, ZVOL_SIZE, sizeof (buf), 334);
+	rc = read(m_datasock1.fd(), &hdr_in, sizeof (hdr_in));
 	ASSERT_ERRNO("read", rc >= 0);
 	ASSERT_EQ(rc, sizeof (hdr_in));
 	EXPECT_EQ(hdr_in.opcode, ZVOL_OPCODE_WRITE);
@@ -972,8 +947,8 @@ TEST_F(ZreplDataTest, WriteInvalidLength) {
 
 	init_buf(buf, sizeof (buf), "cStor-data");
 
-	write_data(m_data_fd1, m_ioseq1, buf, ZVOL_SIZE - 4096, sizeof (buf), 334);
-	rc = read(m_data_fd1, &hdr_in, sizeof (hdr_in));
+	write_data(m_datasock1.fd(), m_ioseq1, buf, ZVOL_SIZE - 4096, sizeof (buf), 334);
+	rc = read(m_datasock1.fd(), &hdr_in, sizeof (hdr_in));
 	ASSERT_ERRNO("read", rc >= 0);
 	ASSERT_EQ(rc, sizeof (hdr_in));
 	EXPECT_EQ(hdr_in.opcode, ZVOL_OPCODE_WRITE);
@@ -986,7 +961,7 @@ TEST_F(ZreplDataTest, WriteInvalidLength) {
  * not finished) or when requested by ZVOL_OP_FLAG_REBUILD flag.
  */
 TEST_F(ZreplDataTest, RebuildFlag) {
-	zvol_io_hdr_t hdr_in, hdr_out;
+	zvol_io_hdr_t hdr_in;
 	struct zvol_io_rw_hdr read_hdr;
 	struct zvol_io_rw_hdr write_hdr;
 	struct zrepl_status_ack status;
@@ -995,7 +970,7 @@ TEST_F(ZreplDataTest, RebuildFlag) {
 	int rc;
 
 	/* write a data block with known ionum */
-	write_data_and_verify_resp(m_data_fd1, m_ioseq1, 0, 654);
+	write_data_and_verify_resp(m_datasock1.fd(), m_ioseq1, 0, 654);
 
 	/* Get zvol status before rebuild */
 	get_zvol_status(m_zvol_name1, m_ioseq1, m_control_fd1, ZVOL_STATUS_DEGRADED, ZVOL_REBUILDING_INIT);
@@ -1008,28 +983,28 @@ TEST_F(ZreplDataTest, RebuildFlag) {
 	get_zvol_status(m_zvol_name1, m_ioseq1, m_control_fd1, ZVOL_STATUS_HEALTHY, ZVOL_REBUILDING_DONE);
 
 	/* read the block without rebuild flag */
-	read_data_start(m_data_fd1, m_ioseq1, 0, sizeof (buf), &hdr_in, 0);
+	read_data_start(m_datasock1.fd(), m_ioseq1, 0, sizeof (buf), &hdr_in, 0);
 	ASSERT_EQ(hdr_in.status, ZVOL_OP_STATUS_OK);
 	ASSERT_EQ(hdr_in.len, sizeof (read_hdr) + sizeof (buf));
-	rc = read(m_data_fd1, &read_hdr, sizeof (read_hdr));
+	rc = read(m_datasock1.fd(), &read_hdr, sizeof (read_hdr));
 	ASSERT_ERRNO("read", rc >= 0);
 	ASSERT_EQ(rc, sizeof (read_hdr));
 	ASSERT_EQ(read_hdr.io_num, 0);
 	ASSERT_EQ(read_hdr.len, sizeof (buf));
-	rc = read(m_data_fd1, buf, sizeof (buf));
+	rc = read(m_datasock1.fd(), buf, sizeof (buf));
 	ASSERT_ERRNO("read", rc >= 0);
 	ASSERT_EQ(rc, sizeof (buf));
 
 	/* read the block with rebuild flag */
-	read_data_start(m_data_fd1, m_ioseq1, 0, sizeof (buf), &hdr_in, ZVOL_OP_FLAG_REBUILD);
+	read_data_start(m_datasock1.fd(), m_ioseq1, 0, sizeof (buf), &hdr_in, ZVOL_OP_FLAG_REBUILD);
 	ASSERT_EQ(hdr_in.status, ZVOL_OP_STATUS_OK);
 	ASSERT_EQ(hdr_in.len, sizeof (read_hdr) + sizeof (buf));
-	rc = read(m_data_fd1, &read_hdr, sizeof (read_hdr));
+	rc = read(m_datasock1.fd(), &read_hdr, sizeof (read_hdr));
 	ASSERT_ERRNO("read", rc >= 0);
 	ASSERT_EQ(rc, sizeof (read_hdr));
 	ASSERT_EQ(read_hdr.io_num, 654);
 	ASSERT_EQ(read_hdr.len, sizeof (buf));
-	rc = read(m_data_fd1, buf, sizeof (buf));
+	rc = read(m_datasock1.fd(), buf, sizeof (buf));
 	ASSERT_ERRNO("read", rc >= 0);
 	ASSERT_EQ(rc, sizeof (buf));
 }
@@ -1039,7 +1014,7 @@ TEST_F(ZreplDataTest, RebuildFlag) {
  * ZVOL_OP_FLAG_READ_METADATA flag.
  */
 TEST_F(ZreplDataTest, ReadMetaDataFlag) {
-	zvol_io_hdr_t hdr_in, hdr_out;
+	zvol_io_hdr_t hdr_in;
 	struct zvol_io_rw_hdr read_hdr;
 	struct zvol_io_rw_hdr write_hdr;
 	struct zrepl_status_ack status;
@@ -1048,31 +1023,31 @@ TEST_F(ZreplDataTest, ReadMetaDataFlag) {
 	int rc;
 
 	/* write a data block with known ionum */
-	write_data_and_verify_resp(m_data_fd1, m_ioseq1, 0, 654);
+	write_data_and_verify_resp(m_datasock1.fd(), m_ioseq1, 0, 654);
 
 	/* read the block without ZVOL_OP_FLAG_READ_METADATA flag */
-	read_data_start(m_data_fd1, m_ioseq1, 0, sizeof (buf), &hdr_in, 0);
+	read_data_start(m_datasock1.fd(), m_ioseq1, 0, sizeof (buf), &hdr_in, 0);
 	ASSERT_EQ(hdr_in.status, ZVOL_OP_STATUS_OK);
 	ASSERT_EQ(hdr_in.len, sizeof (read_hdr) + sizeof (buf));
-	rc = read(m_data_fd1, &read_hdr, sizeof (read_hdr));
+	rc = read(m_datasock1.fd(), &read_hdr, sizeof (read_hdr));
 	ASSERT_ERRNO("read", rc >= 0);
 	ASSERT_EQ(rc, sizeof (read_hdr));
 	ASSERT_EQ(read_hdr.io_num, 0);
 	ASSERT_EQ(read_hdr.len, sizeof (buf));
-	rc = read(m_data_fd1, buf, sizeof (buf));
+	rc = read(m_datasock1.fd(), buf, sizeof (buf));
 	ASSERT_ERRNO("read", rc >= 0);
 	ASSERT_EQ(rc, sizeof (buf));
 
 	/* read the block with ZVOL_OP_FLAG_READ_METADATA flag */
-	read_data_start(m_data_fd1, m_ioseq1, 0, sizeof (buf), &hdr_in, ZVOL_OP_FLAG_READ_METADATA);
+	read_data_start(m_datasock1.fd(), m_ioseq1, 0, sizeof (buf), &hdr_in, ZVOL_OP_FLAG_READ_METADATA);
 	ASSERT_EQ(hdr_in.status, ZVOL_OP_STATUS_OK);
 	ASSERT_EQ(hdr_in.len, sizeof (read_hdr) + sizeof (buf));
-	rc = read(m_data_fd1, &read_hdr, sizeof (read_hdr));
+	rc = read(m_datasock1.fd(), &read_hdr, sizeof (read_hdr));
 	ASSERT_ERRNO("read", rc >= 0);
 	ASSERT_EQ(rc, sizeof (read_hdr));
 	ASSERT_EQ(read_hdr.io_num, 654);
 	ASSERT_EQ(read_hdr.len, sizeof (buf));
-	rc = read(m_data_fd1, buf, sizeof (buf));
+	rc = read(m_datasock1.fd(), buf, sizeof (buf));
 	ASSERT_ERRNO("read", rc >= 0);
 	ASSERT_EQ(rc, sizeof (buf));
 }
@@ -1157,7 +1132,7 @@ TEST(TargetIPTest, CreateAndDestroy) {
  * Test that zrepl will try to reconnect when target restarts.
  */
 TEST(TargetIPTest, Reconnect) {
-	zvol_io_hdr_t hdr_out, hdr_in;
+	zvol_io_hdr_t hdr_in, hdr_out = {0};
 	Zrepl zrepl;
 	TestPool pool("handshake");
 	std::string zvolname = pool.getZvolName("reconnect");
@@ -1182,8 +1157,6 @@ TEST(TargetIPTest, Reconnect) {
 	hdr_out.version = REPLICA_VERSION;
 	hdr_out.opcode = ZVOL_OPCODE_HANDSHAKE;
 	hdr_out.status = ZVOL_OP_STATUS_OK;
-	hdr_out.io_seq = 0;
-	hdr_out.offset = 0;
 	hdr_out.len = zvolname.length() + 1;
 	rc = write(fd, &hdr_out, sizeof (hdr_out));
 	ASSERT_EQ(rc, sizeof (hdr_out));
@@ -1219,7 +1192,7 @@ TEST(Misc, ZreplCheckpointInterval) {
 	Target	target;
 	std::string zvol_name_slow, zvol_name_fast;
 	int	rc, control_fd;
-	int	data_fd_slow, data_fd_fast;
+	SocketFd datasock_slow, datasock_fast;
 	int	ioseq = 0;
 	std::string host_slow, host_fast;
 	uint16_t port_slow, port_fast;
@@ -1246,13 +1219,13 @@ TEST(Misc, ZreplCheckpointInterval) {
 	transition_zvol_to_online(ioseq, control_fd, zvol_name_slow);
 	transition_zvol_to_online(ioseq, control_fd, zvol_name_fast);
 
-	do_data_connection(data_fd_slow, host_slow, port_slow, zvol_name_slow,
+	do_data_connection(datasock_slow.fd(), host_slow, port_slow, zvol_name_slow,
 	    4096, 1000);
-	do_data_connection(data_fd_fast, host_fast, port_fast, zvol_name_fast,
+	do_data_connection(datasock_fast.fd(), host_fast, port_fast, zvol_name_fast,
 	    4096, 1);
 
-	write_data_and_verify_resp(data_fd_slow, ioseq, 0, 888);
-	write_data_and_verify_resp(data_fd_fast, ioseq, 0, 888);
+	write_data_and_verify_resp(datasock_slow.fd(), ioseq, 0, 888);
+	write_data_and_verify_resp(datasock_fast.fd(), ioseq, 0, 888);
 	sleep(2);
 
 	do_handshake(zvol_name_slow, host_slow, port_slow, &ionum_slow,
@@ -1262,8 +1235,8 @@ TEST(Misc, ZreplCheckpointInterval) {
 	ASSERT_NE(ionum_slow, 888);
 	ASSERT_EQ(ionum_fast, 888);
 
-	graceful_close(data_fd_slow);
-	graceful_close(data_fd_fast);
+	datasock_slow.graceful_close();
+	datasock_fast.graceful_close();
 	graceful_close(control_fd);
 }
 
@@ -1273,7 +1246,6 @@ protected:
 	 * Shared setup hook for all zrepl block size tests - called just once.
 	 */
 	static void SetUpTestCase() {
-		zvol_io_hdr_t hdr_out, hdr_in;
 		m_pool = new TestPool("blocksize");
 		m_zrepl = new Zrepl();
 
@@ -1288,6 +1260,7 @@ protected:
 
 	ZreplBlockSizeTest() {
 		m_ioseq = 0;
+		m_port = 0;
 	}
 
 	/*
@@ -1297,7 +1270,6 @@ protected:
 		Target target;
 		int rc;
 
-		m_data_fd = -1;
 		m_control_fd = -1;
 		rc = target.listen();
 		ASSERT_GE(rc, 0);
@@ -1313,8 +1285,6 @@ protected:
 
 	virtual void TearDown() override {
 		m_pool->destroyZvol("vol");
-		if (m_data_fd >= 0)
-			close(m_data_fd);
 		if (m_control_fd >= 0)
 			close(m_control_fd);
 	}
@@ -1325,7 +1295,7 @@ protected:
 	uint16_t m_port;
 	std::string m_host;
 	std::string m_zvol_name;
-	int	m_ioseq, m_data_fd, m_control_fd;
+	int	m_ioseq, m_control_fd;
 };
 
 TestPool *ZreplBlockSizeTest::m_pool = nullptr;
@@ -1335,35 +1305,43 @@ Zrepl *ZreplBlockSizeTest::m_zrepl = nullptr;
  * Test setting metadata granularity on zvol.
  */
 TEST_F(ZreplBlockSizeTest, SetMetaBlockSize) {
-	do_data_connection(m_data_fd, m_host, m_port, m_zvol_name, 4096);
-	write_data_and_verify_resp(m_data_fd, m_ioseq, 0, 1);
-	graceful_close(m_data_fd);
-	m_data_fd = -1;
-	do_data_connection(m_data_fd, m_host, m_port, m_zvol_name, 4096);
-	write_data_and_verify_resp(m_data_fd, m_ioseq, 0, 1);
+	SocketFd datasock1, datasock2;
+
+	do_data_connection(datasock1.fd(), m_host, m_port, m_zvol_name, 4096);
+	write_data_and_verify_resp(datasock1.fd(), m_ioseq, 0, 1);
+	datasock1.graceful_close();
+	do_data_connection(datasock2.fd(), m_host, m_port, m_zvol_name, 4096);
+	write_data_and_verify_resp(datasock2.fd(), m_ioseq, 0, 1);
 }
 
 TEST_F(ZreplBlockSizeTest, SetMetaBlockSizeSmallerThanBlockSize) {
-	do_data_connection(m_data_fd, m_host, m_port, m_zvol_name, 512);
-	write_data_and_verify_resp(m_data_fd, m_ioseq, 0, 1, 512);
+	SocketFd datasock;
+
+	do_data_connection(datasock.fd(), m_host, m_port, m_zvol_name, 512);
+	write_data_and_verify_resp(datasock.fd(), m_ioseq, 0, 1, 512);
 }
 
 TEST_F(ZreplBlockSizeTest, SetMetaBlockSizeBiggerThanBlockSize) {
-	do_data_connection(m_data_fd, m_host, m_port, m_zvol_name, 8192);
-	write_data_and_verify_resp(m_data_fd, m_ioseq, 0, 1, 8192);
+	SocketFd datasock;
+
+	do_data_connection(datasock.fd(), m_host, m_port, m_zvol_name, 8192);
+	write_data_and_verify_resp(datasock.fd(), m_ioseq, 0, 1, 8192);
 }
 
 TEST_F(ZreplBlockSizeTest, SetMetaBlockSizeUnaligned) {
-	do_data_connection(m_data_fd, m_host, m_port, m_zvol_name, 513, 120,
+	SocketFd datasock;
+
+	do_data_connection(datasock.fd(), m_host, m_port, m_zvol_name, 513, 120,
 	    ZVOL_OP_STATUS_FAILED);
 }
 
 TEST_F(ZreplBlockSizeTest, SetDifferentMetaBlockSizes) {
-	do_data_connection(m_data_fd, m_host, m_port, m_zvol_name, 4096);
-	write_data_and_verify_resp(m_data_fd, m_ioseq, 0, 1);
-	graceful_close(m_data_fd);
-	m_data_fd = -1;
-	do_data_connection(m_data_fd, m_host, m_port, m_zvol_name, 512, 120,
+	SocketFd datasock1, datasock2;
+
+	do_data_connection(datasock1.fd(), m_host, m_port, m_zvol_name, 4096);
+	write_data_and_verify_resp(datasock1.fd(), m_ioseq, 0, 1);
+	datasock1.graceful_close();
+	do_data_connection(datasock2.fd(), m_host, m_port, m_zvol_name, 512, 120,
 	    ZVOL_OP_STATUS_FAILED);
 }
 
@@ -1373,7 +1351,8 @@ TEST_F(ZreplBlockSizeTest, SetDifferentMetaBlockSizes) {
 TEST(DiskReplaceTest, SpareReplacement) {
 	Zrepl zrepl;
 	Target target;
-	int rc, data_fd, control_fd;
+	int rc, control_fd;
+	SocketFd datasock;
 	std::string host;
 	uint16_t port;
 	int ioseq;
@@ -1393,35 +1372,35 @@ TEST(DiskReplaceTest, SpareReplacement) {
 	ASSERT_GE(control_fd, 0);
 	do_handshake(pool.getZvolName("vol"), host, port, NULL, control_fd,
 	    ZVOL_OP_STATUS_OK);
-	do_data_connection(data_fd, host, port, pool.getZvolName("vol"));
-	write_data_and_verify_resp(data_fd, ioseq, 0, 10);
+	do_data_connection(datasock.fd(), host, port, pool.getZvolName("vol"));
+	write_data_and_verify_resp(datasock.fd(), ioseq, 0, 10);
 
 	// construct mirrored pool with a spare
 	execCmd("zpool", std::string("attach ") + pool.m_name + " " +
 	    pool.m_vdev->m_path + " " + vdev2.m_path);
-	write_data_and_verify_resp(data_fd, ioseq, 0, 10);
+	write_data_and_verify_resp(datasock.fd(), ioseq, 0, 10);
 	execCmd("zpool", std::string("add ") + pool.m_name + " spare " +
 	    spare.m_path);
-	write_data_and_verify_resp(data_fd, ioseq, 0, 10);
+	write_data_and_verify_resp(datasock.fd(), ioseq, 0, 10);
 	ASSERT_STREQ(getPoolState(pool.m_name).c_str(), "ONLINE");
 
 	// fail one of the disks in the mirror
 	execCmd("zpool", std::string("offline ") + pool.m_name + " " +
 	    vdev2.m_path);
-	write_data_and_verify_resp(data_fd, ioseq, 0, 10);
+	write_data_and_verify_resp(datasock.fd(), ioseq, 0, 10);
 	ASSERT_STREQ(getPoolState(pool.m_name).c_str(), "DEGRADED");
 
 	// replace failed disk by the spare and remove it from mirror
 	execCmd("zpool", std::string("replace ") + pool.m_name + " " +
 	    vdev2.m_path + " " + spare.m_path);
-	write_data_and_verify_resp(data_fd, ioseq, 0, 10);
+	write_data_and_verify_resp(datasock.fd(), ioseq, 0, 10);
 	execCmd("zpool", std::string("detach ") + pool.m_name + " " +
 	    vdev2.m_path);
 	ASSERT_STREQ(getPoolState(pool.m_name).c_str(), "ONLINE");
 
 	//std::cout << execCmd("zpool", std::string("status ") + pool.m_name);
 
-	graceful_close(data_fd);
+	datasock.graceful_close();
 	graceful_close(control_fd);
 }
 
@@ -1429,7 +1408,7 @@ TEST(DiskReplaceTest, SpareReplacement) {
  * Snapshot create and destroy.
  */
 TEST(Snapshot, CreateAndDestroy) {
-	zvol_io_hdr_t hdr_out, hdr_in;
+	zvol_io_hdr_t hdr_in, hdr_out = {0};
 	Zrepl zrepl;
 	Target target;
 	int rc, control_fd;
@@ -1452,7 +1431,6 @@ TEST(Snapshot, CreateAndDestroy) {
 	hdr_out.opcode = ZVOL_OPCODE_SNAP_CREATE;
 	hdr_out.status = ZVOL_OP_STATUS_OK;
 	hdr_out.io_seq = 0;
-	hdr_out.offset = 0;
 	hdr_out.len = bad_snap_name.length() + 1;
 	rc = write(control_fd, &hdr_out, sizeof (hdr_out));
 	ASSERT_EQ(rc, sizeof (hdr_out));
@@ -1464,11 +1442,7 @@ TEST(Snapshot, CreateAndDestroy) {
 	ASSERT_EQ(hdr_in.len, 0);
 
 	// try to create snap of unknown zvol
-	hdr_out.version = REPLICA_VERSION;
-	hdr_out.opcode = ZVOL_OPCODE_SNAP_CREATE;
-	hdr_out.status = ZVOL_OP_STATUS_OK;
-	hdr_out.io_seq = 0;
-	hdr_out.offset = 0;
+	hdr_out.io_seq = 1;
 	hdr_out.len = unknown_snap_name.length() + 1;
 	rc = write(control_fd, &hdr_out, sizeof (hdr_out));
 	ASSERT_EQ(rc, sizeof (hdr_out));
@@ -1480,36 +1454,26 @@ TEST(Snapshot, CreateAndDestroy) {
 	ASSERT_EQ(hdr_in.len, 0);
 
 	// create the snapshot
-	hdr_out.version = REPLICA_VERSION;
-	hdr_out.opcode = ZVOL_OPCODE_SNAP_CREATE;
-	hdr_out.status = ZVOL_OP_STATUS_OK;
-	hdr_out.io_seq = 0;
-	hdr_out.offset = 0;
+	hdr_out.io_seq = 2;
 	hdr_out.len = snap_name.length() + 1;
-
 	rc = write(control_fd, &hdr_out, sizeof (hdr_out));
 	ASSERT_EQ(rc, sizeof (hdr_out));
 	rc = write(control_fd, snap_name.c_str(), hdr_out.len);
 	ASSERT_EQ(rc, hdr_out.len);
-
 	rc = read(control_fd, &hdr_in, sizeof (hdr_in));
 	ASSERT_EQ(rc, sizeof (hdr_in));
 	EXPECT_EQ(hdr_in.version, REPLICA_VERSION);
 	EXPECT_EQ(hdr_in.opcode, ZVOL_OPCODE_SNAP_CREATE);
 	EXPECT_EQ(hdr_in.status, ZVOL_OP_STATUS_OK);
-	EXPECT_EQ(hdr_in.io_seq, 0);
+	EXPECT_EQ(hdr_in.io_seq, 2);
 	ASSERT_EQ(hdr_in.len, 0);
 
 	ASSERT_NO_THROW(execCmd("zfs", std::string("list ") + snap_name));
 
 	// destroy the snapshot
-	hdr_out.version = REPLICA_VERSION;
 	hdr_out.opcode = ZVOL_OPCODE_SNAP_DESTROY;
-	hdr_out.status = ZVOL_OP_STATUS_OK;
-	hdr_out.io_seq = 1;
-	hdr_out.offset = 0;
+	hdr_out.io_seq = 3;
 	hdr_out.len = snap_name.length() + 1;
-
 	rc = write(control_fd, &hdr_out, sizeof (hdr_out));
 	ASSERT_EQ(rc, sizeof (hdr_out));
 	rc = write(control_fd, snap_name.c_str(), hdr_out.len);
@@ -1520,7 +1484,7 @@ TEST(Snapshot, CreateAndDestroy) {
 	EXPECT_EQ(hdr_in.version, REPLICA_VERSION);
 	EXPECT_EQ(hdr_in.opcode, ZVOL_OPCODE_SNAP_DESTROY);
 	EXPECT_EQ(hdr_in.status, ZVOL_OP_STATUS_OK);
-	EXPECT_EQ(hdr_in.io_seq, 1);
+	EXPECT_EQ(hdr_in.io_seq, 3);
 	ASSERT_EQ(hdr_in.len, 0);
 
 	ASSERT_THROW(execCmd("zfs", std::string("list ") + snap_name),
@@ -1533,7 +1497,7 @@ TEST(Snapshot, CreateAndDestroy) {
  * Test zvol resize
  */
 TEST(ZvolResizeTest, ResizeZvol) {
-	zvol_io_hdr_t hdr_out, hdr_in;
+	zvol_io_hdr_t hdr_in, hdr_out = {0};
 	Zrepl zrepl;
 	Target target;
 	int rc, control_fd;
@@ -1564,13 +1528,13 @@ TEST(ZvolResizeTest, ResizeZvol) {
 	hdr_out.opcode = ZVOL_OPCODE_RESIZE;
 	hdr_out.status = ZVOL_OP_STATUS_OK;
 	hdr_out.io_seq = 1;
-	hdr_out.offset = 0;
 	hdr_out.len = sizeof (resize_data);
 	rc = write(control_fd, &hdr_out, sizeof (hdr_out));
 	ASSERT_EQ(rc, sizeof (hdr_out));
 	// double the zvol size
 	val1 <<= 1;
-	strcpy(resize_data.volname, zvolname.c_str());
+	GtestUtils::strlcpy(resize_data.volname, zvolname.c_str(),
+	    sizeof (resize_data.volname));
 	resize_data.size = val1;
 	rc = write(control_fd, &resize_data, sizeof (resize_data));
 	ASSERT_EQ(rc, sizeof (resize_data));
@@ -1640,7 +1604,7 @@ TEST(ZvolCloneTest, CloneZvol) {
 void
 get_used(int control_fd, std::string zvolname, uint64_t *val)
 {
-	zvol_io_hdr_t hdr_out, hdr_in;
+	zvol_io_hdr_t hdr_in, hdr_out = {0};
 	zvol_op_stat_t stat;
 	int rc;
 
@@ -1648,7 +1612,6 @@ get_used(int control_fd, std::string zvolname, uint64_t *val)
 	hdr_out.opcode = ZVOL_OPCODE_STATS;
 	hdr_out.status = ZVOL_OP_STATUS_OK;
 	hdr_out.io_seq = 1;
-	hdr_out.offset = 0;
 	hdr_out.len = zvolname.length() + 1;
 	rc = write(control_fd, &hdr_out, sizeof (hdr_out));
 	ASSERT_EQ(rc, sizeof (hdr_out));
@@ -1671,7 +1634,8 @@ get_used(int control_fd, std::string zvolname, uint64_t *val)
 TEST(ZvolStatsTest, StatsZvol) {
 	Zrepl zrepl;
 	Target target;
-	int rc, control_fd, data_fd;
+	int rc, control_fd;
+	SocketFd datasock;
 	int ioseq = 0;
 	std::string host;
 	uint16_t port;
@@ -1693,14 +1657,14 @@ TEST(ZvolStatsTest, StatsZvol) {
 	// get "used" before
 	get_used(control_fd, zvolname, &val1);
 
-	do_data_connection(data_fd, host, port, zvolname, 4096);
+	do_data_connection(datasock.fd(), host, port, zvolname, 4096);
 	for (int i = 0; i < 100; i++) {
-		write_data_and_verify_resp(data_fd, ioseq, 4096 * i, i + 1);
+		write_data_and_verify_resp(datasock.fd(), ioseq, 4096 * i, i + 1);
 	}
-	graceful_close(data_fd);
+	datasock.graceful_close();
 
 	// get "used" after
 	get_used(control_fd, zvolname, &val2);
-	EXPECT_GT(val2, val1);
+	EXPECT_LE(val1, val2);
 	graceful_close(control_fd);
 }


### PR DESCRIPTION
This fixes a couple of tens of bugs reported by coverity. Most of them are nits nevertheless fixing them improves the quality of our code and it will silence the coverity, so we can focus on more important issues found by it. This should fix all issues in two files: test_zrepl_prot.cc and mgmt_conn.c - both related to management connection. In case you have question about particular code change I will be happy to answer it!