### PR TITLE
Data connection creation issue during zrepl restart

### DIFF
--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -94,7 +94,15 @@ typedef struct zvol_info_s {
 	char 		name[MAXPATHLEN];
 	zvol_state_t	*zv;
 	uint64_t	refcnt;
-	int		is_io_ack_sender_created;
+
+	union {
+		struct {
+			int	is_io_ack_sender_created	: 1;
+			int	is_io_receiver_created		: 1;
+		};
+		int flags;
+	};
+
 	uint32_t	timeout;	/* iSCSI timeout val for this zvol */
 	uint64_t	zvol_guid;
 	uint64_t	running_ionum;

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -1336,13 +1336,6 @@ open_zvol(int fd, zvol_info_t **zinfopp)
 	zv = zinfo->zv;
 	ASSERT3P(zv, !=, NULL);
 
-	if (zv->zv_metavolblocksize != 0) {
-		LOG_ERR("there might be already a data connection for %s",
-		    open_data.volname);
-		hdr.status = ZVOL_OP_STATUS_FAILED;
-		goto open_reply;
-	}
-
 	ASSERT3P(zv->zv_status, ==, ZVOL_STATUS_DEGRADED);
 	ASSERT3P(zv->rebuild_info.zv_rebuild_status, ==, ZVOL_REBUILDING_INIT);
 

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -1321,15 +1321,25 @@ open_zvol(int fd, zvol_info_t **zinfopp)
 		hdr.status = ZVOL_OP_STATUS_FAILED;
 		goto open_reply;
 	}
+	(void) pthread_mutex_lock(&zinfo->zinfo_mutex);
 	if (zinfo->state != ZVOL_INFO_STATE_ONLINE) {
 		LOG_ERR("zvol %s is not online", open_data.volname);
 		hdr.status = ZVOL_OP_STATUS_FAILED;
+		(void) pthread_mutex_unlock(&zinfo->zinfo_mutex);
 		goto open_reply;
 	}
 	if (zinfo->is_io_ack_sender_created != B_FALSE) {
 		LOG_ERR("zvol %s ack sender already present",
 		    open_data.volname);
 		hdr.status = ZVOL_OP_STATUS_FAILED;
+		(void) pthread_mutex_unlock(&zinfo->zinfo_mutex);
+		goto open_reply;
+	}
+	if (zinfo->is_io_receiver_created != B_FALSE) {
+		LOG_ERR("zvol %s io receiver already present",
+		    open_data.volname);
+		hdr.status = ZVOL_OP_STATUS_FAILED;
+		(void) pthread_mutex_unlock(&zinfo->zinfo_mutex);
 		goto open_reply;
 	}
 
@@ -1346,6 +1356,7 @@ open_zvol(int fd, zvol_info_t **zinfopp)
 		    open_data.volname, zv->zv_status,
 		    zv->rebuild_info.zv_rebuild_status);
 		hdr.status = ZVOL_OP_STATUS_FAILED;
+		(void) pthread_mutex_unlock(&zinfo->zinfo_mutex);
 		goto open_reply;
 	}
 	// validate block size (only one bit is set in the number)
@@ -1353,10 +1364,10 @@ open_zvol(int fd, zvol_info_t **zinfopp)
 	    (open_data.tgt_block_size & (open_data.tgt_block_size - 1)) != 0) {
 		LOG_ERR("Invalid block size");
 		hdr.status = ZVOL_OP_STATUS_FAILED;
+		(void) pthread_mutex_unlock(&zinfo->zinfo_mutex);
 		goto open_reply;
 	}
 
-	(void) pthread_mutex_lock(&zinfo->zinfo_mutex);
 	/*
 	 * Hold objset if this is the first query for the zvol. This can happen
 	 * in case that the target creates data connection directly without
@@ -1368,6 +1379,7 @@ open_zvol(int fd, zvol_info_t **zinfopp)
 			(void) pthread_mutex_unlock(&zinfo->zinfo_mutex);
 			LOG_ERR("Failed to hold zvol during open");
 			hdr.status = ZVOL_OP_STATUS_FAILED;
+			(void) pthread_mutex_unlock(&zinfo->zinfo_mutex);
 			goto open_reply;
 		}
 		rele_dataset_on_error = 1;
@@ -1379,6 +1391,7 @@ open_zvol(int fd, zvol_info_t **zinfopp)
 			uzfs_rele_dataset(zv);
 		LOG_ERR("Failed to set granularity of metadata");
 		hdr.status = ZVOL_OP_STATUS_FAILED;
+		(void) pthread_mutex_unlock(&zinfo->zinfo_mutex);
 		goto open_reply;
 	}
 	/*
@@ -1392,6 +1405,7 @@ open_zvol(int fd, zvol_info_t **zinfopp)
 
 	zinfo->conn_closed = B_FALSE;
 	zinfo->is_io_ack_sender_created = B_TRUE;
+	zinfo->is_io_receiver_created = B_TRUE;
 	(void) pthread_mutex_unlock(&zinfo->zinfo_mutex);
 	thrd_arg = kmem_alloc(sizeof (thread_args_t), KM_SLEEP);
 	thrd_arg->fd = fd;
@@ -1519,6 +1533,7 @@ exit:
 	zinfo->io_ack_waiting = 0;
 
 	reinitialize_zv_state(zinfo->zv);
+	zinfo->is_io_receiver_created = B_FALSE;
 	uzfs_zinfo_drop_refcnt(zinfo);
 thread_exit:
 	close(fd);

--- a/tests/cbtest/gtest/test_zrepl_prot.cc
+++ b/tests/cbtest/gtest/test_zrepl_prot.cc
@@ -1263,6 +1263,8 @@ TEST(Misc, ZreplCheckpointInterval) {
 	ASSERT_NE(ionum_slow, 888);
 	ASSERT_EQ(ionum_fast, 888);
 
+	do_data_connection(datasock_slow.fd(), host_slow, port_slow, zvol_name_slow,
+	    4096, 1000);
 	datasock_slow.graceful_close();
 	datasock_fast.graceful_close();
 	graceful_close(control_fd);


### PR DESCRIPTION
To avoid multiple data connections, zrepl checks for metavolblocksize to be 0, as this will be set during the data connection formation.
When zrepl gets restarted, this variable will be set and then, data connection doesn't get formed at all.

This PR is to remove this check, and add other check by tracking io_receiver thread exit to avoid duplicate data connections.

Added testcase for this, which involves restarting zrepl and verifying for data connection.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>