### PR TITLE
feat(zfs): store snapshot IO number in ZAP as healthy_ioseq

### DIFF
--- a/cmd/uzfs_test/uzfs_test_rebuilding.c
+++ b/cmd/uzfs_test/uzfs_test_rebuilding.c
@@ -380,6 +380,25 @@ rebuild_replica_thread(void *arg)
 }
 
 static void
+uzfs_zvol_store_last_committed_io_no(zvol_state_t *zv, char *key,
+    uint64_t io_seq)
+{
+	uzfs_zap_kv_t *kv_array[0];
+	uzfs_zap_kv_t zap;
+
+	if (io_seq == 0)
+		return;
+
+	zap.key = key;
+	zap.value = io_seq;
+	zap.size = sizeof (io_seq);
+
+	kv_array[0] = &zap;
+	VERIFY0(uzfs_update_zap_entries(zv,
+	    (const uzfs_zap_kv_t **) kv_array, 1));
+}
+
+static void
 replica_writer_thread(void *arg)
 {
 	worker_args_t *warg = (worker_args_t *)arg;

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -108,10 +108,24 @@ typedef struct zvol_info_s {
 
 	uint32_t	timeout;	/* iSCSI timeout val for this zvol */
 	uint64_t	zvol_guid;
+
+	/* Highest IO num of received write IOs */
 	uint64_t	running_ionum;
-	uint64_t	stored_healthy_ionum; /* healthy_io_num stored in zap */
+
+	/* IO num that is stored to ZAP as healthy_ionum when vol is healthy */
+	uint64_t	stored_healthy_ionum;
+
+	/*
+	 * IO num that will be written to ZAP as healthy_ionum
+	 * This tells that all IOs lesser than this are committed to replica
+	 * So, running_ionum will be made as checkpointed_ionum and will be
+	 * stored to ZAP after 'update_ionum_interval' time period.
+	 */
 	uint64_t	checkpointed_ionum;
+
+	/* running_ionum that is stored to ZAP when vol is degraded */
 	uint64_t	degraded_checkpointed_ionum;
+
 	time_t		checkpointed_time;	/* time of the last chkpoint */
 	uint64_t	rebuild_cmd_queued_cnt;
 	uint64_t	rebuild_cmd_acked_cnt;

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -109,6 +109,7 @@ typedef struct zvol_info_s {
 	uint32_t	timeout;	/* iSCSI timeout val for this zvol */
 	uint64_t	zvol_guid;
 	uint64_t	running_ionum;
+	uint64_t	stored_healthy_ionum; /* healthy_io_num stored in zap */
 	uint64_t	checkpointed_ionum;
 	uint64_t	degraded_checkpointed_ionum;
 	time_t		checkpointed_time;	/* time of the last chkpoint */
@@ -129,6 +130,7 @@ typedef struct zvol_info_s {
 	 */
 	pthread_mutex_t	zinfo_mutex;
 	pthread_cond_t	io_ack_cond;
+	pthread_mutex_t	zinfo_ionum_mutex;
 
 	/* All cmds after execution will go here for ack */
 	STAILQ_HEAD(, zvol_io_cmd_s)	complete_queue;
@@ -192,8 +194,10 @@ extern zvol_info_t *uzfs_zinfo_lookup(const char *name);
 extern void uzfs_zinfo_replay_zil_all(void);
 extern int uzfs_zinfo_destroy(const char *ds_name, spa_t *spa);
 uint64_t uzfs_zvol_get_last_committed_io_no(zvol_state_t *zv, char *key);
-void uzfs_zvol_store_last_committed_io_no(zvol_state_t *zv,
-    char *key, uint64_t io_seq);
+void uzfs_zvol_store_last_committed_healthy_io_no(zvol_info_t *zinfo,
+    uint64_t io_seq);
+void uzfs_zvol_store_last_committed_degraded_io_no(zvol_info_t *zv,
+    uint64_t io_seq);
 extern int set_socket_keepalive(int sfd);
 extern int create_and_bind(const char *port, int bind_needed,
     boolean_t nonblocking);

--- a/lib/libzpool/zrepl_mgmt.c
+++ b/lib/libzpool/zrepl_mgmt.c
@@ -462,7 +462,7 @@ uzfs_zvol_store_last_committed_healthy_io_no(zvol_info_t *zinfo,
 		return;
 	}
 	zinfo->stored_healthy_ionum = io_seq;
-	pthread_mutex_unlock(&zinfo->zinfo_ionum_mutex);
 	uzfs_zvol_store_last_committed_io_no(zinfo->main_zv,
 	    HEALTHY_IO_SEQNUM, io_seq);
+	pthread_mutex_unlock(&zinfo->zinfo_ionum_mutex);
 }

--- a/lib/libzpool/zrepl_mgmt.c
+++ b/lib/libzpool/zrepl_mgmt.c
@@ -282,9 +282,9 @@ uzfs_zinfo_lookup(const char *name)
 static void
 uzfs_zinfo_init_mutex(zvol_info_t *zinfo)
 {
-
 	(void) pthread_mutex_init(&zinfo->zinfo_mutex, NULL);
 	(void) pthread_cond_init(&zinfo->io_ack_cond, NULL);
+	(void) pthread_mutex_init(&zinfo->zinfo_ionum_mutex, NULL);
 }
 
 static void
@@ -293,6 +293,7 @@ uzfs_zinfo_destroy_mutex(zvol_info_t *zinfo)
 
 	(void) pthread_mutex_destroy(&zinfo->zinfo_mutex);
 	(void) pthread_cond_destroy(&zinfo->io_ack_cond);
+	(void) pthread_mutex_destroy(&zinfo->zinfo_ionum_mutex);
 }
 
 int
@@ -416,12 +417,16 @@ uzfs_zvol_get_last_committed_io_no(zvol_state_t *zv, char *key)
 	return (zap.value);
 }
 
-void
+static void
 uzfs_zvol_store_last_committed_io_no(zvol_state_t *zv, char *key,
     uint64_t io_seq)
 {
 	uzfs_zap_kv_t *kv_array[0];
 	uzfs_zap_kv_t zap;
+
+	if (io_seq == 0)
+		return;
+
 	zap.key = key;
 	zap.value = io_seq;
 	zap.size = sizeof (io_seq);
@@ -429,4 +434,35 @@ uzfs_zvol_store_last_committed_io_no(zvol_state_t *zv, char *key,
 	kv_array[0] = &zap;
 	VERIFY0(uzfs_update_zap_entries(zv,
 	    (const uzfs_zap_kv_t **) kv_array, 1));
+}
+
+void
+uzfs_zvol_store_last_committed_degraded_io_no(zvol_info_t *zinfo,
+    uint64_t io_seq)
+{
+	uzfs_zvol_store_last_committed_io_no(zinfo->main_zv,
+	    DEGRADED_IO_SEQNUM, io_seq);
+}
+
+/*
+ * Stores given io_seq as healthy_io_seqnum if previously committed is
+ * less than given io_seq.
+ * Updates in-memory committed io_num.
+ */
+void
+uzfs_zvol_store_last_committed_healthy_io_no(zvol_info_t *zinfo,
+    uint64_t io_seq)
+{
+	if (io_seq == 0)
+		return;
+
+	pthread_mutex_lock(&zinfo->zinfo_ionum_mutex);
+	if (zinfo->stored_healthy_ionum > io_seq) {
+		pthread_mutex_unlock(&zinfo->zinfo_ionum_mutex);
+		return;
+	}
+	zinfo->stored_healthy_ionum = io_seq;
+	pthread_mutex_unlock(&zinfo->zinfo_ionum_mutex);
+	uzfs_zvol_store_last_committed_io_no(zinfo->main_zv,
+	    HEALTHY_IO_SEQNUM, io_seq);
 }

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -619,6 +619,12 @@ exit:
 	zk_thread_exit();
 }
 
+#define	STORE_LAST_COMMITTED_HEALTHY_IO_NO	\
+    uzfs_zvol_store_last_committed_healthy_io_no
+
+#define	STORE_LAST_COMMITTED_DEGRADED_IO_NO	\
+    uzfs_zvol_store_last_committed_degraded_io_no
+
 void
 uzfs_zvol_timer_thread(void)
 {
@@ -665,10 +671,8 @@ uzfs_zvol_timer_thread(void)
 					    "%lu on %s",
 					    zinfo->checkpointed_ionum,
 					    zinfo->name);
-					uzfs_zvol_store_last_committed_io_no(
-					    zinfo->main_zv,
-					    HEALTHY_IO_SEQNUM,
-					    zinfo->checkpointed_ionum);
+					STORE_LAST_COMMITTED_HEALTHY_IO_NO(
+					    zinfo, zinfo->checkpointed_ionum);
 					zinfo->checkpointed_ionum =
 					    zinfo->running_ionum;
 					zinfo->checkpointed_time = now;
@@ -689,9 +693,8 @@ uzfs_zvol_timer_thread(void)
 					    "%lu on %s for degraded mode",
 					    zinfo->degraded_checkpointed_ionum,
 					    zinfo->name);
-					uzfs_zvol_store_last_committed_io_no(
-					    zinfo->main_zv,
-					    DEGRADED_IO_SEQNUM,
+					STORE_LAST_COMMITTED_DEGRADED_IO_NO(
+					    zinfo,
 					    zinfo->degraded_checkpointed_ionum);
 					zinfo->degraded_checkpointed_time =
 					    now;

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -685,7 +685,7 @@ uzfs_zvol_timer_thread(void)
 				next_check = zinfo->degraded_checkpointed_time
 				    + DEGRADED_IO_UPDATE_INTERVAL;
 				if (next_check <= now &&
-				    zinfo->degraded_checkpointed_ionum !=
+				    zinfo->degraded_checkpointed_ionum <
 				    zinfo->running_ionum) {
 					zinfo->degraded_checkpointed_ionum =
 					    zinfo->running_ionum;

--- a/tests/cbtest/gtest/test_uzfs.cc
+++ b/tests/cbtest/gtest/test_uzfs.cc
@@ -624,6 +624,8 @@ TEST(SnapCreate, SnapCreateSuccess) {
 	/* Create snapshot */
 	EXPECT_EQ(0, uzfs_zvol_create_snapshot_update_zap(zinfo,
 	    snapname, snapshot_io_num));
+	EXPECT_EQ(999, uzfs_zvol_get_last_committed_io_no(zinfo->main_zv,
+	    (char *)HEALTHY_IO_SEQNUM));
 }
 
 /* Retrieve Snap dataset and IO number */

--- a/tests/cbtest/gtest/test_uzfs.cc
+++ b/tests/cbtest/gtest/test_uzfs.cc
@@ -611,25 +611,8 @@ TEST(SnapCreate, SnapCreateFailureHigherIO) {
 	    snapname, snapshot_io_num));
 }
 
-/* Snap create failure */
-TEST(SnapCreate, SnapCreateFailure) {
-
-	/*
-	 * By default volume state is marked downgraded
-	 * so updation of ZAP attribute would fail
-	 */
-	uzfs_zvol_set_rebuild_status(zinfo->main_zv, ZVOL_REBUILDING_INIT);
-	uzfs_zvol_set_status(zinfo->main_zv, ZVOL_STATUS_DEGRADED);
-
-	zinfo->running_ionum = snapshot_io_num -1;
-	/* Create snapshot */
-	EXPECT_EQ(-1, uzfs_zvol_create_snapshot_update_zap(zinfo,
-	    snapname, snapshot_io_num));
-}
-
 /* Snap create success */
 TEST(SnapCreate, SnapCreateSuccess) {
-
 	/*
 	 * Set volume state to healthy so that we can
 	 * update ZAP attribute and take snapshot


### PR DESCRIPTION
This PR is to store io_seq received in SNAPCREATE opcode as healthy_ioseq in its ZAP.
Also, added checks to store higher io_seq in ZAP everytime.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>