### PR TITLE
New command `stats` for zfs to fetch ARC and ZVOL related statistics

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -106,6 +106,7 @@ static int zfs_do_holds(int argc, char **argv);
 static int zfs_do_release(int argc, char **argv);
 static int zfs_do_diff(int argc, char **argv);
 static int zfs_do_bookmark(int argc, char **argv);
+static int zfs_do_stats(int argc, char **argv);
 
 /*
  * Enable a reasonable set of defaults for libumem debugging on DEBUG builds.
@@ -153,6 +154,7 @@ typedef enum {
 	HELP_RELEASE,
 	HELP_DIFF,
 	HELP_BOOKMARK,
+	HELP_STATS,
 } zfs_help_t;
 
 typedef struct zfs_command {
@@ -206,6 +208,7 @@ static zfs_command_t command_table[] = {
 	{ "holds",	zfs_do_holds,		HELP_HOLDS		},
 	{ "release",	zfs_do_release,		HELP_RELEASE		},
 	{ "diff",	zfs_do_diff,		HELP_DIFF		},
+	{ "stats",	zfs_do_stats,		HELP_STATS		},
 };
 
 #define	NCOMMAND	(sizeof (command_table) / sizeof (command_table[0]))
@@ -326,6 +329,8 @@ get_usage(zfs_help_t idx)
 		    "[snapshot|filesystem]\n"));
 	case HELP_BOOKMARK:
 		return (gettext("\tbookmark <snapshot> <bookmark>\n"));
+	case HELP_STATS:
+		return (gettext("\tstats <volume>\n"));
 	}
 
 	abort();
@@ -7034,6 +7039,29 @@ zfs_do_bookmark(int argc, char **argv)
 usage:
 	usage(B_FALSE);
 	return (-1);
+}
+
+static int
+zfs_do_stats(int argc, char **argv)
+{
+	char *volname = NULL;
+	int err = 0;
+	nvlist_t *nvl, *result;
+
+	argc -= optind;
+	argv += optind;
+
+	nvl = fnvlist_alloc();
+	if (argc > 1)
+		volname = argv[0];
+
+	err = lzc_zfs_stats(nvl, &result);
+
+	dump_nvlist(result, 0);
+
+	nvlist_free(nvl);
+	nvlist_free(result);
+	return (err != 0);
 }
 
 int

--- a/include/data_conn.h
+++ b/include/data_conn.h
@@ -38,6 +38,7 @@ typedef struct rebuild_thread_arg {
 	int		fd;
 	char		ip[MAX_IP_LEN];
 	uint16_t	port;
+	rebuild_stats_t *rebuild_stats;
 } rebuild_thread_arg_t;
 
 typedef struct conn_acceptors {
@@ -61,8 +62,8 @@ int uzfs_zvol_get_ip(char *host, size_t host_len);
 void uzfs_zvol_io_conn_acceptor(void *arg);
 void init_zrepl(void);
 void remove_pending_cmds_to_ack(int fd, zvol_info_t *zinfo);
-zvol_io_cmd_t *zio_cmd_alloc(zvol_io_hdr_t *hdr, int fd);
-void zio_cmd_free(zvol_io_cmd_t **cmd);
+zvol_io_cmd_t *zio_cmd_alloc(zvol_info_t *zinfo, zvol_io_hdr_t *hdr, int fd);
+void zio_cmd_free(zvol_info_t *zinfo, zvol_io_cmd_t **cmd);
 int uzfs_zvol_socket_read(int fd, char *buf, uint64_t nbytes);
 int uzfs_zvol_read_header(int fd, zvol_io_hdr_t *hdr);
 int uzfs_zvol_socket_write(int fd, char *buf, uint64_t nbytes);

--- a/include/libuzfs.h
+++ b/include/libuzfs.h
@@ -66,7 +66,8 @@ typedef struct uzfs_monitor {
     _UZFS_IOC(ZFS_IOC_RECV_NEW, 1, 1, "resumable receive")                     \
     _UZFS_IOC(ZFS_IOC_SEND_PROGRESS, 0, 0, "print zfs send stats")             \
     _UZFS_IOC(ZFS_IOC_VDEV_ADD, 1, 0, "add vdev to the pool")                  \
-    _UZFS_IOC(ZFS_IOC_VDEV_REMOVE, 1, 0, "remove vdev from the pool")
+    _UZFS_IOC(ZFS_IOC_VDEV_REMOVE, 1, 0, "remove vdev from the pool")          \
+    _UZFS_IOC(ZFS_IOC_GET_STATS, 0, 0, "print zfs stats")
 
 #define	MAX_NVLIST_SRC_SIZE (128 * 1024 * 1024)
 

--- a/include/libzfs_core.h
+++ b/include/libzfs_core.h
@@ -92,8 +92,8 @@ boolean_t lzc_exists(const char *);
 
 int lzc_rollback(const char *, char *, int);
 int lzc_rollback_to(const char *, const char *);
-
 int lzc_sync(const char *, nvlist_t *, nvlist_t **);
+int lzc_zfs_stats(nvlist_t *, nvlist_t **);
 
 #ifdef	__cplusplus
 }

--- a/include/sys/arc.h
+++ b/include/sys/arc.h
@@ -265,6 +265,10 @@ void l2arc_fini(void);
 void l2arc_start(void);
 void l2arc_stop(void);
 
+#if defined(_UZFS)
+void uzfs_arc_stats(nvlist_t **);
+#endif
+
 #ifndef _KERNEL
 extern boolean_t arc_watch;
 #endif

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -1070,6 +1070,7 @@ typedef enum zfs_ioc {
 	ZFS_IOC_EVENTS_NEXT,
 	ZFS_IOC_EVENTS_CLEAR,
 	ZFS_IOC_EVENTS_SEEK,
+	ZFS_IOC_GET_STATS,
 
 	/*
 	 * FreeBSD - 1/64 numbers reserved.

--- a/include/uzfs_rebuilding.h
+++ b/include/uzfs_rebuilding.h
@@ -22,12 +22,33 @@
 #ifndef	_UZFS_REBUILDING_H
 #define	_UZFS_REBUILDING_H
 
+#include <sys/queue.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 #define	IO_DIFF_SNAPNAME		".io_snap"
 #define	REBUILD_SNAPSHOT_SNAPNAME	"rebuild_snap"
 #define	REBUILD_SNAPSHOT_CLONENAME	"rebuild_clone"
+
+/*
+ * rebuild statistics
+ */
+typedef struct rebuild_stats {
+	TAILQ_ENTRY(rebuild_stats) stat_next;
+
+	uint64_t offset;	/* offset from where rebuild is happening */
+	uint64_t len;		/* size of data being rebuild */
+	uint64_t io_seq;	/* minimum io sequence number */
+	/*
+	 * current offset only for helping replica
+	 * If Replica is rebuilding itself then running_offset should be 0
+	 */
+	uint64_t running_offset;
+	struct sockaddr_in target;	/* target replica info */
+} rebuild_stats_t;
 
 /*
  * API to compare metadata

--- a/include/uzfs_zap.h
+++ b/include/uzfs_zap.h
@@ -40,6 +40,9 @@ typedef struct {
 int uzfs_update_zap_entries(void *zv, const uzfs_zap_kv_t **kv_array,
     uint64_t n);
 int uzfs_read_zap_entry(void *zv, uzfs_zap_kv_t *entry);
+int uzfs_remove_zap_entries(void *zvol, const char *key);
+int uzfs_update_zap_key_name(void *zvol, const char *old_key,
+    const char *new_key);
 int uzfs_read_last_iter_txg(void *spa, uint64_t *val);
 void uzfs_update_txg_zap_thread(void *s);
 void uzfs_update_txg_interval(spa_t *spa, uint32_t timeout);

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -1048,3 +1048,13 @@ lzc_destroy_bookmarks(nvlist_t *bmarks, nvlist_t **errlist)
 
 	return (error);
 }
+
+int
+lzc_zfs_stats(nvlist_t *args, nvlist_t **result)
+{
+	int error;
+
+	error = lzc_ioctl(ZFS_IOC_GET_STATS, NULL, args, result);
+	return (error);
+
+}

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -7877,6 +7877,41 @@ l2arc_stop(void)
 	mutex_exit(&l2arc_feed_thr_lock);
 }
 
+#if defined(_UZFS)
+void
+uzfs_dump_arc_stats(nvlist_t **stat)
+{
+	nvlist_t *nv;
+
+	ASSERT(!*stat);
+
+	if (nvlist_alloc(&nv, NV_UNIQUE_NAME, 0)) {
+		printf("failed to alloc nvlist\n");
+		return;
+	}
+
+	nvlist_add_uint64(nv, "arc_size", arc_size);
+	nvlist_add_uint64(nv, "arc_p", arc_p);
+	nvlist_add_uint64(nv, "arc_c", arc_c);
+	nvlist_add_uint64(nv, "arc_c_min", arc_c_min);
+	nvlist_add_uint64(nv, "arc_c_max", arc_c_max);
+	nvlist_add_uint64(nv, "arc_no_grow", arc_no_grow);
+	nvlist_add_uint64(nv, "arc_tempreserve", arc_tempreserve);
+	nvlist_add_uint64(nv, "arc_loaned_bytes", arc_loaned_bytes);
+	nvlist_add_uint64(nv, "arc_meta_limit", arc_meta_limit);
+	nvlist_add_uint64(nv, "arc_dnode_limit", arc_dnode_limit);
+	nvlist_add_uint64(nv, "arc_meta_min", arc_meta_min);
+	nvlist_add_uint64(nv, "arc_meta_used", arc_meta_used);
+	nvlist_add_uint64(nv, "arc_meta_max", arc_meta_max);
+	nvlist_add_uint64(nv, "arc_dbuf_size", arc_dbuf_size);
+	nvlist_add_uint64(nv, "arc_dnode_size", arc_dnode_size);
+	nvlist_add_uint64(nv, "arc_bonus_size", arc_bonus_size);
+	nvlist_add_uint64(nv, "arc_need_free", arc_need_free);
+	nvlist_add_uint64(nv, "arc_sys_free", arc_sys_free);
+	*stat = nv;
+}
+#endif
+
 #if defined(_KERNEL) && defined(HAVE_SPL)
 EXPORT_SYMBOL(arc_buf_size);
 EXPORT_SYMBOL(arc_write);

--- a/tests/cbtest/gtest/test_zrepl_prot.cc
+++ b/tests/cbtest/gtest/test_zrepl_prot.cc
@@ -1272,7 +1272,7 @@ TEST(Misc, ZreplCheckpointInterval) {
 	ASSERT_NE(ionum_slow, 888);
 	ASSERT_EQ(ionum_fast, 888);
 	ASSERT_EQ(degraded_ionum_slow, 555);
-	ASSERT_EQ(degraded_ionum_fast, 555);
+	ASSERT_EQ(degraded_ionum_fast, 888);
 
 	do_data_connection(datasock_slow.fd(), host_slow, port_slow, zvol_name_slow,
 	    4096, 1000);


### PR DESCRIPTION
    - Adding a new command for zfs `stats` to display information about
      ARC consumption, ZVOL related information and rebuilding information.
      `zfs stats` will display information for all volumes.
    - Updating ZAP key `degraded_io_seq` to `running_io_seq`.

Sample output of `zfs stats` commands.
1. If REPLICA is in degraded mode
```
arc:
    arc_size: 1577768
    arc_p: 985179648
    arc_c: 1970359296
    arc_c_min: 985179648
    arc_c_max: 1970359296
    arc_no_grow: 0
    arc_tempreserve: 0
    arc_loaned_bytes: 0
    arc_meta_limit: 1477769472
    arc_dnode_limit: 147776947
    arc_meta_min: 16777216
    arc_meta_used: 1577768
    arc_meta_max: 1603912
    arc_dbuf_size: 28080
    arc_dnode_size: 84000
    arc_bonus_size: 11840
    arc_need_free: 0
    arc_sys_free: 0
zinfo:
    tpool/vol1:
        guid: 16694477751889199106
        mgmt ip: '172.18.0.101'
        mgmt port: 34224
        refcnt: 4
        timeout: 180
        running_ionum: 1087597
        checkpointed_ionum: 1061905
        degraded_checkpointed_ionum: 1087597
        checkpointed_time: 'Thu Jan  1 00:00:00 1970'
        read_req_received_cnt: 0
        write_req_received_cnt: 0
        sync_req_received_cnt: 0
        read_req_ack_cnt: 0
        write_req_ack_cnt: 0
        sync_req_ack_cnt: 0
        zio_cmd_inflight: 0
        state: 'online'
        zvol status: 'degraded'
        rebuild_bytes: 0
        rebuild count: 0
        rebuild done count: 0
        rebuild failed count: 0
        rebuild status: 'ZVOL_REBUILDING_INIT'
```
 2. If REPLICA is in rebuilding mode
```
arc:
    arc_size: 1807992
    arc_p: 985179648
    arc_c: 1970359296
    arc_c_min: 985179648
    arc_c_max: 1970359296
    arc_no_grow: 1
    arc_tempreserve: 0
    arc_loaned_bytes: 0
    arc_meta_limit: 1477769472
    arc_dnode_limit: 147776947
    arc_meta_min: 16777216
    arc_meta_used: 1742456
    arc_meta_max: 1752656
    arc_dbuf_size: 33696
    arc_dnode_size: 99600
    arc_bonus_size: 15040
    arc_need_free: 0
    arc_sys_free: 0
zinfo:
    tpool/vol1:
        guid: 4214613259133278938
        mgmt ip: '172.18.0.103'
        mgmt port: 56920
        refcnt: 5
        timeout: 180
        running_ionum: 1096984
        checkpointed_ionum: 1087407
        degraded_checkpointed_ionum: 1096984
        checkpointed_time: 'Thu Jan  1 00:00:00 1970'
        read_req_received_cnt: 0
        write_req_received_cnt: 1320
        sync_req_received_cnt: 0
        read_req_ack_cnt: 0
        write_req_ack_cnt: 0
        sync_req_ack_cnt: 0
        zio_cmd_inflight: 0
        state: 'online'
        zvol status: 'degraded'
        rebuild_bytes: 0
        rebuild count: 1
        rebuild done count: 0
        rebuild failed count: 0
        rebuild status: 'ZVOL_REBUILDING_IN_PROGRESS'
        Rebuild stats[0]:
            offset: 4495360
            size: 10240
            io_sequence: 1087407
            helping replica IP: '172.18.0.102'
            helping replica port: 3233
```

3. If REPLICA is helping other REPLICA to rebuild
```
arc:
    arc_size: 12073792
    arc_p: 985179648
    arc_c: 1970359296
    arc_c_min: 985179648
    arc_c_max: 1970359296
    arc_no_grow: 0
    arc_tempreserve: 0
    arc_loaned_bytes: 0
    arc_meta_limit: 1477769472
    arc_dnode_limit: 147776947
    arc_meta_min: 16777216
    arc_meta_used: 2865984
    arc_meta_max: 2866496
    arc_dbuf_size: 98496
    arc_dnode_size: 106800
    arc_bonus_size: 15680
    arc_need_free: 0
    arc_sys_free: 0
zinfo:
    tpool/vol1:
        guid: 12421833773398843414
        mgmt ip: '172.18.0.102'
        mgmt port: 57244
        refcnt: 5
        timeout: 180
        running_ionum: 1100486
        checkpointed_ionum: 1087597
        degraded_checkpointed_ionum: 1100486
        checkpointed_time: 'Thu Jan  1 00:00:00 1970'
        read_req_received_cnt: 1326
        write_req_received_cnt: 0
        sync_req_received_cnt: 0
        read_req_ack_cnt: 1326
        write_req_ack_cnt: 0
        sync_req_ack_cnt: 0
        zio_cmd_inflight: 0
        state: 'online'
        zvol status: 'degraded'
        rebuild_bytes: 0
        rebuild count: 0
        rebuild done count: 0
        rebuild failed count: 0
        rebuild status: 'ZVOL_REBUILDING_INIT'
        Rebuild stats[0]:
            offset: 4515840
            size: 10240
            io_sequence: 1087407
            completed: 6144
            target replica IP: '172.18.0.103'
            target replica port: 54946
```
Signed-off-by: mayank <mayank.patel@cloudbyte.com>