### PR TITLE
[TA1652] [DE17][DE37] Fixing these issues & avoid operations on stale io-fd

### DIFF
--- a/cmd/zrepl/zrepl.c
+++ b/cmd/zrepl/zrepl.c
@@ -184,6 +184,8 @@ uzfs_zvol_io_receiver(void *arg)
 
 	while ((rc = uzfs_zvol_socket_read(fd, (char *)&hdr, sizeof (hdr))) ==
 	    0) {
+		if ((zinfo->state == ZVOL_INFO_STATE_OFFLINE))
+			break;
 
 		if (hdr.opcode != ZVOL_OPCODE_WRITE &&
 		    hdr.opcode != ZVOL_OPCODE_READ &&
@@ -211,6 +213,10 @@ uzfs_zvol_io_receiver(void *arg)
 			}
 		}
 
+		if (zinfo->state == ZVOL_INFO_STATE_OFFLINE) {
+			zio_cmd_free(&zio_cmd);
+			goto exit;
+		}
 		/* Take refcount for uzfs_zvol_worker to work on it */
 		uzfs_zinfo_take_refcnt(zinfo, B_FALSE);
 		zio_cmd->zv = zinfo;

--- a/cmd/zrepl/zrepl.c
+++ b/cmd/zrepl/zrepl.c
@@ -419,19 +419,12 @@ uzfs_zvol_io_ack_sender(void *arg)
 		zio_cmd_free(&zio_cmd);
 	}
 exit:
-<<<<<<< HEAD
 	zinfo->zio_cmd_in_ack = NULL;
 	shutdown(fd, SHUT_RDWR);
 	close(fd);
 	LOG_INFO("Data connection for zvol %s closed", zinfo->name);
-=======
-	LOG_DEBUG("uzfs_zvol_io_ack_sender thread for zvol %s exiting",
-	    zinfo->name);
 
 	(void) pthread_mutex_lock(&zinfo->zinfo_mutex);
-	zinfo->zio_cmd_in_ack = NULL;
-	shutdown(fd, SHUT_RDWR);
->>>>>>> 1b968cf... [TA1652][DE17] Atomic inc and decrement of zinfo refcount done.
 	while (!STAILQ_EMPTY(&zinfo->complete_queue)) {
 		zio_cmd = STAILQ_FIRST(&zinfo->complete_queue);
 		STAILQ_REMOVE_HEAD(&zinfo->complete_queue, cmd_link);

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -81,7 +81,7 @@ typedef struct zvol_info_s {
 	zvol_info_state_t	state;
 	char 		name[MAXPATHLEN];
 	zvol_state_t	*zv;
-	uint16_t	refcnt;
+	uint64_t	refcnt;
 	int		is_io_ack_sender_created;
 	uint32_t	timeout;	/* iSCSI timeout val for this zvol */
 	uint64_t	zvol_guid;
@@ -153,8 +153,6 @@ typedef struct zvol_rebuild_s {
 extern int uzfs_zinfo_init(void *zv, const char *ds_name,
     nvlist_t *create_props);
 extern zvol_info_t *uzfs_zinfo_lookup(const char *name);
-extern void uzfs_zinfo_drop_refcnt(zvol_info_t *zinfo, int locked);
-extern void uzfs_zinfo_take_refcnt(zvol_info_t *zinfo, int locked);
 extern void uzfs_zinfo_replay_zil_all(void);
 extern int uzfs_zinfo_destroy(const char *ds_name, spa_t *spa);
 uint64_t uzfs_zvol_get_last_committed_io_no(zvol_state_t *zv);
@@ -162,6 +160,25 @@ void uzfs_zvol_store_last_committed_io_no(zvol_state_t *zv,
     uint64_t io_seq);
 extern int create_and_bind(const char *port, int bind_needed,
     boolean_t nonblocking);
+
+/*
+ * API to drop refcnt on zinfo. If refcnt
+ * dropped to zero then free zinfo.
+ */
+inline void
+uzfs_zinfo_drop_refcnt(zvol_info_t *zinfo)
+{
+	atomic_dec_64(&zinfo->refcnt);
+}
+
+/*
+ * API to take refcount on zinfo.
+ */
+inline void
+uzfs_zinfo_take_refcnt(zvol_info_t *zinfo)
+{
+	atomic_inc_64(&zinfo->refcnt);
+}
 
 #ifdef	__cplusplus
 }

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -81,7 +81,7 @@ typedef struct zvol_info_s {
 	zvol_info_state_t	state;
 	char 		name[MAXPATHLEN];
 	zvol_state_t	*zv;
-	int 		refcnt;
+	uint16_t	refcnt;
 	int		is_io_ack_sender_created;
 	uint32_t	timeout;	/* iSCSI timeout val for this zvol */
 	uint64_t	zvol_guid;

--- a/lib/libzpool/uzfs_rebuilding.c
+++ b/lib/libzpool/uzfs_rebuilding.c
@@ -209,6 +209,8 @@ uzfs_get_io_diff(zvol_state_t *zv, blk_metadata_t *low,
 					EXECUTE_DIFF_CALLBACK(last_lun_offset,
 					    diff_count, buf, last_index, arg,
 					    last_md, snap_zv, func, ret);
+					if (ret != 0)
+						break;
 					last_lun_offset = lun_offset;
 					last_md = (blk_metadata_t *)(buf+i);
 					last_index = i;
@@ -224,6 +226,8 @@ uzfs_get_io_diff(zvol_state_t *zv, blk_metadata_t *low,
 				EXECUTE_DIFF_CALLBACK(last_lun_offset,
 				    diff_count, buf, last_index, arg, last_md,
 				    snap_zv, func, ret);
+				if (ret != 0)
+					break;
 			}
 
 			lun_offset += zv->zv_metavolblocksize;
@@ -231,6 +235,8 @@ uzfs_get_io_diff(zvol_state_t *zv, blk_metadata_t *low,
 		if (!ret && diff_count) {
 			EXECUTE_DIFF_CALLBACK(last_lun_offset, diff_count, buf,
 			    last_index, arg, last_md, snap_zv, func, ret);
+			if (ret != 0)
+				break;
 		}
 	}
 

--- a/lib/libzpool/zrepl_mgmt.c
+++ b/lib/libzpool/zrepl_mgmt.c
@@ -145,7 +145,7 @@ uzfs_mark_offline_and_free_zinfo(zvol_info_t *zinfo)
 
 	/* Wait for refcounts to be drained */
 	while (zinfo->refcnt > 0) {
-		LOG_INFO("Waiting for refcount to go down to"
+		LOG_DEBUG("Waiting for refcount to go down to"
 		    " zero on zvol:%s", zinfo->name);
 		sleep(5);
 	}

--- a/lib/libzpool/zrepl_mgmt.c
+++ b/lib/libzpool/zrepl_mgmt.c
@@ -245,7 +245,7 @@ uzfs_zinfo_destroy(const char *name, spa_t *spa)
 			    zinfo->name, strlen(spa_name(spa))) == 0) {
 				SLIST_REMOVE(&zvol_list, zinfo, zvol_info_s,
 				    zinfo_next);
-			
+
 				mutex_exit(&zvol_list_mutex);
 				zv = zinfo->zv;
 				uzfs_mark_offline_and_free_zinfo(zinfo);
@@ -261,7 +261,7 @@ uzfs_zinfo_destroy(const char *name, spa_t *spa)
 			    zinfo->name[namelen + 1] == '\0')) {
 				SLIST_REMOVE(&zvol_list, zinfo, zvol_info_s,
 				    zinfo_next);
-			
+
 				mutex_exit(&zvol_list_mutex);
 				zv = zinfo->zv;
 				uzfs_mark_offline_and_free_zinfo(zinfo);

--- a/lib/libzpool/zrepl_mgmt.c
+++ b/lib/libzpool/zrepl_mgmt.c
@@ -126,18 +126,7 @@ create_and_bind(const char *port, int bind_needed, boolean_t nonblock)
 void
 uzfs_zinfo_drop_refcnt(zvol_info_t *zinfo, int locked)
 {
-	if (!locked) {
-		(void) mutex_enter(&zvol_list_mutex);
-	}
-
-	zinfo->refcnt--;
-	if (zinfo->refcnt == 0) {
-		(void) uzfs_zinfo_free(zinfo);
-	}
-
-	if (!locked) {
-		(void) mutex_exit(&zvol_list_mutex);
-	}
+	atomic_dec_16(&zinfo->refcnt);
 }
 
 /*
@@ -146,13 +135,7 @@ uzfs_zinfo_drop_refcnt(zvol_info_t *zinfo, int locked)
 void
 uzfs_zinfo_take_refcnt(zvol_info_t *zinfo, int locked)
 {
-	if (!locked) {
-		(void) mutex_enter(&zvol_list_mutex);
-	}
-	zinfo->refcnt++;
-	if (!locked) {
-		(void) mutex_exit(&zvol_list_mutex);
-	}
+	atomic_inc_16(&zinfo->refcnt);
 }
 
 static void
@@ -167,10 +150,8 @@ uzfs_insert_zinfo_list(zvol_info_t *zinfo)
 }
 
 static void
-uzfs_remove_zinfo_list(zvol_info_t *zinfo)
+uzfs_mark_offline_and_free_zinfo(zvol_info_t *zinfo)
 {
-	LOG_INFO("Removing zvol %s", zinfo->name);
-	SLIST_REMOVE(&zvol_list, zinfo, zvol_info_s, zinfo_next);
 	(void) pthread_mutex_lock(&zinfo->zinfo_mutex);
 	zinfo->state = ZVOL_INFO_STATE_OFFLINE;
 	/* Send signal to ack_sender thread about offline */
@@ -180,6 +161,14 @@ uzfs_remove_zinfo_list(zvol_info_t *zinfo)
 	(void) pthread_mutex_unlock(&zinfo->zinfo_mutex);
 	/* Base refcount is droped here */
 	uzfs_zinfo_drop_refcnt(zinfo, B_TRUE);
+
+	/* Wait for refcounts to be drained */
+	while (zinfo->refcnt > 0) {
+		sleep(1);
+	}
+
+	LOG_INFO("Freeing zvol %s", zinfo->name);
+	(void) uzfs_zinfo_free(zinfo);
 }
 
 zvol_info_t *
@@ -254,9 +243,14 @@ uzfs_zinfo_destroy(const char *name, spa_t *spa)
 		SLIST_FOREACH_SAFE(zinfo, &zvol_list, zinfo_next, zt) {
 			if (strncmp(spa_name(spa),
 			    zinfo->name, strlen(spa_name(spa))) == 0) {
+				SLIST_REMOVE(&zvol_list, zinfo, zvol_info_s,
+				    zinfo_next);
+			
+				mutex_exit(&zvol_list_mutex);
 				zv = zinfo->zv;
-				uzfs_remove_zinfo_list(zinfo);
+				uzfs_mark_offline_and_free_zinfo(zinfo);
 				uzfs_close_dataset(zv);
+				mutex_enter(&zvol_list_mutex);
 			}
 		}
 	} else {
@@ -265,9 +259,14 @@ uzfs_zinfo_destroy(const char *name, spa_t *spa)
 			    ((strncmp(zinfo->name, name, namelen) == 0) &&
 			    zinfo->name[namelen] == '/' &&
 			    zinfo->name[namelen + 1] == '\0')) {
+				SLIST_REMOVE(&zvol_list, zinfo, zvol_info_s,
+				    zinfo_next);
+			
+				mutex_exit(&zvol_list_mutex);
 				zv = zinfo->zv;
-				uzfs_remove_zinfo_list(zinfo);
+				uzfs_mark_offline_and_free_zinfo(zinfo);
 				uzfs_close_dataset(zv);
+				mutex_enter(&zvol_list_mutex);
 				break;
 			}
 		}

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -828,6 +828,9 @@ uzfs_zvol_rebuild_scanner_callback(off_t offset, size_t len,
 	hdr.len = len;
 	hdr.flags = ZVOL_OP_FLAG_REBUILD;
 	hdr.status = ZVOL_OP_STATUS_OK;
+	if (zinfo->state == ZVOL_INFO_STATE_OFFLINE)
+		return (-1);
+
 	LOG_DEBUG("IO number for rebuild %ld", metadata->io_num);
 	zio_cmd = zio_cmd_alloc(&hdr, warg->fd);
 	/* Take refcount for uzfs_zvol_worker to work on it */
@@ -869,10 +872,9 @@ uzfs_zvol_rebuild_scanner(void *arg)
 	}
 read_socket:
 	rc = uzfs_zvol_read_header(fd, &hdr);
-	if (rc != 0) {
-		LOG_DEBUG("Error:%d in reading header\n", errno);
+	if ((rc != 0) || ((zinfo != NULL) &&
+	    (zinfo->state == ZVOL_INFO_STATE_OFFLINE)))
 		goto exit;
-	}
 
 	LOG_DEBUG("op_code=%d io_seq=%ld", hdr.opcode, hdr.io_seq);
 

--- a/lib/libzrepl/mgmt_conn.c
+++ b/lib/libzrepl/mgmt_conn.c
@@ -559,7 +559,7 @@ static void
 free_async_task(async_task_t *async_task)
 {
 	ASSERT(MUTEX_HELD(&async_tasks_mtx));
-	uzfs_zinfo_drop_refcnt(async_task->zinfo, B_FALSE);
+	uzfs_zinfo_drop_refcnt(async_task->zinfo);
 	kmem_free(async_task->payload, async_task->payload_length);
 	kmem_free(async_task, sizeof (*async_task));
 }
@@ -755,7 +755,7 @@ ret_error:
 			goto ret_error;
 		}
 
-		uzfs_zinfo_take_refcnt(zinfo, B_FALSE);
+		uzfs_zinfo_take_refcnt(zinfo);
 
 		thrd_arg = kmem_alloc(sizeof (rebuild_thread_arg_t), KM_SLEEP);
 		thrd_arg->zinfo = zinfo;
@@ -801,7 +801,7 @@ handle_start_rebuild_req(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 	    (zinfo->zv == NULL)) {
 		if (zinfo != NULL) {
 			LOG_ERR("rebuilding failed for %s..", zinfo->name);
-			uzfs_zinfo_drop_refcnt(zinfo, B_FALSE);
+			uzfs_zinfo_drop_refcnt(zinfo);
 		}
 		else
 			LOG_ERR("rebuilding failed..");
@@ -815,7 +815,7 @@ handle_start_rebuild_req(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 	if (uzfs_zvol_get_rebuild_status(zinfo->zv) !=
 	    ZVOL_REBUILDING_INIT) {
 		mutex_exit(&zinfo->zv->rebuild_mtx);
-		uzfs_zinfo_drop_refcnt(zinfo, B_FALSE);
+		uzfs_zinfo_drop_refcnt(zinfo);
 		LOG_ERR("rebuilding failed for %s due to improper rebuild "
 		    "status", zinfo->name);
 		rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED,
@@ -842,7 +842,7 @@ handle_start_rebuild_req(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 		uzfs_update_ionum_interval(zinfo, 0);
 		LOG_INFO("Rebuild of zvol %s completed",
 		    zinfo->name);
-		uzfs_zinfo_drop_refcnt(zinfo, B_FALSE);
+		uzfs_zinfo_drop_refcnt(zinfo);
 		rc = reply_nodata(conn, ZVOL_OP_STATUS_OK,
 		    hdrp->opcode, hdrp->io_seq);
 		goto end;
@@ -857,7 +857,7 @@ handle_start_rebuild_req(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 	    zinfo, rebuild_op_cnt);
 
 	/* dropping refcount for uzfs_zinfo_lookup */
-	uzfs_zinfo_drop_refcnt(zinfo, B_FALSE);
+	uzfs_zinfo_drop_refcnt(zinfo);
 end:
 	return (rc);
 }
@@ -907,7 +907,7 @@ process_message(uzfs_mgmt_conn_t *conn)
 		 * from that case would not be trivial so we pretend a miss.
 		 */
 		if (zinfo->mgmt_conn != conn) {
-			uzfs_zinfo_drop_refcnt(zinfo, B_FALSE);
+			uzfs_zinfo_drop_refcnt(zinfo);
 			LOGERRCONN(conn, "Target used invalid connection for "
 			    "zvol %s", zvol_name);
 			rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED,
@@ -936,7 +936,7 @@ process_message(uzfs_mgmt_conn_t *conn)
 		} else {
 			ASSERT(0);
 		}
-		uzfs_zinfo_drop_refcnt(zinfo, B_FALSE);
+		uzfs_zinfo_drop_refcnt(zinfo);
 		break;
 
 	case ZVOL_OPCODE_SNAP_CREATE:
@@ -965,7 +965,7 @@ process_message(uzfs_mgmt_conn_t *conn)
 			break;
 		}
 		if (zinfo->mgmt_conn != conn) {
-			uzfs_zinfo_drop_refcnt(zinfo, B_FALSE);
+			uzfs_zinfo_drop_refcnt(zinfo);
 			LOGERRCONN(conn, "Target used invalid connection for "
 			    "zvol %s", zvol_name);
 			rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED,
@@ -999,7 +999,7 @@ process_message(uzfs_mgmt_conn_t *conn)
 			break;
 		}
 		if (zinfo->mgmt_conn != conn) {
-			uzfs_zinfo_drop_refcnt(zinfo, B_FALSE);
+			uzfs_zinfo_drop_refcnt(zinfo);
 			LOGERRCONN(conn, "Target used invalid connection for "
 			    "zvol %s", zvol_name);
 			rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED,

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -515,7 +515,7 @@ out:
 	}
 
 #if !defined(_KERNEL)
-	uzfs_zinfo_drop_refcnt(zinfo, B_FALSE);
+	uzfs_zinfo_drop_refcnt(zinfo);
 #else
 	if (zv != NULL)
 		mutex_exit(&zv->zv_state_lock);

--- a/tests/cbtest/gtest/test_uzfs.cc
+++ b/tests/cbtest/gtest/test_uzfs.cc
@@ -309,7 +309,7 @@ test_alloc_async_task_and_add_to_list(zvol_info_t *zinfo,
 {
 	async_task_t *arg;
 
-	uzfs_zinfo_take_refcnt(zinfo, B_TRUE);
+	uzfs_zinfo_take_refcnt(zinfo);
 	arg = (async_task_t *)kmem_zalloc(sizeof (async_task_t), KM_SLEEP);
 	arg->conn = conn;
 	arg->zinfo = zinfo;
@@ -411,7 +411,7 @@ TEST(uZFS, TestZInfoRefcnt) {
 
 	EXPECT_EQ(2, zinfo->refcnt);
 
-	uzfs_zinfo_drop_refcnt(zinfo, B_FALSE);
+	uzfs_zinfo_drop_refcnt(zinfo);
 	EXPECT_EQ(1, zinfo->refcnt);
 
 	GtestUtils::strlcpy(ds1, "vol1 ", MAXNAMELEN);
@@ -451,7 +451,7 @@ TEST(uZFS, TestZInfoRefcnt) {
 	EXPECT_EQ(NULL, !zinfo1);
 	EXPECT_EQ(3, zinfo->refcnt);
 
-	uzfs_zinfo_drop_refcnt(zinfo, B_FALSE);
+	uzfs_zinfo_drop_refcnt(zinfo);
 	EXPECT_EQ(2, zinfo->refcnt);
 }
 
@@ -934,7 +934,7 @@ next_step:
 		 * Take refcount for uzfs_zvol_worker to work on it.
 		 * Will dropped by uzfs_zvol_worker once cmd is executed.
 		 */
-		uzfs_zinfo_take_refcnt(zinfo, B_FALSE);
+		uzfs_zinfo_take_refcnt(zinfo);
 		zio_cmd->zv = zinfo;
 		uzfs_zvol_worker(zio_cmd);
 		if (zio_cmd->hdr.status != ZVOL_OP_STATUS_OK) {
@@ -978,7 +978,7 @@ exit:
 		close(sfd);
 	}
 	/* Parent thread have taken refcount, drop it now */
-	uzfs_zinfo_drop_refcnt(zinfo, B_FALSE);
+	uzfs_zinfo_drop_refcnt(zinfo);
 
 	rebuild_test_case = 0;
 	zk_thread_exit();
@@ -996,7 +996,7 @@ void execute_rebuild_test_case(const char *s, int test_case,
 	zinfo->zv->zv_status = ZVOL_STATUS_DEGRADED;
 	memset(&zinfo->zv->rebuild_info, 0, sizeof (zvol_rebuild_info_t));
 	zinfo->zv->rebuild_info.rebuild_cnt = 1;
-	uzfs_zinfo_take_refcnt(zinfo, B_FALSE);
+	uzfs_zinfo_take_refcnt(zinfo);
 	uzfs_zvol_set_rebuild_status(zinfo->zv, status);
 
 	if (!is_rebuild_scanner)


### PR DESCRIPTION
This change include couple of things:-
1. Wait refcounts to be drained on zinfo before freeing it. By doing so we make sure that all IOs committed to disk and it is safe to release and free data-set object and zv object.
2. io-fd is shared by two threads i.e. io_ack_sender and io_receiver, if there is an error, both threads would exit asynchronous to each other. io_ack_sender thread close fd and free zio_cmds...so there is window when new connection may pick same fd for communication for another replica in that case there is chance of performing read/write on this stale fd by io_recceiver. With this fix we are making sure that io--fd wont be closed untill both threads exit.
3. Fix of leaking fd in uzfs_zvol_io_receiver if open_zvol return error in the beginning.
4. Refcount on Zinfo is taken for each IO by taking mutex which is little costly at there would be 4 system call per IO(one pair of lock & unlock in uzfs_zvol_io_receiver for incrementing refcount and other in uzfs_zvol_worker for droping refcount) which is little costly.  Now we are using atomic_inc/dec for incrementing & decrementing refcount.

Unit Testing: I have done manual unit testing to simulate the case to free zinfo(wait till refcounts drained out).  I have put a sleep in uzfs_zvol_worker to make sure that we have lots of IOs pending in task_Q. Once we have lots of IOs pending, I have issued "sudo ./cmd/zfs/zfs destroy uzfs_pool/ds0" command on another window to destory volume. I have seen that we are waiting for refcounts to be drained out. Unit test logs looks like ....
<Unit test logs>
2018-07-09/13:51:49.731 [tgt 127.0.0.1:6060]: Replica status command for zvol ds0
2018-07-09/13:51:51.178 Waiting for refcount to go down to zero on zvol:uzfs_pool/ds0
2018-07-09/13:51:51.179 ERROR Socket conn closed 15: Success
2018-07-09/13:51:56.179 Freeing zvol uzfs_pool/ds0
2018-07-09/13:51:56.179 [tgt 127.0.0.1:6060]: Closing the connection
</Unit test logs>
Apart from this regular unit test suit has been used to verify that system is working as per expectations.