### PR TITLE
[DE81]uzfs_zvol_worker should not free zio_cmd if zio_cmd is related to rebuild write.

### DIFF
--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -141,6 +141,7 @@ typedef struct zvol_io_cmd_s {
 	zvol_io_hdr_t 	hdr;
 	void		*zv;
 	void		*buf;
+	uint64_t	buf_len;
 	metadata_desc_t	*metadata_desc;
 	int		conn;
 } zvol_io_cmd_t;


### PR DESCRIPTION
This fix is avoid double free of zio cmd. This was happening because rebuild was going on volume and meanwhile we have destroyed volume which change state of volume to Offline and freed cmd. Later on same command was freed by rebuild thread. Now fix is to avoid freeing zio cmd in uzfs_zvol_worker if cmd is meant for rebuild write.