### PR TITLE
[DE83] Reinitializing zv variables during data connection break

### DIFF
--- a/cmd/zrepl/zrepl.c
+++ b/cmd/zrepl/zrepl.c
@@ -216,7 +216,8 @@ uzfs_zvol_io_receiver(void *arg)
 		}
 	}
 
-	LOG_INFO("Data connection associated with zvol %s fd: %d", zinfo->name, fd);
+	LOG_INFO("Data connection associated with zvol %s fd: %d",
+	    zinfo->name, fd);
 
 	while ((rc = uzfs_zvol_socket_read(fd, (char *)&hdr, sizeof (hdr))) ==
 	    0) {
@@ -461,7 +462,8 @@ uzfs_zvol_io_ack_sender(void *arg)
 exit:
 	zinfo->zio_cmd_in_ack = NULL;
 	shutdown(fd, SHUT_RDWR);
-	LOG_INFO("Data connection for zvol %s closed on fd: %d", zinfo->name, fd);
+	LOG_INFO("Data connection for zvol %s closed on fd: %d",
+	    zinfo->name, fd);
 
 	(void) pthread_mutex_lock(&zinfo->zinfo_mutex);
 	while (!STAILQ_EMPTY(&zinfo->complete_queue)) {

--- a/cmd/zrepl/zrepl.c
+++ b/cmd/zrepl/zrepl.c
@@ -42,8 +42,11 @@ reinitialize_zv_state(zvol_state_t *zv)
 	if (zv == NULL)
 		return;
 	zv->zv_metavolblocksize = 0;
-	zv->zv_status = ZVOL_STATUS_DEGRADED;
+
+	uzfs_zvol_set_status(zv, ZVOL_STATUS_DEGRADED);
 	bzero(&zv->rebuild_info, sizeof (zvol_rebuild_info_t));
+
+	uzfs_zvol_set_rebuild_status(zv, ZVOL_REBUILDING_INIT);
 }
 
 /*

--- a/cmd/zrepl/zrepl.c
+++ b/cmd/zrepl/zrepl.c
@@ -30,6 +30,22 @@ static void uzfs_zvol_io_ack_sender(void *arg);
 kthread_t	*conn_accpt_thread;
 kthread_t	*uzfs_timer_thread;
 kthread_t	*mgmt_conn_thread;
+
+/*
+ * (Re)Initializes zv's state variables.
+ * This fn need to be called to use zv across network disconnections.
+ * Lock protection and life of zv need to be managed by caller
+ */
+static void
+reinitialize_zv_state(zvol_state_t *zv)
+{
+	if (zv == NULL)
+		return;
+	zv->zv_metavolblocksize = 0;
+	zv->zv_status = ZVOL_STATUS_DEGRADED;
+	bzero(&zv->rebuild_info, sizeof (zvol_rebuild_info_t));
+}
+
 /*
  * Process open request on data connection, the first message.
  *
@@ -45,9 +61,10 @@ open_zvol(int fd, zvol_info_t **zinfopp)
 	zvol_io_hdr_t	hdr;
 	zvol_op_open_data_t open_data;
 	zvol_info_t	*zinfo = NULL;
-	zvol_state_t	*zv;
+	zvol_state_t	*zv = NULL;
 	kthread_t	*thrd_info;
 	thread_args_t 	*thrd_arg;
+	int		rele_dataset_on_error = 0;
 
 	/*
 	 * If we don't know the version yet, be more careful when
@@ -78,14 +95,24 @@ open_zvol(int fd, zvol_info_t **zinfopp)
 		hdr.status = ZVOL_OP_STATUS_FAILED;
 		goto open_reply;
 	}
-	zv = zinfo->zv;
-	ASSERT3P(zv, !=, NULL);
-	if (zv->zv_metavolblocksize != 0 &&
-	    zv->zv_metavolblocksize != open_data.tgt_block_size) {
-		LOG_ERR("Conflicting block size");
+	if (zinfo->state != ZVOL_INFO_STATE_ONLINE) {
+		LOG_ERR("zvol %s is not online", open_data.volname);
 		hdr.status = ZVOL_OP_STATUS_FAILED;
 		goto open_reply;
 	}
+	zv = zinfo->zv;
+
+	if (zv->zv_metavolblocksize != 0) {
+		LOG_ERR("there might be already a data connection for %s",
+		    open_data.volname);
+		hdr.status = ZVOL_OP_STATUS_FAILED;
+		goto open_reply;
+	}
+
+	ASSERT3P(zv, !=, NULL);
+	ASSERT3P(zv->zv_status, ==, ZVOL_STATUS_DEGRADED);
+	ASSERT3P(zv->rebuild_info.zv_rebuild_status, ==, ZVOL_REBUILDING_INIT);
+
 	// validate block size (only one bit is set in the number)
 	if (open_data.tgt_block_size == 0 ||
 	    (open_data.tgt_block_size & (open_data.tgt_block_size - 1)) != 0) {
@@ -100,16 +127,22 @@ open_zvol(int fd, zvol_info_t **zinfopp)
 	 * in case that the target creates data connection directly without
 	 * getting the endpoint through mgmt connection first.
 	 */
-	if (zv->zv_objset == NULL && uzfs_hold_dataset(zv) != 0) {
-		(void) pthread_mutex_unlock(&zinfo->zinfo_mutex);
-		LOG_ERR("Failed to hold zvol during open");
-		hdr.status = ZVOL_OP_STATUS_FAILED;
-		goto open_reply;
+	rele_dataset_on_error = 0;
+	if (zv->zv_objset == NULL) {
+		if (uzfs_hold_dataset(zv) != 0) {
+			(void) pthread_mutex_unlock(&zinfo->zinfo_mutex);
+			LOG_ERR("Failed to hold zvol during open");
+			hdr.status = ZVOL_OP_STATUS_FAILED;
+			goto open_reply;
+		}
+		else
+			rele_dataset_on_error = 1;
 	}
 	if (uzfs_update_metadata_granularity(zv,
 	    open_data.tgt_block_size) != 0) {
 		(void) pthread_mutex_unlock(&zinfo->zinfo_mutex);
-		uzfs_rele_dataset(zv);
+		if (rele_dataset_on_error == 1)
+			uzfs_rele_dataset(zv);
 		LOG_ERR("Failed to set granularity of metadata");
 		hdr.status = ZVOL_OP_STATUS_FAILED;
 		goto open_reply;
@@ -149,6 +182,7 @@ open_reply:
 		LOG_ERR("Failed to send reply for open request");
 	if (hdr.status != ZVOL_OP_STATUS_OK) {
 		ASSERT3P(*zinfopp, ==, NULL);
+		reinitialize_zv_state(zv);
 		if (zinfo != NULL)
 			uzfs_zinfo_drop_refcnt(zinfo);
 		return (-1);
@@ -178,14 +212,11 @@ uzfs_zvol_io_receiver(void *arg)
 			    (zinfo->is_io_ack_sender_created))
 				goto exit;
 			shutdown(fd, SHUT_RDWR);
-			(void) close(fd);
-			LOG_INFO("Data connection closed");
-			zk_thread_exit();
-			return;
+			goto thread_exit;
 		}
 	}
 
-	LOG_INFO("Data connection associated with zvol %s", zinfo->name);
+	LOG_INFO("Data connection associated with zvol %s fd: %d", zinfo->name, fd);
 
 	while ((rc = uzfs_zvol_socket_read(fd, (char *)&hdr, sizeof (hdr))) ==
 	    0) {
@@ -249,8 +280,13 @@ exit:
 	}
 	(void) pthread_mutex_unlock(&zinfo->zinfo_mutex);
 
-	close(fd);
+	zinfo->io_ack_waiting = 0;
+
+	reinitialize_zv_state(zinfo->zv);
 	uzfs_zinfo_drop_refcnt(zinfo);
+thread_exit:
+	close(fd);
+	LOG_INFO("Data connection closed on fd: %d", fd);
 	zk_thread_exit();
 }
 
@@ -344,7 +380,6 @@ uzfs_zvol_io_ack_sender(void *arg)
 		while (1) {
 			if ((zinfo->state == ZVOL_INFO_STATE_OFFLINE) ||
 			    (zinfo->conn_closed == B_TRUE)) {
-				zinfo->is_io_ack_sender_created = B_FALSE;
 				(void) pthread_mutex_unlock(
 				    &zinfo->zinfo_mutex);
 				goto exit;
@@ -426,7 +461,7 @@ uzfs_zvol_io_ack_sender(void *arg)
 exit:
 	zinfo->zio_cmd_in_ack = NULL;
 	shutdown(fd, SHUT_RDWR);
-	LOG_INFO("Data connection for zvol %s closed", zinfo->name);
+	LOG_INFO("Data connection for zvol %s closed on fd: %d", zinfo->name, fd);
 
 	(void) pthread_mutex_lock(&zinfo->zinfo_mutex);
 	while (!STAILQ_EMPTY(&zinfo->complete_queue)) {
@@ -434,6 +469,8 @@ exit:
 		STAILQ_REMOVE_HEAD(&zinfo->complete_queue, cmd_link);
 		zio_cmd_free(&zio_cmd);
 	}
+	zinfo->conn_closed = B_FALSE;
+	zinfo->is_io_ack_sender_created = B_FALSE;
 	(void) pthread_mutex_unlock(&zinfo->zinfo_mutex);
 	uzfs_zinfo_drop_refcnt(zinfo);
 

--- a/cmd/zrepl/zrepl.c
+++ b/cmd/zrepl/zrepl.c
@@ -135,8 +135,7 @@ open_zvol(int fd, zvol_info_t **zinfopp)
 			hdr.status = ZVOL_OP_STATUS_FAILED;
 			goto open_reply;
 		}
-		else
-			rele_dataset_on_error = 1;
+		rele_dataset_on_error = 1;
 	}
 	if (uzfs_update_metadata_granularity(zv,
 	    open_data.tgt_block_size) != 0) {

--- a/include/gtest_utils.h
+++ b/include/gtest_utils.h
@@ -122,7 +122,7 @@ public:
 			m_fd = -1;
 		}
 	}
-	int fd();
+	int &fd();
 	SocketFd& operator=(int other);
 	void graceful_close();
 	bool opened();

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -99,14 +99,10 @@ typedef struct zvol_info_s {
 	pthread_mutex_t	zinfo_mutex;
 	pthread_cond_t	io_ack_cond;
 
-//	pthread_t 	io_receiver_thread;
-//	pthread_t 	io_ack_sender_thread;
-
 	/* All cmds after execution will go here for ack */
 	STAILQ_HEAD(, zvol_io_cmd_s)	complete_queue;
 
 	uint8_t		io_ack_waiting;
-//	uint8_t		error_count;
 
 	/* Will be used to singal ack-sender to exit */
 	uint8_t		conn_closed;

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -99,14 +99,14 @@ typedef struct zvol_info_s {
 	pthread_mutex_t	zinfo_mutex;
 	pthread_cond_t	io_ack_cond;
 
-	pthread_t 	io_receiver_thread;
-	pthread_t 	io_ack_sender_thread;
+//	pthread_t 	io_receiver_thread;
+//	pthread_t 	io_ack_sender_thread;
 
 	/* All cmds after execution will go here for ack */
 	STAILQ_HEAD(, zvol_io_cmd_s)	complete_queue;
 
 	uint8_t		io_ack_waiting;
-	uint8_t		error_count;
+//	uint8_t		error_count;
 
 	/* Will be used to singal ack-sender to exit */
 	uint8_t		conn_closed;

--- a/include/zrepl_prot.h
+++ b/include/zrepl_prot.h
@@ -153,8 +153,8 @@ typedef enum zvol_rebuild_status zvol_rebuild_status_t;
  * zvol status
  */
 enum zvol_status {
-	ZVOL_STATUS_HEALTHY,		/* zvol has latest data */
-	ZVOL_STATUS_DEGRADED		/* zvol is missing some data */
+	ZVOL_STATUS_DEGRADED,		/* zvol is missing some data */
+	ZVOL_STATUS_HEALTHY		/* zvol has latest data */
 } __attribute__((packed));
 
 typedef enum zvol_status zvol_status_t;

--- a/lib/libzpool/uzfs_mgmt.c
+++ b/lib/libzpool/uzfs_mgmt.c
@@ -474,6 +474,7 @@ uzfs_zvol_create_cb(const char *ds_name, void *arg)
 		return (0);
 	}
 
+//	error = uzfs_dataset_zv_create(ds_name, &zv);
 	error = uzfs_own_dataset(ds_name, &zv);
 	if (error) {
 		/* happens normally for all non-zvol-type datasets */

--- a/lib/libzpool/uzfs_mgmt.c
+++ b/lib/libzpool/uzfs_mgmt.c
@@ -306,7 +306,7 @@ get_controller_ip(objset_t *os, char *buf, int len)
 
 /* owns objset with name 'ds_name' in pool 'spa' */
 static int
-uzfs_own_dataset(const char *ds_name, zvol_state_t **z)
+uzfs_dataset_zv_create(const char *ds_name, zvol_state_t **z)
 {
 	zvol_state_t *zv = NULL;
 	int error = -1;
@@ -420,7 +420,7 @@ uzfs_open_dataset(spa_t *spa, const char *ds_name, zvol_state_t **z)
 		return (error);
 	(void) snprintf(name, sizeof (name), "%s/%s", spa_name(spa), ds_name);
 
-	error = uzfs_own_dataset(name, z);
+	error = uzfs_dataset_zv_create(name, z);
 	return (error);
 }
 
@@ -474,8 +474,7 @@ uzfs_zvol_create_cb(const char *ds_name, void *arg)
 		return (0);
 	}
 
-//	error = uzfs_dataset_zv_create(ds_name, &zv);
-	error = uzfs_own_dataset(ds_name, &zv);
+	error = uzfs_dataset_zv_create(ds_name, &zv);
 	if (error) {
 		/* happens normally for all non-zvol-type datasets */
 		return (error);
@@ -542,6 +541,9 @@ uzfs_rele_dataset(zvol_state_t *zv)
 		dnode_rele(zv->zv_dn, zv);
 	if (zv->zv_objset != NULL)
 		dmu_objset_disown(zv->zv_objset, zv);
+	zv->zv_zilog = NULL;
+	zv->zv_dn = NULL;
+	zv->zv_objset = NULL;
 }
 
 /* disowns, closes dataset */

--- a/lib/libzpool/uzfs_mgmt.c
+++ b/lib/libzpool/uzfs_mgmt.c
@@ -392,6 +392,7 @@ free_ret:
 
 	/* On boot, mark zvol status health */
 	uzfs_zvol_set_status(zv, ZVOL_STATUS_DEGRADED);
+	uzfs_zvol_set_rebuild_status(zv, ZVOL_REBUILDING_INIT);
 
 	if (spa_writeable(dmu_objset_spa(os))) {
 //		if (zil_replay_disable)

--- a/lib/libzpool/zrepl_mgmt.c
+++ b/lib/libzpool/zrepl_mgmt.c
@@ -291,6 +291,7 @@ uzfs_zinfo_init(void *zv, const char *ds_name, nvlist_t *create_props)
 
 	strlcpy(zinfo->name, ds_name, MAXNAMELEN);
 	zinfo->zv = zv;
+	zinfo->state = ZVOL_INFO_STATE_ONLINE;
 	/* iSCSI target will overwrite this value during handshake */
 	zinfo->update_ionum_interval = 6000;
 	/* Update zvol list */

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -615,6 +615,7 @@ remove_pending_cmds_to_ack(int fd, zvol_info_t *zinfo)
 	while ((zinfo->zio_cmd_in_ack != NULL) &&
 	    (((zvol_io_cmd_t *)(zinfo->zio_cmd_in_ack))->conn == fd)) {
 		(void) pthread_mutex_unlock(&zinfo->zinfo_mutex);
+		LOG_INFO("Waiting for IO to send off on vol %s", zinfo->name);
 		sleep(1);
 		(void) pthread_mutex_lock(&zinfo->zinfo_mutex);
 	}

--- a/lib/libzrepl/mgmt_conn.c
+++ b/lib/libzrepl/mgmt_conn.c
@@ -66,12 +66,12 @@
  */
 
 /* log wrappers which prefix log message by iscsi target address */
-#define	DBGCONN(c, fmt, ...)	LOG_DEBUG("[tgt %s:%u]: " fmt, \
-				(c)->conn_host, (c)->conn_port, ##__VA_ARGS__)
-#define	LOGCONN(c, fmt, ...)	LOG_INFO("[tgt %s:%u]: " fmt, \
-				(c)->conn_host, (c)->conn_port, ##__VA_ARGS__)
-#define	LOGERRCONN(c, fmt, ...)	LOG_ERR("[tgt %s:%u]: " fmt, \
-				(c)->conn_host, (c)->conn_port, ##__VA_ARGS__)
+#define	DBGCONN(c, fmt, ...)	LOG_DEBUG("[tgt %s:%u:%d]: " fmt, \
+				(c)->conn_host, (c)->conn_port, c->conn_fd, ##__VA_ARGS__)
+#define	LOGCONN(c, fmt, ...)	LOG_INFO("[tgt %s:%u:%d]: " fmt, \
+				(c)->conn_host, (c)->conn_port, c->conn_fd, ##__VA_ARGS__)
+#define	LOGERRCONN(c, fmt, ...)	LOG_ERR("[tgt %s:%u:%d]: " fmt, \
+				(c)->conn_host, (c)->conn_port, c->conn_fd, ##__VA_ARGS__)
 
 /* Max # of events from epoll processed at once */
 #define	MAX_EVENTS	10

--- a/lib/libzrepl/mgmt_conn.c
+++ b/lib/libzrepl/mgmt_conn.c
@@ -67,11 +67,14 @@
 
 /* log wrappers which prefix log message by iscsi target address */
 #define	DBGCONN(c, fmt, ...)	LOG_DEBUG("[tgt %s:%u:%d]: " fmt, \
-				(c)->conn_host, (c)->conn_port, c->conn_fd, ##__VA_ARGS__)
+				(c)->conn_host, (c)->conn_port, \
+				c->conn_fd, ##__VA_ARGS__)
 #define	LOGCONN(c, fmt, ...)	LOG_INFO("[tgt %s:%u:%d]: " fmt, \
-				(c)->conn_host, (c)->conn_port, c->conn_fd, ##__VA_ARGS__)
+				(c)->conn_host, (c)->conn_port, \
+				c->conn_fd, ##__VA_ARGS__)
 #define	LOGERRCONN(c, fmt, ...)	LOG_ERR("[tgt %s:%u:%d]: " fmt, \
-				(c)->conn_host, (c)->conn_port, c->conn_fd, ##__VA_ARGS__)
+				(c)->conn_host, (c)->conn_port, \
+				c->conn_fd, ##__VA_ARGS__)
 
 /* Max # of events from epoll processed at once */
 #define	MAX_EVENTS	10

--- a/tests/cbtest/gtest/gtest_utils.cc
+++ b/tests/cbtest/gtest/gtest_utils.cc
@@ -193,7 +193,7 @@ GtestUtils::strlcpy(char *dst, const char *src, size_t len)
         return (slen);
 }
 
-int
+int &
 GtestUtils::SocketFd::fd()
 {
 	return m_fd;

--- a/tests/cbtest/gtest/test_zrepl_prot.cc
+++ b/tests/cbtest/gtest/test_zrepl_prot.cc
@@ -1034,20 +1034,7 @@ TEST_F(ZreplDataTest, ReadMetaDataFlag) {
 
 	/* write a data block with known ionum */
 	write_data_and_verify_resp(m_datasock1.fd(), m_ioseq1, 0, 654);
-#if 0
-	/* read the block without ZVOL_OP_FLAG_READ_METADATA flag */
-	read_data_start(m_datasock1.fd(), m_ioseq1, 0, sizeof (buf), &hdr_in, 0);
-	ASSERT_EQ(hdr_in.status, ZVOL_OP_STATUS_OK);
-	ASSERT_EQ(hdr_in.len, sizeof (read_hdr) + sizeof (buf));
-	rc = read(m_datasock1.fd(), &read_hdr, sizeof (read_hdr));
-	ASSERT_ERRNO("read", rc >= 0);
-	ASSERT_EQ(rc, sizeof (read_hdr));
-	ASSERT_EQ(read_hdr.io_num, 0);
-	ASSERT_EQ(read_hdr.len, sizeof (buf));
-	rc = read(m_datasock1.fd(), buf, sizeof (buf));
-	ASSERT_ERRNO("read", rc >= 0);
-	ASSERT_EQ(rc, sizeof (buf));
-#endif
+
 	/* read the block with ZVOL_OP_FLAG_READ_METADATA flag */
 	read_data_start(m_datasock1.fd(), m_ioseq1, 0, sizeof (buf), &hdr_in, ZVOL_OP_FLAG_READ_METADATA);
 	ASSERT_EQ(hdr_in.status, ZVOL_OP_STATUS_OK);

--- a/tests/cbtest/gtest/test_zrepl_prot.cc
+++ b/tests/cbtest/gtest/test_zrepl_prot.cc
@@ -111,45 +111,55 @@ static void do_handshake(std::string zvol_name, std::string &host,
  * NOTE: Return value must be void otherwise we could not use asserts
  * (pecularity of gtest framework).
  */
-static void do_data_connection(int data_fd, std::string host, uint16_t port,
+static void do_data_connection(int &data_fd, std::string host, uint16_t port,
     std::string zvol_name, int bs=4096, int timeout=120,
     int res=ZVOL_OP_STATUS_OK) {
 	struct sockaddr_in addr;
 	zvol_io_hdr_t hdr_in, hdr_out = {0};
 	zvol_op_open_data_t open_data;
 	int rc;
+	char val;
+	int fd;
 
 	memset(&addr, 0, sizeof (addr));
 	addr.sin_family = AF_INET;
 	addr.sin_port = htons(port);
 	rc = inet_pton(AF_INET, host.c_str(), &addr.sin_addr);
 	ASSERT_TRUE(rc > 0);
-	rc = connect(data_fd, (struct sockaddr *)&addr, sizeof (addr));
+retry:
+	fd = socket(AF_INET, SOCK_STREAM, 0);
+	rc = connect(fd, (struct sockaddr *)&addr, sizeof (addr));
 	if (rc != 0) {
 		perror("connect");
 		ASSERT_EQ(errno, 0);
 	}
-
 	hdr_out.version = REPLICA_VERSION;
 	hdr_out.opcode = ZVOL_OPCODE_OPEN;
 	hdr_out.status = ZVOL_OP_STATUS_OK;
 	hdr_out.len = sizeof (open_data);
 
-	rc = write(data_fd, &hdr_out, sizeof (hdr_out));
+	rc = write(fd, &hdr_out, sizeof (hdr_out));
 	ASSERT_EQ(rc, sizeof (hdr_out));
 
 	open_data.tgt_block_size = bs;
 	open_data.timeout = timeout;
 	GtestUtils::strlcpy(open_data.volname, zvol_name.c_str(),
 	    sizeof (open_data.volname));
-	rc = write(data_fd, &open_data, hdr_out.len);
+	rc = write(fd, &open_data, hdr_out.len);
 
-	rc = read(data_fd, &hdr_in, sizeof (hdr_in));
+	rc = read(fd, &hdr_in, sizeof (hdr_in));
 	ASSERT_EQ(rc, sizeof (hdr_in));
 	ASSERT_EQ(hdr_in.version, REPLICA_VERSION);
 	ASSERT_EQ(hdr_in.opcode, ZVOL_OPCODE_OPEN);
 	ASSERT_EQ(hdr_in.len, 0);
-	ASSERT_EQ(hdr_in.status, res);
+	if (hdr_in.status != res) {
+		sleep(2);
+		shutdown(fd, SHUT_WR);
+		rc = read(fd, &val, sizeof (val));
+		close(fd);
+		goto retry;
+	}
+	data_fd = fd;
 }
 
 /*
@@ -691,8 +701,8 @@ protected:
 
 		m_zrepl->start();
 		m_pool1->create();
-		m_pool1->createZvol("vol1", "-o io.openebs:targetip=127.0.0.1:6060");
-		m_zvol_name1 = m_pool1->getZvolName("vol1");
+		m_pool1->createZvol("ivol1", "-o io.openebs:targetip=127.0.0.1:6060");
+		m_zvol_name1 = m_pool1->getZvolName("ivol1");
 
 		rc = target1.listen();
 		ASSERT_GE(rc, 0);
@@ -713,7 +723,7 @@ protected:
 
 		m_pool2->create();
 		m_pool2->createZvol("vol1", "-o io.openebs:targetip=127.0.0.1:12345");
-		m_zvol_name2 = m_pool1->getZvolName("vol1");
+		m_zvol_name2 = m_pool1->getZvolName("ivol1");
 
 		rc = target2.listen(12345);
 		ASSERT_GE(rc, 0);
@@ -729,7 +739,7 @@ protected:
 	}
 
 	static void TearDownTestCase() {
-		m_pool1->destroyZvol("vol1");
+		m_pool1->destroyZvol("ivol1");
 		m_pool2->destroyZvol("vol1");
 		delete m_pool1;
 		delete m_pool2;
@@ -1024,7 +1034,7 @@ TEST_F(ZreplDataTest, ReadMetaDataFlag) {
 
 	/* write a data block with known ionum */
 	write_data_and_verify_resp(m_datasock1.fd(), m_ioseq1, 0, 654);
-
+#if 0
 	/* read the block without ZVOL_OP_FLAG_READ_METADATA flag */
 	read_data_start(m_datasock1.fd(), m_ioseq1, 0, sizeof (buf), &hdr_in, 0);
 	ASSERT_EQ(hdr_in.status, ZVOL_OP_STATUS_OK);
@@ -1037,7 +1047,7 @@ TEST_F(ZreplDataTest, ReadMetaDataFlag) {
 	rc = read(m_datasock1.fd(), buf, sizeof (buf));
 	ASSERT_ERRNO("read", rc >= 0);
 	ASSERT_EQ(rc, sizeof (buf));
-
+#endif
 	/* read the block with ZVOL_OP_FLAG_READ_METADATA flag */
 	read_data_start(m_datasock1.fd(), m_ioseq1, 0, sizeof (buf), &hdr_in, ZVOL_OP_FLAG_READ_METADATA);
 	ASSERT_EQ(hdr_in.status, ZVOL_OP_STATUS_OK);
@@ -1198,6 +1208,13 @@ TEST(Misc, ZreplCheckpointInterval) {
 	uint16_t port_slow, port_fast;
 	uint64_t ionum_slow, ionum_fast;
 
+	zvol_io_hdr_t hdr_in;
+	struct zvol_io_rw_hdr read_hdr;
+	struct zvol_io_rw_hdr write_hdr;
+	struct zrepl_status_ack status;
+	struct mgmt_ack mgmt_ack;
+	char buf[4096];
+
 	zrepl.start();
 	pool.create();
 	pool.createZvol("slow", "-o io.openebs:targetip=127.0.0.1:6060");
@@ -1216,16 +1233,31 @@ TEST(Misc, ZreplCheckpointInterval) {
 	    control_fd, ZVOL_OP_STATUS_OK);
 	ASSERT_NE(ionum_slow, 888);
 	ASSERT_NE(ionum_fast, 888);
-	transition_zvol_to_online(ioseq, control_fd, zvol_name_slow);
-	transition_zvol_to_online(ioseq, control_fd, zvol_name_fast);
 
 	do_data_connection(datasock_slow.fd(), host_slow, port_slow, zvol_name_slow,
 	    4096, 1000);
 	do_data_connection(datasock_fast.fd(), host_fast, port_fast, zvol_name_fast,
 	    4096, 2);
 
+	transition_zvol_to_online(ioseq, control_fd, zvol_name_slow);
+	transition_zvol_to_online(ioseq, control_fd, zvol_name_fast);
+
 	write_data_and_verify_resp(datasock_slow.fd(), ioseq, 0, 888);
 	write_data_and_verify_resp(datasock_fast.fd(), ioseq, 0, 888);
+
+	/* read the block without ZVOL_OP_FLAG_READ_METADATA flag in healthy state */
+	read_data_start(datasock_slow.fd(), ioseq, 0, sizeof (buf), &hdr_in, 0);
+	ASSERT_EQ(hdr_in.status, ZVOL_OP_STATUS_OK);
+	ASSERT_EQ(hdr_in.len, sizeof (read_hdr) + sizeof (buf));
+	rc = read(datasock_slow.fd(), &read_hdr, sizeof (read_hdr));
+	ASSERT_ERRNO("read", rc >= 0);
+	ASSERT_EQ(rc, sizeof (read_hdr));
+	ASSERT_EQ(read_hdr.io_num, 0);
+	ASSERT_EQ(read_hdr.len, sizeof (buf));
+	rc = read(datasock_slow.fd(), buf, sizeof (buf));
+	ASSERT_ERRNO("read", rc >= 0);
+	ASSERT_EQ(rc, sizeof (buf));
+
 	sleep(10);	/* Due to spa sync interval, sleep for 10 sec is required here */
 
 	zrepl.kill();


### PR DESCRIPTION
- When data connection is formed between controller and replica, replica sets zv variables, and its status gets updated over period of time.
But, when the disconnection happens, these need to be re-initialized.
This PR takes care of re-initializing the zv status on data connection disconnection.

- Multiple data connections should not allowed. This PR makes sure that multiple data connections doesn't happen by checking for initial values of zv's member variables.

- Fixed gtest cases with these new constraints

- Some minor changes like - change in macros values for zvol status, and removed unused member variables in zinfo.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>