### PR TITLE
ARC informed only 1/4 of phys_mem as all_mem

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -3999,7 +3999,7 @@ arc_all_memory(void)
 	return (ptob(totalram_pages));
 #endif /* CONFIG_HIGHMEM */
 #else
-	return (ptob(physmem) / 2);
+	return (ptob(physmem) / 4);
 #endif /* _KERNEL */
 }
 


### PR DESCRIPTION
Currently, ARC is informed half of phys_mem as available_mem, on assumption that, other half is sufficient for ongoing IOs/dbufs/ZIOs and all other allocation.
But, zrepl is ending up using more than the half, thus, causing node to hang or causing cluster to evict the pod.
This PR is to inform only quarter of phys_mem as available_mem, to be on safe side, till the analysis of entire memory requirement is done.
This is just an approximation based on ongoing writes and rebuild on the pool.
Signed-off-by: Vishnu Itta <vitta@mayadata.io>