### PR TITLE
[TA31] Test for storing IO_Seq number in ZAP attribute periodically

### DIFF
--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -532,15 +532,8 @@ uzfs_zvol_timer_thread(void)
 
 	mutex_enter(&timer_mtx);
 	while (1) {
-#ifdef	DEBUG
-		/*
-		 * For testing purpose, we are setting min_interval
-		 * to 10 seconds
-		 */
-		min_interval = 10;
-#else
 		min_interval = 600;  // we check intervals at least every 10mins
-#endif
+
 		mutex_enter(&zvol_list_mutex);
 		now = time(NULL);
 		SLIST_FOREACH(zinfo, &zvol_list, zinfo_next) {

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -532,7 +532,15 @@ uzfs_zvol_timer_thread(void)
 
 	mutex_enter(&timer_mtx);
 	while (1) {
+#ifdef	DEBUG
+		/*
+		 * For testing purpose, we are setting min_interval
+		 * to 10 seconds
+		 */
+		min_interval = 10;
+#else
 		min_interval = 600;  // we check intervals at least every 10mins
+#endif
 		mutex_enter(&zvol_list_mutex);
 		now = time(NULL);
 		SLIST_FOREACH(zinfo, &zvol_list, zinfo_next) {

--- a/tests/cbtest/gtest/test_zrepl_prot.cc
+++ b/tests/cbtest/gtest/test_zrepl_prot.cc
@@ -1226,7 +1226,15 @@ TEST(Misc, ZreplCheckpointInterval) {
 
 	write_data_and_verify_resp(datasock_slow.fd(), ioseq, 0, 888);
 	write_data_and_verify_resp(datasock_fast.fd(), ioseq, 0, 888);
-	sleep(2);
+	sleep(30);
+
+	zrepl.kill();
+
+	zrepl.start();
+	pool.import();
+
+	control_fd = target.accept(10);
+	ASSERT_GE(control_fd, 0);
 
 	do_handshake(zvol_name_slow, host_slow, port_slow, &ionum_slow,
 	    control_fd, ZVOL_OP_STATUS_OK);

--- a/tests/cbtest/gtest/test_zrepl_prot.cc
+++ b/tests/cbtest/gtest/test_zrepl_prot.cc
@@ -1222,24 +1222,25 @@ TEST(Misc, ZreplCheckpointInterval) {
 	do_data_connection(datasock_slow.fd(), host_slow, port_slow, zvol_name_slow,
 	    4096, 1000);
 	do_data_connection(datasock_fast.fd(), host_fast, port_fast, zvol_name_fast,
-	    4096, 1);
+	    4096, 2);
 
 	write_data_and_verify_resp(datasock_slow.fd(), ioseq, 0, 888);
 	write_data_and_verify_resp(datasock_fast.fd(), ioseq, 0, 888);
-	sleep(30);
+	sleep(10);	/* Due to spa sync interval, sleep for 10 sec is required here */
 
 	zrepl.kill();
 
 	zrepl.start();
 	pool.import();
 
-	control_fd = target.accept(10);
+	control_fd = target.accept(-1);
 	ASSERT_GE(control_fd, 0);
 
 	do_handshake(zvol_name_slow, host_slow, port_slow, &ionum_slow,
 	    control_fd, ZVOL_OP_STATUS_OK);
 	do_handshake(zvol_name_fast, host_fast, port_fast, &ionum_fast,
 	    control_fd, ZVOL_OP_STATUS_OK);
+
 	ASSERT_NE(ionum_slow, 888);
 	ASSERT_EQ(ionum_fast, 888);
 


### PR DESCRIPTION
**Changes :** 
Changed `ZreplCheckpointInterval` test in `test_zrepl_prot.cc` to test storing of `IO_Seq` in ZAP attribute and validating after `zrepl` restart.

Signed-off-by: mayank <mayank.patel@cloudbyte.com>