### PR TITLE
[TA2331] feat(snaprebuild): handling snapshot rebuild

### DIFF
--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -93,9 +93,10 @@ typedef struct zvol_info_s {
 	/* Logical Unit related fields */
 	zvol_info_state_t	state;
 	char 		name[MAXPATHLEN];
-	zvol_state_t	*main_zv;
-	zvol_state_t	*clone_zv;
-	zvol_state_t	*snap_zv;
+	zvol_state_t	*main_zv; // original volume
+	zvol_state_t	*clone_zv; // cloned volume for rebuilding
+	zvol_state_t	*snap_zv; // snap volume from where clone is created
+	zvol_state_t    *rebuild_zv; // current snapshot which is rebuilding
 	uint64_t	refcnt;
 
 	union {

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -271,7 +271,7 @@ uzfs_zvol_worker(void *arg)
 {
 	zvol_io_cmd_t	*zio_cmd;
 	zvol_info_t	*zinfo;
-	zvol_state_t	*zvol_state;
+	zvol_state_t	*zvol_state, *read_zv;
 	zvol_io_hdr_t 	*hdr;
 	metadata_desc_t	**metadata_desc;
 	int		rc = 0;
@@ -318,7 +318,21 @@ uzfs_zvol_worker(void *arg)
 	}
 	switch (hdr->opcode) {
 		case ZVOL_OPCODE_READ:
-			rc = uzfs_read_data(zinfo->main_zv,
+			read_zv = zinfo->main_zv;
+			if (rebuild_cmd_req) {
+				/*
+				 * if we are rebuilding, we have
+				 * to read the data from the snapshot
+				 */
+				if (zinfo->rebuild_zv) {
+					read_zv = zinfo->rebuild_zv;
+				} else {
+					rc = -1;
+					break;
+				}
+			}
+
+			rc = uzfs_read_data(read_zv,
 			    (char *)zio_cmd->buf,
 			    hdr->offset, hdr->len,
 			    metadata_desc);
@@ -1018,6 +1032,7 @@ uzfs_zvol_rebuild_scanner_callback(off_t offset, size_t len,
 	/* Take refcount for uzfs_zvol_worker to work on it */
 	uzfs_zinfo_take_refcnt(zinfo);
 	zio_cmd->zinfo = zinfo;
+	zinfo->rebuild_zv = zv;
 
 	/*
 	 * Any error in uzfs_zvol_worker will send FAILURE status to degraded

--- a/tests/cbtest/gtest/test_zrepl_prot.cc
+++ b/tests/cbtest/gtest/test_zrepl_prot.cc
@@ -1014,16 +1014,7 @@ TEST_F(ZreplDataTest, RebuildFlag) {
 
 	/* read the block with rebuild flag */
 	read_data_start(m_datasock1.fd(), m_ioseq1, 0, sizeof (buf), &hdr_in, ZVOL_OP_FLAG_REBUILD);
-	ASSERT_EQ(hdr_in.status, ZVOL_OP_STATUS_OK);
-	ASSERT_EQ(hdr_in.len, sizeof (read_hdr) + sizeof (buf));
-	rc = read(m_datasock1.fd(), &read_hdr, sizeof (read_hdr));
-	ASSERT_ERRNO("read", rc >= 0);
-	ASSERT_EQ(rc, sizeof (read_hdr));
-	ASSERT_EQ(read_hdr.io_num, 654);
-	ASSERT_EQ(read_hdr.len, sizeof (buf));
-	rc = read(m_datasock1.fd(), buf, sizeof (buf));
-	ASSERT_ERRNO("read", rc >= 0);
-	ASSERT_EQ(rc, sizeof (buf));
+	ASSERT_EQ(hdr_in.status, ZVOL_OP_STATUS_FAILED);
 	m_datasock1.graceful_close();
 	m_datasock2.graceful_close();
 	sleep(5);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
While rebuilding the snapshot, we should read from the
snapshot. Currently we are rebuilding from the active dataset.

Introduced a rebuild_zv which will point to the snapshot and
we will use this while reading the rebuild data.