### PR TITLE
[TA2924] API(snap_rebuild): returns zv of snap which got created just after given ionum

### DIFF
--- a/include/mgmt_conn.h
+++ b/include/mgmt_conn.h
@@ -107,6 +107,7 @@ int finish_async_tasks(void);
 
 int uzfs_zvol_create_snapshot_update_zap(zvol_info_t *zinfo,
     char *snapname, uint64_t snapshot_io_num);
+zvol_state_t *uzfs_zvol_get_snap_zv(zvol_info_t *zinfo, uint64_t ionum);
 
 int uzfs_zvol_get_snap_dataset_with_io(zvol_info_t *zinfo,
     char *snapname, uint64_t *snapshot_io_num, zvol_state_t **snap_zv);

--- a/include/mgmt_conn.h
+++ b/include/mgmt_conn.h
@@ -107,7 +107,7 @@ int finish_async_tasks(void);
 
 int uzfs_zvol_create_snapshot_update_zap(zvol_info_t *zinfo,
     char *snapname, uint64_t snapshot_io_num);
-zvol_state_t *uzfs_zvol_get_snap_zv(zvol_info_t *zinfo, uint64_t ionum);
+zvol_state_t *uzfs_get_snap_zv_ionum(zvol_info_t *zinfo, uint64_t ionum);
 
 int uzfs_zvol_get_snap_dataset_with_io(zvol_info_t *zinfo,
     char *snapname, uint64_t *snapshot_io_num, zvol_state_t **snap_zv);

--- a/include/uzfs_mgmt.h
+++ b/include/uzfs_mgmt.h
@@ -46,6 +46,8 @@ extern void uzfs_fini(void);
 extern uint64_t uzfs_random(uint64_t);
 extern int uzfs_hold_dataset(zvol_state_t *zv);
 extern void uzfs_rele_dataset(zvol_state_t *zv);
+int get_snapshot_zv(zvol_state_t *zv, char *snap_name, zvol_state_t **snap_zv);
+extern void destroy_snapshot_zv(zvol_state_t *zv, char *snap_name);
 
 int uzfs_pool_create(const char *name, char *path, spa_t **spa);
 #ifdef __cplusplus

--- a/lib/libzpool/uzfs_mgmt.c
+++ b/lib/libzpool/uzfs_mgmt.c
@@ -20,6 +20,7 @@
  */
 
 #include <sys/dmu_objset.h>
+#include <sys/dsl_destroy.h>
 #include <sys/zap.h>
 #include <sys/dsl_prop.h>
 #include <sys/uzfs_zvol.h>
@@ -553,6 +554,61 @@ uzfs_zvol_create_minors(spa_t *spa, const char *name)
 	strncpy(pool_name, name, MAXNAMELEN);
 	dmu_objset_find(pool_name, uzfs_zvol_create_cb, NULL, DS_FIND_CHILDREN);
 	kmem_free(pool_name, MAXNAMELEN);
+}
+
+int
+get_snapshot_zv(zvol_state_t *zv, char *snap_name, zvol_state_t **snap_zv)
+{
+	char *dataset;
+	int ret = 0;
+
+	dataset = kmem_asprintf("%s@%s", strchr(zv->zv_name, '/') + 1,
+	    snap_name);
+
+	ret = uzfs_open_dataset(zv->zv_spa, dataset, snap_zv);
+	if (ret == ENOENT) {
+		ret = dmu_objset_snapshot_one(zv->zv_name, snap_name);
+		if (ret) {
+			LOG_ERR("Failed to create snapshot %s@%s: %d",
+			    zv->zv_name, snap_name, ret);
+			strfree(dataset);
+			return (ret);
+		}
+
+		ret = uzfs_open_dataset(zv->zv_spa, dataset, snap_zv);
+		if (ret == 0) {
+			ret = uzfs_hold_dataset(*snap_zv);
+			if (ret != 0) {
+				LOG_ERR("Failed to hold snapshot: %d", ret);
+				uzfs_close_dataset(*snap_zv);
+			}
+		}
+		else
+			LOG_ERR("Failed to open snapshot: %d", ret);
+	} else if (ret == 0) {
+		LOG_INFO("holding already available snapshot %s@%s",
+		    zv->zv_name, snap_name);
+		ret = uzfs_hold_dataset(*snap_zv);
+		if (ret != 0) {
+			LOG_ERR("Failed to hold already existing snapshot: %d",
+			    ret);
+			uzfs_close_dataset(*snap_zv);
+		}
+	} else
+		LOG_ERR("Failed to open snapshot: %d", ret);
+
+	strfree(dataset);
+	return (ret);
+}
+
+void
+destroy_snapshot_zv(zvol_state_t *zv, char *snap_name)
+{
+	char *dataset;
+
+	dataset = kmem_asprintf("%s@%s", zv->zv_name, snap_name);
+	(void) dsl_destroy_snapshot(dataset, B_FALSE);
+	strfree(dataset);
 }
 
 /* uZFS Zvol destroy call back function */

--- a/lib/libzpool/zrepl_mgmt.c
+++ b/lib/libzpool/zrepl_mgmt.c
@@ -380,7 +380,7 @@ uzfs_zinfo_init(void *zv, const char *ds_name, nvlist_t *create_props)
 	strlcpy(zinfo->name, ds_name, MAXNAMELEN);
 	zinfo->main_zv = zv;
 	zinfo->state = ZVOL_INFO_STATE_ONLINE;
-	/* iSCSI target will overwrite this value during handshake */
+	/* iSCSI target will overwrite this value (in sec) during handshake */
 	zinfo->update_ionum_interval = 6000;
 	/* Update zvol list */
 	uzfs_insert_zinfo_list(zinfo);
@@ -409,6 +409,7 @@ uint64_t
 uzfs_zvol_get_last_committed_io_no(zvol_state_t *zv, char *key)
 {
 	uzfs_zap_kv_t zap;
+
 	zap.key = key;
 	zap.value = 0;
 	zap.size = sizeof (uint64_t);
@@ -418,7 +419,7 @@ uzfs_zvol_get_last_committed_io_no(zvol_state_t *zv, char *key)
 }
 
 static void
-uzfs_zvol_store_last_committed_io_no(zvol_state_t *zv, char *key,
+uzfs_zvol_store_kv_pair(zvol_state_t *zv, char *key,
     uint64_t io_seq)
 {
 	uzfs_zap_kv_t *kv_array[0];
@@ -440,7 +441,7 @@ void
 uzfs_zvol_store_last_committed_degraded_io_no(zvol_info_t *zinfo,
     uint64_t io_seq)
 {
-	uzfs_zvol_store_last_committed_io_no(zinfo->main_zv,
+	uzfs_zvol_store_kv_pair(zinfo->main_zv,
 	    DEGRADED_IO_SEQNUM, io_seq);
 }
 
@@ -462,7 +463,7 @@ uzfs_zvol_store_last_committed_healthy_io_no(zvol_info_t *zinfo,
 		return;
 	}
 	zinfo->stored_healthy_ionum = io_seq;
-	uzfs_zvol_store_last_committed_io_no(zinfo->main_zv,
+	uzfs_zvol_store_kv_pair(zinfo->main_zv,
 	    HEALTHY_IO_SEQNUM, io_seq);
 	pthread_mutex_unlock(&zinfo->zinfo_ionum_mutex);
 }

--- a/lib/libzrepl/mgmt_conn.c
+++ b/lib/libzrepl/mgmt_conn.c
@@ -640,9 +640,11 @@ uzfs_zvol_create_snapshot_update_zap(zvol_info_t *zinfo,
 /*
  * Returns zv of snap that is just higher than given ionum
  * If no such snap exists, it returns NULL
+ * Note: caller should do uzfs_close_dataset of zv, and,
+ * caller need to take care of any ongoing snap requests
  */
 zvol_state_t *
-uzfs_zvol_get_snap_zv(zvol_info_t *zinfo, uint64_t ionum)
+uzfs_get_snap_zv_ionum(zvol_info_t *zinfo, uint64_t ionum)
 {
 	if ((zinfo == NULL) || (zinfo->main_zv == NULL) ||
 	    (zinfo->main_zv->zv_objset == NULL))

--- a/lib/libzrepl/mgmt_conn.c
+++ b/lib/libzrepl/mgmt_conn.c
@@ -636,6 +636,55 @@ uzfs_zvol_create_snapshot_update_zap(zvol_info_t *zinfo,
 }
 
 /*
+ * Returns zv of snap that is just higher than given ionum
+ * If no such snap exists, it returns NULL
+ */
+zvol_state_t *
+uzfs_zvol_get_snap_zv(zvol_info_t *zinfo, uint64_t ionum)
+{
+	if ((zinfo == NULL) || (zinfo->main_zv == NULL) ||
+	    (zinfo->main_zv->zv_objset == NULL))
+		return (NULL);
+
+	uint64_t obj = 0, cookie = 0;
+	zvol_state_t *zv = zinfo->main_zv;
+	zvol_state_t *snap_zv = NULL;
+	zvol_state_t *smallest_higher_snapzv = NULL;
+	objset_t *os = zv->zv_objset;
+	char snapname[MAXNAMELEN];
+	uint64_t healthy_ionum, smallest_higher_ionum = 0;
+	int error;
+
+	while (1) {
+		dsl_pool_config_enter(spa_get_dsl(zv->zv_spa), FTAG);
+		error = dmu_snapshot_list_next(os, sizeof (snapname) - 1,
+		    snapname, &obj, &cookie, NULL);
+		dsl_pool_config_exit(spa_get_dsl(zv->zv_spa), FTAG);
+
+		if (error) {
+			if (error == ENOENT)
+				error = 0;
+			break;
+		}
+		error = get_snapshot_zv(zv, snapname, &snap_zv);
+		if (error)
+			break;
+		healthy_ionum = uzfs_zvol_get_last_committed_io_no(snap_zv,
+		    HEALTHY_IO_SEQNUM);
+		if ((healthy_ionum > ionum) &&
+		    ((smallest_higher_snapzv == NULL) ||
+		    (smallest_higher_ionum > healthy_ionum))) {
+			smallest_higher_ionum = healthy_ionum;
+			if (smallest_higher_snapzv != NULL)
+				uzfs_close_dataset(smallest_higher_snapzv);
+			smallest_higher_snapzv = snap_zv;
+		} else
+			uzfs_close_dataset(snap_zv);
+	}
+	return (smallest_higher_snapzv);
+}
+
+/*
  * For a given snap name, get snap dataset and IO number stored in ZAP
  * Input: zinfo, snap
  * Output: snapshot_io_num, snap_zv

--- a/tests/cbtest/gtest/test_uzfs.cc
+++ b/tests/cbtest/gtest/test_uzfs.cc
@@ -727,22 +727,22 @@ TEST(GetSnapFromIO, GetDestroySnap) {
 	zvol_state_t *zv;
 	int ret;
 
-	zv = uzfs_zvol_get_snap_zv(zinfo, 1998);
+	zv = uzfs_get_snap_zv_ionum(zinfo, 1998);
 	ret = strcmp(zv->zv_name, "pool1/vol1@snapa");
 	EXPECT_EQ(ret, 0);
 	uzfs_close_dataset(zv);
 
-	zv = uzfs_zvol_get_snap_zv(zinfo, 1999);
+	zv = uzfs_get_snap_zv_ionum(zinfo, 1999);
 	ret = strcmp(zv->zv_name, "pool1/vol1@snapb");
 	EXPECT_EQ(ret, 0);
 	uzfs_close_dataset(zv);
 
-	zv = uzfs_zvol_get_snap_zv(zinfo, 3000);
+	zv = uzfs_get_snap_zv_ionum(zinfo, 3000);
 	ret = strcmp(zv->zv_name, "pool1/vol1@snapc");
 	EXPECT_EQ(ret, 0);
 	uzfs_close_dataset(zv);
 
-	zv = uzfs_zvol_get_snap_zv(zinfo, 3999);
+	zv = uzfs_get_snap_zv_ionum(zinfo, 3999);
 	ret = (zv == NULL) ? 0 : 1;
 	EXPECT_EQ(ret, 0);
 

--- a/tests/cbtest/gtest/test_uzfs.cc
+++ b/tests/cbtest/gtest/test_uzfs.cc
@@ -613,6 +613,9 @@ TEST(SnapCreate, SnapCreateFailureHigherIO) {
 
 /* Snap create success */
 TEST(SnapCreate, SnapCreateSuccess) {
+	char *snapname1 = (char *)"snapa";
+	char *snapname2 = (char *)"snapb";
+	char *snapname3 = (char *)"snapc";
 	/*
 	 * Set volume state to healthy so that we can
 	 * update ZAP attribute and take snapshot
@@ -621,11 +624,55 @@ TEST(SnapCreate, SnapCreateSuccess) {
 	uzfs_zvol_set_status(zinfo->main_zv, ZVOL_STATUS_HEALTHY);
 
 	zinfo->running_ionum = snapshot_io_num -1;
+
 	/* Create snapshot */
 	EXPECT_EQ(0, uzfs_zvol_create_snapshot_update_zap(zinfo,
 	    snapname, snapshot_io_num));
 	EXPECT_EQ(999, uzfs_zvol_get_last_committed_io_no(zinfo->main_zv,
 	    (char *)HEALTHY_IO_SEQNUM));
+
+	EXPECT_EQ(0, uzfs_zvol_create_snapshot_update_zap(zinfo,
+	    snapname1, 2000));
+	EXPECT_EQ(1999, uzfs_zvol_get_last_committed_io_no(zinfo->main_zv,
+	    (char *)HEALTHY_IO_SEQNUM));
+
+	EXPECT_EQ(0, uzfs_zvol_create_snapshot_update_zap(zinfo,
+	    snapname2, 3000));
+	EXPECT_EQ(2999, uzfs_zvol_get_last_committed_io_no(zinfo->main_zv,
+	    (char *)HEALTHY_IO_SEQNUM));
+
+	EXPECT_EQ(0, uzfs_zvol_create_snapshot_update_zap(zinfo,
+	    snapname3, 4000));
+	EXPECT_EQ(3999, uzfs_zvol_get_last_committed_io_no(zinfo->main_zv,
+	    (char *)HEALTHY_IO_SEQNUM));
+}
+
+TEST(GetSnapFromIO, GetDestroySnap) {
+	zvol_state_t *zv;
+	int ret;
+
+	zv = uzfs_zvol_get_snap_zv(zinfo, 1998);
+	ret = strcmp(zv->zv_name, "pool1/vol1@snapa");
+	EXPECT_EQ(ret, 0);
+	uzfs_close_dataset(zv);
+
+	zv = uzfs_zvol_get_snap_zv(zinfo, 1999);
+	ret = strcmp(zv->zv_name, "pool1/vol1@snapb");
+	EXPECT_EQ(ret, 0);
+	uzfs_close_dataset(zv);
+
+	zv = uzfs_zvol_get_snap_zv(zinfo, 3000);
+	ret = strcmp(zv->zv_name, "pool1/vol1@snapc");
+	EXPECT_EQ(ret, 0);
+	uzfs_close_dataset(zv);
+
+	zv = uzfs_zvol_get_snap_zv(zinfo, 3999);
+	ret = (zv == NULL) ? 0 : 1;
+	EXPECT_EQ(ret, 0);
+
+	EXPECT_EQ(0, dsl_destroy_snapshot("pool1/vol1@snapb", B_FALSE));
+	EXPECT_EQ(0, dsl_destroy_snapshot("pool1/vol1@snapa", B_FALSE));
+	EXPECT_EQ(0, dsl_destroy_snapshot("pool1/vol1@snapc", B_FALSE));
 }
 
 /* Retrieve Snap dataset and IO number */


### PR DESCRIPTION
Rebuilding snapshots feature requires an API, which takes, volume and ionum as input, and, returns zv of a snapshot which is taken just after given ionum.
This PR provides this API, and returns NULL if no such snapshot exists.

Added testcases for API in gtest framework.

This PR also includes minor change like function name change.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>