### PR TITLE
TA1727 add slow txg sync message

### DIFF
--- a/include/sys/fm/fs/zfs.h
+++ b/include/sys/fm/fs/zfs.h
@@ -49,6 +49,8 @@ extern "C" {
 #define	FM_EREPORT_ZFS_PROBE_FAILURE		"probe_failure"
 #define	FM_EREPORT_ZFS_LOG_REPLAY		"log_replay"
 #define	FM_EREPORT_ZFS_CONFIG_CACHE_WRITE	"config_cache_write"
+#define	FM_EREPORT_ZFS_SYNC_SLOW		"sync_slow"
+#define	FM_EREPORT_ZFS_QUIESCE_SLOW		"quiesce_slow"
 
 #define	FM_EREPORT_PAYLOAD_ZFS_POOL		"pool"
 #define	FM_EREPORT_PAYLOAD_ZFS_POOL_FAILMODE	"pool_failmode"

--- a/include/sys/txg.h
+++ b/include/sys/txg.h
@@ -66,6 +66,10 @@ typedef struct txg_list {
 
 struct dsl_pool;
 
+/* Based on these thresholds are generated ereports */
+extern volatile int sync_threshold;
+extern volatile int quiesce_threshold;
+
 extern void txg_init(struct dsl_pool *dp, uint64_t txg);
 extern void txg_fini(struct dsl_pool *dp);
 extern void txg_sync_start(struct dsl_pool *dp);

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -165,7 +165,7 @@ extern int create_and_bind(const char *port, int bind_needed,
  * API to drop refcnt on zinfo. If refcnt
  * dropped to zero then free zinfo.
  */
-inline void
+static inline void
 uzfs_zinfo_drop_refcnt(zvol_info_t *zinfo)
 {
 	atomic_dec_64(&zinfo->refcnt);
@@ -174,7 +174,7 @@ uzfs_zinfo_drop_refcnt(zvol_info_t *zinfo)
 /*
  * API to take refcount on zinfo.
  */
-inline void
+static inline void
 uzfs_zinfo_take_refcnt(zvol_info_t *zinfo)
 {
 	atomic_inc_64(&zinfo->refcnt);


### PR DESCRIPTION
Add log messages for slow spa sync and quiesce times. Slow means > 15 seconds. The threshold is defined as volatile global int so it can be changed on the fly from debugger should there be a need for it.

Implementation detail: The log message is implement through the means of zfs ereport as I don't want to pull zrepl log function which is for higher level code in zrepl to standard zfs code. Log flooding is not a problem because based on the value of threshold we will not see the message more often than each 15 seconds in the log file, which is acceptable.

Minor fix for Satbir's commit for zinfo reference counting. The incr and decr inline functions must be declared as static because they are defined in header file. zfs build would otherwise fail if cc optimizations (including inlining) were disabled.