### PR TITLE
[DE84] Reconnecting to disconnected targets periodically, and, setting keepalive parameters for connections

### DIFF
--- a/include/mgmt_conn.h
+++ b/include/mgmt_conn.h
@@ -31,6 +31,18 @@
 extern "C" {
 #endif
 
+#define	timesdiff(_clockid, _st, _now, _re)				\
+{									\
+	clock_gettime(_clockid, &_now);					\
+	if ((_now.tv_nsec - _st.tv_nsec) < 0) {				\
+		_re.tv_sec  = _now.tv_sec - _st.tv_sec - 1;		\
+		_re.tv_nsec = 1000000000 + _now.tv_nsec - _st.tv_nsec;	\
+	} else {							\
+		_re.tv_sec  = _now.tv_sec - _st.tv_sec;			\
+		_re.tv_nsec = _now.tv_nsec - _st.tv_nsec;		\
+	}								\
+}
+
 /*
  * Mgmt connection states.
  */

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -158,6 +158,7 @@ extern int uzfs_zinfo_destroy(const char *ds_name, spa_t *spa);
 uint64_t uzfs_zvol_get_last_committed_io_no(zvol_state_t *zv);
 void uzfs_zvol_store_last_committed_io_no(zvol_state_t *zv,
     uint64_t io_seq);
+extern int set_socket_keepalive(int sfd);
 extern int create_and_bind(const char *port, int bind_needed,
     boolean_t nonblocking);
 int uzfs_zvol_name_compare(zvol_info_t *zv, const char *name);

--- a/lib/libzpool/zrepl_mgmt.c
+++ b/lib/libzpool/zrepl_mgmt.c
@@ -81,30 +81,36 @@ set_socket_keepalive(int sfd)
 	}
 
 	if (setsockopt(sfd, SOL_SOCKET, SO_KEEPALIVE, &val, sizeof (val)) < 0) {
-		LOG_ERR("Failed to set SO_KEEPALIVE for fd(%d) err(%d)\n", sfd, errno);
+		LOG_ERR("Failed to set SO_KEEPALIVE for fd(%d) err(%d)\n",
+		    sfd, errno);
 		ret = errno;
 		goto out;
 	}
 
 	if (setsockopt(sfd, SOL_TCP, TCP_KEEPCNT, &max_try, sizeof (max_try))) {
-		LOG_ERR("Failed to set TCP_KEEPCNT for fd(%d) err(%d)\n", sfd, errno);
+		LOG_ERR("Failed to set TCP_KEEPCNT for fd(%d) err(%d)\n",
+		    sfd, errno);
 		ret = errno;
 		goto out;
 	}
 
-	if (setsockopt(sfd, SOL_TCP, TCP_KEEPIDLE, &max_idle_time, sizeof (max_idle_time))) {
-		LOG_ERR("Failed to set TCP_KEEPIDLE for fd(%d) err(%d)\n", sfd, errno);
+	if (setsockopt(sfd, SOL_TCP, TCP_KEEPIDLE, &max_idle_time,
+	    sizeof (max_idle_time))) {
+		LOG_ERR("Failed to set TCP_KEEPIDLE for fd(%d) err(%d)\n",
+		    sfd, errno);
 		ret = errno;
 		goto out;
 	}
 
-	if (setsockopt(sfd, SOL_TCP, TCP_KEEPINTVL, &probe_interval, sizeof (probe_interval))) {
-		LOG_ERR("Failed to set TCP_KEEPINTVL for fd(%d) err(%d)\n", sfd, errno);
+	if (setsockopt(sfd, SOL_TCP, TCP_KEEPINTVL, &probe_interval,
+	    sizeof (probe_interval))) {
+		LOG_ERR("Failed to set TCP_KEEPINTVL for fd(%d) err(%d)\n",
+		    sfd, errno);
 		ret = errno;
 	}
 
 out:
-	return ret;
+	return (ret);
 }
 
 int

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -783,7 +783,7 @@ uzfs_zvol_io_conn_acceptor(void *arg)
 			rc = set_socket_keepalive(new_fd);
 			if (rc != 0)
 				LOG_ERR("Failed to set keepalive on "
-				   "accepted fd %d", new_fd);
+				    "accepted fd %d", new_fd);
 			rc = 0;
 
 			if (events[i].data.fd == io_sfd) {

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -375,6 +375,11 @@ uzfs_zvol_rebuild_dw_replica(void *arg)
 		goto exit;
 	}
 
+	rc = set_socket_keepalive(sfd);
+	if (rc != 0)
+		LOG_ERR("keepalive errored on connected rebuild fd %d", sfd);
+	rc = 0;
+
 	/* Set state in-progess state now */
 	checkpointed_ionum = uzfs_zvol_get_last_committed_io_no(zinfo->zv);
 	zvol_state = zinfo->zv;
@@ -774,6 +779,13 @@ uzfs_zvol_io_conn_acceptor(void *arg)
 			kmem_free(hbuf, NI_MAXHOST);
 			kmem_free(sbuf, NI_MAXSERV);
 #endif
+
+			rc = set_socket_keepalive(new_fd);
+			if (rc != 0)
+				LOG_ERR("Failed to set keepalive on "
+				   "accepted fd %d", new_fd);
+			rc = 0;
+
 			if (events[i].data.fd == io_sfd) {
 				LOG_INFO("New data connection");
 				thrd_info = zk_thread_create(NULL, 0,

--- a/lib/libzrepl/mgmt_conn.c
+++ b/lib/libzrepl/mgmt_conn.c
@@ -186,6 +186,7 @@ connect_to_tgt(uzfs_mgmt_conn_t *conn)
 		    conn->conn_port);
 		return (-1);
 	}
+
 	return (sfd);
 }
 
@@ -1048,6 +1049,10 @@ move_to_next_state(uzfs_mgmt_conn_t *conn)
 	switch (conn->conn_state) {
 	case CS_CONNECT:
 		LOGCONN(conn, "Connected");
+		rc = set_socket_keepalive(conn->conn_fd);
+		if (rc != 0)
+			LOGERRCONN(conn, "Failed to set keepalive");
+		rc = 0;
 		/* Fall-through */
 	case CS_INIT:
 		DBGCONN(conn, "Reading version..");


### PR DESCRIPTION
- When replica or controller node just goes off, other side of connection doesn't know that the node went off. By setting TCP keepalive parameters, replica will know that connection got broken.
Settings are:
TCP_KEEPCNT = 5
TCP_KEEPIDLE = 5
TCP_KEEPINTVL = 5

Reference link: https://www.tldp.org/HOWTO/html_single/TCP-Keepalive-HOWTO/#setsockopt

This PR is to set TCP keepalive parameters for the accepted connections from target and from other replica for rebuild, and for the connections that replica connected to target and to other replica for rebuild.

- Replica need to be made to reconnect to target periodically. But, currently, replica tries to connect to target either during provisioning or de-provisioning or when there are no events to any connected targets in last 2 seconds.

If there is any activity with any target on management connection every 2 seconds, replica doesn't retries to connect to disconnected targets.

This PR is to scan for disconnected targets, if any, for every 2 seconds without depending on other events like provisioning (or) de-provisioning (or) activity on other connections.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>