### PR TITLE
[TA1652] Lockless refcount increment and decrement

### DIFF
--- a/cmd/zrepl/zrepl.c
+++ b/cmd/zrepl/zrepl.c
@@ -176,9 +176,9 @@ uzfs_zvol_io_receiver(void *arg)
 	}
 
 	while (1) {
-		rc = uzfs_zvol_socket_read(fd, (char *)&hdr,
-		    sizeof (hdr));
-		if (rc != 0)
+		rc = uzfs_zvol_socket_read(fd, (char *)&hdr, sizeof (hdr));
+
+		if ((rc != 0) || (zinfo->state == ZVOL_INFO_STATE_OFFLINE))
 			goto exit;
 
 		if (hdr.opcode != ZVOL_OPCODE_WRITE &&
@@ -207,6 +207,10 @@ uzfs_zvol_io_receiver(void *arg)
 			}
 		}
 
+		if (zinfo->state == ZVOL_INFO_STATE_OFFLINE) {
+			zio_cmd_free(&zio_cmd);
+			goto exit;
+		}
 		/* Take refcount for uzfs_zvol_worker to work on it */
 		uzfs_zinfo_take_refcnt(zinfo, B_FALSE);
 		zio_cmd->zv = zinfo;

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -81,7 +81,7 @@ typedef struct zvol_info_s {
 	zvol_info_state_t	state;
 	char 		name[MAXPATHLEN];
 	zvol_state_t	*zv;
-	int 		refcnt;
+	uint16_t	refcnt;
 	int		is_io_ack_sender_created;
 	uint32_t	timeout;	/* iSCSI timeout val for this zvol */
 	uint64_t	zvol_guid;

--- a/lib/libzpool/uzfs_rebuilding.c
+++ b/lib/libzpool/uzfs_rebuilding.c
@@ -209,6 +209,8 @@ uzfs_get_io_diff(zvol_state_t *zv, blk_metadata_t *low,
 					EXECUTE_DIFF_CALLBACK(last_lun_offset,
 					    diff_count, buf, last_index, arg,
 					    last_md, snap_zv, func, ret);
+					if (ret != 0)
+						break;
 					last_lun_offset = lun_offset;
 					last_md = (blk_metadata_t *)(buf+i);
 					last_index = i;
@@ -224,6 +226,8 @@ uzfs_get_io_diff(zvol_state_t *zv, blk_metadata_t *low,
 				EXECUTE_DIFF_CALLBACK(last_lun_offset,
 				    diff_count, buf, last_index, arg, last_md,
 				    snap_zv, func, ret);
+				if (ret != 0)
+					break;
 			}
 
 			lun_offset += zv->zv_metavolblocksize;
@@ -231,6 +235,8 @@ uzfs_get_io_diff(zvol_state_t *zv, blk_metadata_t *low,
 		if (!ret && diff_count) {
 			EXECUTE_DIFF_CALLBACK(last_lun_offset, diff_count, buf,
 			    last_index, arg, last_md, snap_zv, func, ret);
+			if (ret != 0)
+				break;
 		}
 	}
 

--- a/lib/libzpool/zrepl_mgmt.c
+++ b/lib/libzpool/zrepl_mgmt.c
@@ -245,7 +245,7 @@ uzfs_zinfo_destroy(const char *name, spa_t *spa)
 			    zinfo->name, strlen(spa_name(spa))) == 0) {
 				SLIST_REMOVE(&zvol_list, zinfo, zvol_info_s,
 				    zinfo_next);
-			
+
 				mutex_exit(&zvol_list_mutex);
 				zv = zinfo->zv;
 				uzfs_mark_offline_and_free_zinfo(zinfo);
@@ -261,7 +261,7 @@ uzfs_zinfo_destroy(const char *name, spa_t *spa)
 			    zinfo->name[namelen + 1] == '\0')) {
 				SLIST_REMOVE(&zvol_list, zinfo, zvol_info_s,
 				    zinfo_next);
-			
+
 				mutex_exit(&zvol_list_mutex);
 				zv = zinfo->zv;
 				uzfs_mark_offline_and_free_zinfo(zinfo);

--- a/lib/libzpool/zrepl_mgmt.c
+++ b/lib/libzpool/zrepl_mgmt.c
@@ -126,18 +126,7 @@ create_and_bind(const char *port, int bind_needed, boolean_t nonblock)
 void
 uzfs_zinfo_drop_refcnt(zvol_info_t *zinfo, int locked)
 {
-	if (!locked) {
-		(void) mutex_enter(&zvol_list_mutex);
-	}
-
-	zinfo->refcnt--;
-	if (zinfo->refcnt == 0) {
-		(void) uzfs_zinfo_free(zinfo);
-	}
-
-	if (!locked) {
-		(void) mutex_exit(&zvol_list_mutex);
-	}
+	atomic_dec_16(&zinfo->refcnt);
 }
 
 /*
@@ -146,13 +135,7 @@ uzfs_zinfo_drop_refcnt(zvol_info_t *zinfo, int locked)
 void
 uzfs_zinfo_take_refcnt(zvol_info_t *zinfo, int locked)
 {
-	if (!locked) {
-		(void) mutex_enter(&zvol_list_mutex);
-	}
-	zinfo->refcnt++;
-	if (!locked) {
-		(void) mutex_exit(&zvol_list_mutex);
-	}
+	atomic_inc_16(&zinfo->refcnt);
 }
 
 static void
@@ -167,10 +150,8 @@ uzfs_insert_zinfo_list(zvol_info_t *zinfo)
 }
 
 static void
-uzfs_remove_zinfo_list(zvol_info_t *zinfo)
+uzfs_mark_offline_and_free_zinfo(zvol_info_t *zinfo)
 {
-	LOG_INFO("Removing zvol %s", zinfo->name);
-	SLIST_REMOVE(&zvol_list, zinfo, zvol_info_s, zinfo_next);
 	(void) pthread_mutex_lock(&zinfo->zinfo_mutex);
 	zinfo->state = ZVOL_INFO_STATE_OFFLINE;
 	/* Send signal to ack_sender thread about offline */
@@ -180,6 +161,14 @@ uzfs_remove_zinfo_list(zvol_info_t *zinfo)
 	(void) pthread_mutex_unlock(&zinfo->zinfo_mutex);
 	/* Base refcount is droped here */
 	uzfs_zinfo_drop_refcnt(zinfo, B_TRUE);
+
+	/* Wait for refcounts to be drained */
+	while (zinfo->refcnt > 0) {
+		sleep(1);
+	}
+
+	LOG_INFO("Freeing zvol %s", zinfo->name);
+	(void) uzfs_zinfo_free(zinfo);
 }
 
 zvol_info_t *
@@ -254,9 +243,14 @@ uzfs_zinfo_destroy(const char *name, spa_t *spa)
 		SLIST_FOREACH_SAFE(zinfo, &zvol_list, zinfo_next, zt) {
 			if (strncmp(spa_name(spa),
 			    zinfo->name, strlen(spa_name(spa))) == 0) {
+				SLIST_REMOVE(&zvol_list, zinfo, zvol_info_s,
+				    zinfo_next);
+			
+				mutex_exit(&zvol_list_mutex);
 				zv = zinfo->zv;
-				uzfs_remove_zinfo_list(zinfo);
+				uzfs_mark_offline_and_free_zinfo(zinfo);
 				uzfs_close_dataset(zv);
+				mutex_enter(&zvol_list_mutex);
 			}
 		}
 	} else {
@@ -265,9 +259,14 @@ uzfs_zinfo_destroy(const char *name, spa_t *spa)
 			    ((strncmp(zinfo->name, name, namelen) == 0) &&
 			    zinfo->name[namelen] == '/' &&
 			    zinfo->name[namelen + 1] == '\0')) {
+				SLIST_REMOVE(&zvol_list, zinfo, zvol_info_s,
+				    zinfo_next);
+			
+				mutex_exit(&zvol_list_mutex);
 				zv = zinfo->zv;
-				uzfs_remove_zinfo_list(zinfo);
+				uzfs_mark_offline_and_free_zinfo(zinfo);
 				uzfs_close_dataset(zv);
+				mutex_enter(&zvol_list_mutex);
 				break;
 			}
 		}


### PR DESCRIPTION
Signed-off-by: satbir <satbir.chhikara@gmail.com>

Hi,

I have made changes to implement lockless increment and decrement of refcount on zinfo object. I have done frist round of testing. Before I do more robust Unit testing ( with automation), want take your opinion if you see any issue with current implementation. Little details about zinfo refcounting ...
1. There are primarily 5 thread which get zinfo from zvol_list by taking global lock "zvol_list_mutex". This lookup happens via handshake message and take refcount under this lock. These threads are
a) mgmt thread b) io receiver thread c) io_ack sender thread d) rebuild scanner thread e) dw_rebuild thead.
2. Once zinfo nuked out of zvol_list, no new thread can take refcount on it.
3. When we destroy/export volumes, it will nuke out zinfo from zvol_list and then wait for refcount to hit to zero. Once it is zero, it will free the zinfo.

So far I am convinced with this approach but since it is race, you never know. I request each of you to please provide your valuable input. 

Th

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
