### PR TITLE
[DE83] update zvol status as degraded when target connection breaks

### DIFF
--- a/cmd/zrepl/zrepl.c
+++ b/cmd/zrepl/zrepl.c
@@ -250,6 +250,8 @@ exit:
 	(void) pthread_mutex_unlock(&zinfo->zinfo_mutex);
 
 	close(fd);
+	uzfs_zvol_set_status(zinfo->zv, ZVOL_STATUS_DEGRADED);
+	uzfs_zvol_set_rebuild_status(zinfo->zv, ZVOL_REBUILDING_INIT);
 	uzfs_zinfo_drop_refcnt(zinfo);
 	zk_thread_exit();
 }


### PR DESCRIPTION
Changes : 
Setting ZVOL status as degraded when connection with the target breaks. Due to this, when the target comes up, the replica will report its status as degraded.

Signed-off-by: mayank <mayank.patel@cloudbyte.com>