### PR TITLE
rw_lock modification to favor writes over read ops.

### DIFF
--- a/cmd/uzfs_test/uzfs_test.c
+++ b/cmd/uzfs_test/uzfs_test.c
@@ -58,6 +58,7 @@ uzfs_test_info_t uzfs_tests[] = {
 	    " metadata for given data block" },
 	{ unit_test_fn, "zvol random read/write verification with metadata" },
 	{ zrepl_rebuild_test, "ZFS rebuild test" },
+	{ read_write_lock_performance_testz, "RW_LOCK performance test" },
 };
 
 uint64_t metaverify = 0;

--- a/cmd/uzfs_test/zrepl_utest.c
+++ b/cmd/uzfs_test/zrepl_utest.c
@@ -1266,11 +1266,12 @@ rwlock_writer_thread(void *arg)
 	mtx = warg->mtx;
 	cv = warg->cv;
 	threads_done = warg->threads_done;
-	
+
 	printf("Writing .....\n");
 	while (i < warg->max_iops) {
 		rw_enter(warg->rw_lock, RW_WRITER);
-		for (j = 0; j <= 10; j++);
+		for (j = 0; j <= 10; j++) {
+		}
 		rw_exit(warg->rw_lock);
 		i++;
 	}
@@ -1297,7 +1298,8 @@ rwlock_reader_thread(void *arg)
 	printf("Reading .....\n");
 	while (i < warg->max_iops) {
 		rw_enter(warg->rw_lock, RW_READER);
-		for (j = 0; j <= 10; j++);
+		for (j = 0; j <= 10; j++) {
+		}
 		rw_exit(warg->rw_lock);
 		i++;
 	}
@@ -1331,7 +1333,7 @@ read_write_lock_performance_testz(void *xarg)
 	args.cv = &cv;
 	args.max_iops = 1000000;
 	args.rw_lock = &rw_lock;
-	while (i < 4) {
+	while (i < 1) {
 		writer = zk_thread_create(NULL, 0,
 		    (thread_func_t)rwlock_writer_thread, &args, 0, NULL,
 		    TS_RUN, 0, PTHREAD_CREATE_DETACHED);
@@ -1340,8 +1342,9 @@ read_write_lock_performance_testz(void *xarg)
 	}
 
 	i = 0;
-	while(i < 6) {
-		reader = zk_thread_create(NULL, 0, (thread_func_t)rwlock_reader_thread,
+	while (i < 3) {
+		reader = zk_thread_create(NULL, 0,
+		    (thread_func_t)rwlock_reader_thread,
 		    &args, 0, NULL, TS_RUN, 0, PTHREAD_CREATE_DETACHED);
 		num_threads++;
 		i++;

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -327,9 +327,15 @@ typedef int krw_t;
 #define	RW_DEFAULT	RW_READER
 #define	RW_NOLOCKDEP	RW_READER
 
+#if !defined(_KERNEL)
+#define	RW_READ_HELD(x)		((x)->read_cnt > 0)
+#define	RW_WRITE_HELD(x)	((x)->write_cnt > 0)
+#define	RW_LOCK_HELD(x)		(RW_READ_HELD(x) || RW_WRITE_HELD(x))
+#else
 #define	RW_READ_HELD(x)		((x)->rw_readers > 0)
 #define	RW_WRITE_HELD(x)	((x)->rw_wr_owner == curthread)
 #define	RW_LOCK_HELD(x)		(RW_READ_HELD(x) || RW_WRITE_HELD(x))
+#endif
 
 #undef RW_LOCK_HELD
 #define	RW_LOCK_HELD(x)		(RW_READ_HELD(x) || RW_WRITE_HELD(x))

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -308,7 +308,9 @@ typedef struct krwlock {
 	pthread_mutex_t		cv_lock;
 	pthread_cond_t		read_cv;
 	pthread_cond_t		write_cv;
-	uint_t			read_cnt;
+#endif
+	uint_t			rw_readers;
+#if !defined(_KERNEL)
 	uint_t			write_cnt;
 	uint_t			write_wait_cnt;
 	uint_t			read_wait_cnt;
@@ -316,7 +318,6 @@ typedef struct krwlock {
 	double			write_wait_time;
 #else
 	pthread_rwlock_t	rw_lock;
-	uint_t			rw_readers;
 #endif
 } krwlock_t;
 
@@ -327,15 +328,9 @@ typedef int krw_t;
 #define	RW_DEFAULT	RW_READER
 #define	RW_NOLOCKDEP	RW_READER
 
-#if !defined(_KERNEL)
-#define	RW_READ_HELD(x)		((x)->read_cnt > 0)
-#define	RW_WRITE_HELD(x)	((x)->write_cnt > 0)
-#define	RW_LOCK_HELD(x)		(RW_READ_HELD(x) || RW_WRITE_HELD(x))
-#else
 #define	RW_READ_HELD(x)		((x)->rw_readers > 0)
 #define	RW_WRITE_HELD(x)	((x)->rw_wr_owner == curthread)
 #define	RW_LOCK_HELD(x)		(RW_READ_HELD(x) || RW_WRITE_HELD(x))
-#endif
 
 #undef RW_LOCK_HELD
 #define	RW_LOCK_HELD(x)		(RW_READ_HELD(x) || RW_WRITE_HELD(x))

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -304,8 +304,20 @@ typedef struct krwlock {
 	void			*rw_owner;
 	void			*rw_wr_owner;
 	uint64_t		rw_magic;
+#if !defined(_KERNEL)
+	pthread_mutex_t		cv_lock;
+	pthread_cond_t		read_cv;
+	pthread_cond_t		write_cv;
+	uint_t			read_cnt;
+	uint_t			write_cnt;
+	uint_t			write_wait_cnt;
+	uint_t			read_wait_cnt;
+	double			read_wait_time;
+	double			write_wait_time;
+#else
 	pthread_rwlock_t	rw_lock;
 	uint_t			rw_readers;
+#endif
 } krwlock_t;
 
 typedef int krw_t;

--- a/include/uzfs_test.h
+++ b/include/uzfs_test.h
@@ -53,6 +53,7 @@ extern void open_pool(spa_t **);
 extern void open_ds(spa_t *, char *, zvol_state_t **);
 
 typedef struct worker_args {
+	krwlock_t *rw_lock;
 	void *zv;
 	kmutex_t *mtx;
 	kcondvar_t *cv;
@@ -61,7 +62,7 @@ typedef struct worker_args {
 	uint64_t io_block_size;
 	uint64_t active_size;
 	int sfd[2];
-	int max_iops;
+	uint64_t max_iops;
 	int rebuild_test;
 } worker_args_t;
 
@@ -75,4 +76,5 @@ void unit_test_fn(void *arg);
 void zrepl_utest(void *arg);
 void uzfs_rebuild_test(void *arg);
 void zrepl_rebuild_test(void *arg);
+void read_write_lock_performance_testz(void *arg);
 #endif

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -576,12 +576,12 @@ rw_enter(krwlock_t *rwlp, krw_t rw)
 				atomic_inc_uint(&rwlp->read_cnt);
 				goto exit;
 			}
-			//atomic_inc_uint(&rwlp->read_wait_cnt);
+			// atomic_inc_uint(&rwlp->read_wait_cnt);
 			start = clock();
 			pthread_cond_wait(&rwlp->read_cv, &rwlp->cv_lock);
 			end = clock();
-			//atomic_dec_uint(&rwlp->read_wait_cnt);
-			rwlp->read_wait_time = ((double) (end - start)) /
+			// atomic_dec_uint(&rwlp->read_wait_cnt);
+			rwlp->read_wait_time = ((double)(end - start)) /
 			    CLOCKS_PER_SEC;
 		} else {
 			if (!rwlp->read_cnt && !rwlp->write_cnt) {
@@ -593,13 +593,12 @@ rw_enter(krwlock_t *rwlp, krw_t rw)
 			pthread_cond_wait(&rwlp->write_cv, &rwlp->cv_lock);
 			end = clock();
 			atomic_dec_uint(&rwlp->write_wait_cnt);
-			rwlp->write_wait_time = ((double) (end - start)) /
+			rwlp->write_wait_time = ((double)(end - start)) /
 			    CLOCKS_PER_SEC;
 		}
 	}
 exit:
 	(void) pthread_mutex_unlock(&rwlp->cv_lock);
-	return;
 }
 #else
 void
@@ -646,7 +645,7 @@ rw_exit(krwlock_t *rwlp)
 		ASSERT(!rwlp->write_cnt && !rwlp->read_cnt);
 		if (rwlp->write_wait_cnt)
 			pthread_cond_signal(&rwlp->write_cv);
-		else /*if (rwlp->read_wait_cnt)*/
+		else /* if (rwlp->read_wait_cnt) */
 			pthread_cond_broadcast(&rwlp->read_cv);
 	}
 
@@ -687,7 +686,7 @@ rw_tryenter(krwlock_t *rwlp, krw_t rw)
 		(void) pthread_mutex_unlock(&rwlp->cv_lock);
 		return (1);
 	}
-		
+
 	pthread_mutex_unlock(&rwlp->cv_lock);
 	return (0);
 }


### PR DESCRIPTION
Signed-off-by: satbir <satbir.chhikara@gmail.com>

There is read_write lock implementation which is baised towards reader i.e. it allow reader to let go
even where writers are waiting and blocked on lock. I have made changed in rw_enter and rw_exit
to favor writer than read opearation. From given below results its is evident that average wait time
for write has been reduced but average wait time for read has increased.
Test configuration used:
Number of reader threads = 6
Number of writer thread = 4
Number of operations per thread = 1000000
Once lock is granted then each thread just looping for 10 times, no disk operation involved in it.
We have used 6 reader thread and 4 writer thread assuming that there will be less than 40% writes
in any typical setup.

By no means I am convinced/happy with this result and my quest for better results will continue, I am sharing this info to let other know where we are:

Without changes:-
Write wait time :0.000108 Read wait time: 0.000001
Write wait time :0.000125 Read wait time: 0.000001
Write wait time :0.000119 Read wait time: 0.000001

With changes:-
Write wait time :0.000046 Read wait time: 0.000421
Write wait time :0.000053 Read wait time: 0.001451
Write wait time :0.000049 Read wait time: 0.000153

There might be concerns that why we need to make rw_lock favoring write operation over read ops
which are comparatively lesser in number/ratio. I agree that writes would be 30/40% and reads would
be 60/70% and more frequent ops should be optimized over less frequent. But here in this case from
our performance testing (we have done couple of months back) found that sync thread(which is very critical in ZFS) waited for almost 2sec to get lock and we all know that how important sync_thread progress is for ZFS to work smoothly . 

