### PR TITLE
 [DE94]fix(zfs):zrepl crash during data conn break

### DIFF
--- a/include/gtest_utils.h
+++ b/include/gtest_utils.h
@@ -19,6 +19,7 @@
 
 namespace GtestUtils {
 
+void graceful_close(int sockfd);
 std::string execCmd(std::string const &zfsCmd, std::string const &args);
 std::string getCmdPath(std::string zfsCmd);
 int verify_buf(void *buf, int len, const char *pattern);

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -71,6 +71,7 @@ struct zvol_io_cmd_s;
 #if DEBUG
 typedef struct inject_delay_s {
 	int helping_replica_rebuild_step;
+	int pre_uzfs_write_data;
 } inject_delay_t;
 
 typedef struct inject_error_s {

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -1163,7 +1163,6 @@ reinitialize_zv_state(zvol_state_t *zv)
 {
 	if (zv == NULL)
 		return;
-	zv->zv_metavolblocksize = 0;
 
 	uzfs_zvol_set_status(zv, ZVOL_STATUS_DEGRADED);
 	uzfs_zvol_set_rebuild_status(zv, ZVOL_REBUILDING_INIT);

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -276,6 +276,14 @@ uzfs_zvol_worker(void *arg)
 	rebuild_cmd_req = hdr->flags & ZVOL_OP_FLAG_REBUILD;
 	read_metadata = hdr->flags & ZVOL_OP_FLAG_READ_METADATA;
 
+	if (zinfo->is_io_ack_sender_created == B_FALSE) {
+		if (!(rebuild_cmd_req && (hdr->opcode == ZVOL_OPCODE_WRITE)))
+			zio_cmd_free(&zio_cmd);
+		if (hdr->opcode == ZVOL_OPCODE_WRITE)
+			atomic_inc_64(&zinfo->write_req_received_cnt);
+		goto drop_refcount;
+	}
+
 	/*
 	 * For rebuild case, do not free zio_cmd
 	 */
@@ -1346,11 +1354,14 @@ exit:
 	LOG_INFO("Data connection for zvol %s closed on fd: %d",
 	    zinfo->name, fd);
 
+	(void) pthread_mutex_lock(&zinfo->zinfo_mutex);
+	zinfo->is_io_ack_sender_created = B_FALSE;
+	(void) pthread_mutex_unlock(&zinfo->zinfo_mutex);
+
 	remove_pending_cmds_to_ack(fd, zinfo);
 
 	(void) pthread_mutex_lock(&zinfo->zinfo_mutex);
 	zinfo->conn_closed = B_FALSE;
-	zinfo->is_io_ack_sender_created = B_FALSE;
 	(void) pthread_mutex_unlock(&zinfo->zinfo_mutex);
 
 	uzfs_zinfo_drop_refcnt(zinfo);
@@ -1604,7 +1615,7 @@ exit:
 	 * wait for ack thread to exit to avoid races with new
 	 * connections for the same zinfo
 	 */
-	while (zinfo->conn_closed && zinfo->is_io_ack_sender_created) {
+	while (zinfo->conn_closed || zinfo->is_io_ack_sender_created) {
 		(void) pthread_mutex_unlock(&zinfo->zinfo_mutex);
 		usleep(1000);
 		(void) pthread_mutex_lock(&zinfo->zinfo_mutex);
@@ -1615,6 +1626,7 @@ exit:
 
 	zinfo->io_ack_waiting = 0;
 
+	taskq_wait(zinfo->uzfs_zvol_taskq);
 	reinitialize_zv_state(zinfo->zv);
 	zinfo->is_io_receiver_created = B_FALSE;
 	uzfs_zinfo_drop_refcnt(zinfo);

--- a/tests/cbtest/gtest/gtest_utils.cc
+++ b/tests/cbtest/gtest/gtest_utils.cc
@@ -16,6 +16,25 @@
 #define	POOL_SIZE	(100 * 1024 * 1024)
 #define	ZVOL_SIZE	(10 * 1024 * 1024)
 
+/*
+ * We have to wait for the other end to close the connection, because the
+ * next test case could initiate a new connection before this one is
+ * fully closed and cause a handshake error. Or it could result in EBUSY
+ * error when destroying zpool if it is not released in time by zrepl.
+ */
+void GtestUtils::graceful_close(int sockfd)
+{
+	int rc;
+	char val;
+
+	if (sockfd < 0)
+		return;
+	shutdown(sockfd, SHUT_WR);
+	rc = read(sockfd, &val, sizeof (val));
+	ASSERT_EQ(rc, 0);
+	close(sockfd);
+}
+
 void GtestUtils::init_buf(void *buf, int len, const char *pattern) {
 	int i;
 	char c;

--- a/tests/cbtest/gtest/test_zrepl_prot.cc
+++ b/tests/cbtest/gtest/test_zrepl_prot.cc
@@ -406,25 +406,6 @@ static void transition_zvol_to_online(int &ioseq, int control_fd,
 	EXPECT_EQ(hdr_in.len, 0);
 }
 
-/*
- * We have to wait for the other end to close the connection, because the
- * next test case could initiate a new connection before this one is
- * fully closed and cause a handshake error. Or it could result in EBUSY
- * error when destroying zpool if it is not released in time by zrepl.
- */
-static void graceful_close(int sockfd)
-{
-	int rc;
-	char val;
-
-	if (sockfd < 0)
-		return;
-	shutdown(sockfd, SHUT_WR);
-	rc = read(sockfd, &val, sizeof (val));
-	ASSERT_EQ(rc, 0);
-	close(sockfd);
-}
-
 static std::string getPoolState(std::string pname)
 {
 	return (execCmd("zpool", std::string("list -Ho health ") + pname));


### PR DESCRIPTION
When data connection breaks, volume's metavolblocksize is made to 0. If any IOs are pending during this time, executing them will use this and causes floating point exception.

This PR handles it by:
- waiting for all IOs in taskq as part of data connection breakage handling
- error out ongoing IOs if data connection is broken
- not to set metavolblocksize to 0

Also, this PR includes fix for strict name comparison during pool deletion, and checks to catch any change in tgt_block_size.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>