### PR TITLE
[TA2091] Fix volume name compare issue.

### DIFF
--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -160,6 +160,7 @@ void uzfs_zvol_store_last_committed_io_no(zvol_state_t *zv,
     uint64_t io_seq);
 extern int create_and_bind(const char *port, int bind_needed,
     boolean_t nonblocking);
+int uzfs_zvol_name_compare(zvol_info_t *zv, const char *name);
 
 /*
  * API to drop refcnt on zinfo. If refcnt

--- a/lib/libzrepl/mgmt_conn.c
+++ b/lib/libzrepl/mgmt_conn.c
@@ -716,8 +716,7 @@ uzfs_zvol_rebuild_dw_replica_start(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 	for (; rebuild_op_cnt > 0; rebuild_op_cnt--, mack++) {
 		LOG_INFO("zvol %s at %s:%u helping in rebuild",
 		    mack->volname, mack->ip, mack->port);
-		if (strncmp(zinfo->name, mack->dw_volname, MAXNAMELEN)
-		    != 0) {
+		if (uzfs_zvol_name_compare(zinfo, mack->dw_volname) != 0) {
 			LOG_ERR("zvol %s not matching with zinfo %s",
 			    mack->dw_volname, zinfo->name);
 ret_error:

--- a/tests/cbtest/gtest/test_uzfs.cc
+++ b/tests/cbtest/gtest/test_uzfs.cc
@@ -1157,3 +1157,19 @@ TEST(RebuildScanner, RebuildSuccess) {
 
 	memset(&zinfo->zv->rebuild_info, 0, sizeof (zvol_rebuild_info_t));
 }
+
+/* Volume name stored in zinfo is "pool1/vol1" */
+TEST(VolumeNameCompare, VolumeNameCompareTest) {
+
+	/* Pass NULL string for compare */
+	EXPECT_EQ(-1, uzfs_zvol_name_compare(zinfo, ""));
+
+	/* Pass wrong volname but smaller string size */
+	EXPECT_EQ(-1, uzfs_zvol_name_compare(zinfo, "vol"));
+
+	/* Pass wrong volname but larger string size */
+	EXPECT_EQ(-1, uzfs_zvol_name_compare(zinfo, "vol12345678910"));
+
+	/* Pass correct volname */
+	EXPECT_EQ(0, uzfs_zvol_name_compare(zinfo, "vol1"));
+}


### PR DESCRIPTION
Signed-off-by: satbir <satbir.chhikara@gmail.com>

iSCSI controller send volume name without prefix while  uZFS maintain volume name with prefix (with pool name), so when uZFS try to find a zinfo for a given volume name, it failed because of different in volume name format. Fixing it.