### PR TITLE
refactor (snaprebuild): added err respones to API

### DIFF
--- a/cmd/uzfs_test/uzfs_test_rebuilding.c
+++ b/cmd/uzfs_test/uzfs_test_rebuilding.c
@@ -298,8 +298,8 @@ rebuild_replica_thread(void *arg)
 
 	uzfs_zvol_set_rebuild_status(to_zvol, ZVOL_REBUILDING_INIT);
 
-	latest_io = uzfs_zvol_get_last_committed_io_no(from_zvol,
-	    HEALTHY_IO_SEQNUM);
+	uzfs_zvol_get_last_committed_io_no(from_zvol,
+	    HEALTHY_IO_SEQNUM, &latest_io);
 	printf("io number... healthy replica:%lu degraded replica:%lu\n",
 	    latest_io, r_info->base_io_num);
 	uzfs_zvol_set_rebuild_status(to_zvol, ZVOL_REBUILDING_SNAP);
@@ -510,8 +510,8 @@ replica_writer_thread(void *arg)
 			 * and continue to update last_committed_io_number in
 			 * degraded replica.
 			 */
-			last_io_num = uzfs_zvol_get_last_committed_io_no(zvol2,
-			    HEALTHY_IO_SEQNUM);
+			uzfs_zvol_get_last_committed_io_no(zvol2,
+			    HEALTHY_IO_SEQNUM, &last_io_num);
 			rebuild_info.base_io_num = last_io_num;
 		} else if (now > replica_rebuild_start_time &&
 		    !rebuilding_started) {

--- a/include/mgmt_conn.h
+++ b/include/mgmt_conn.h
@@ -107,7 +107,7 @@ int finish_async_tasks(void);
 
 int uzfs_zvol_create_snapshot_update_zap(zvol_info_t *zinfo,
     char *snapname, uint64_t snapshot_io_num);
-zvol_state_t *uzfs_get_snap_zv_ionum(zvol_info_t *zinfo, uint64_t ionum);
+int uzfs_get_snap_zv_ionum(zvol_info_t *, uint64_t, zvol_state_t **);
 
 int uzfs_zvol_get_snap_dataset_with_io(zvol_info_t *zinfo,
     char *snapname, uint64_t *snapshot_io_num, zvol_state_t **snap_zv);

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -208,7 +208,7 @@ extern int uzfs_zinfo_init(void *zv, const char *ds_name,
 extern zvol_info_t *uzfs_zinfo_lookup(const char *name);
 extern void uzfs_zinfo_replay_zil_all(void);
 extern int uzfs_zinfo_destroy(const char *ds_name, spa_t *spa);
-uint64_t uzfs_zvol_get_last_committed_io_no(zvol_state_t *zv, char *key);
+int uzfs_zvol_get_last_committed_io_no(zvol_state_t *, char *, uint64_t *);
 void uzfs_zvol_store_last_committed_healthy_io_no(zvol_info_t *zinfo,
     uint64_t io_seq);
 void uzfs_zvol_store_last_committed_degraded_io_no(zvol_info_t *zv,

--- a/lib/libzpool/uzfs_mgmt.c
+++ b/lib/libzpool/uzfs_mgmt.c
@@ -201,6 +201,7 @@ uzfs_zvol_create_meta(objset_t *os, uint64_t block_size,
     uint64_t meta_block_size, dmu_tx_t *tx)
 {
 	uint64_t metadatasize;
+	uint64_t io_seqnum = 0;
 	int error;
 
 	if (meta_block_size > block_size)
@@ -215,6 +216,14 @@ uzfs_zvol_create_meta(objset_t *os, uint64_t block_size,
 	    &metadatasize, tx);
 	if (error != 0)
 		return (error);
+
+	error = zap_update(os, ZVOL_ZAP_OBJ, HEALTHY_IO_SEQNUM, 8, 1,
+	    &io_seqnum, tx);
+	ASSERT(error == 0);
+
+	error = zap_update(os, ZVOL_ZAP_OBJ, DEGRADED_IO_SEQNUM, 8, 1,
+	    &io_seqnum, tx);
+	ASSERT(error == 0);
 
 	return (0);
 }

--- a/lib/libzpool/zrepl_mgmt.c
+++ b/lib/libzpool/zrepl_mgmt.c
@@ -405,17 +405,21 @@ uzfs_zinfo_free(zvol_info_t *zinfo)
 	return (0);
 }
 
-uint64_t
-uzfs_zvol_get_last_committed_io_no(zvol_state_t *zv, char *key)
+int
+uzfs_zvol_get_last_committed_io_no(zvol_state_t *zv, char *key, uint64_t *ionum)
 {
 	uzfs_zap_kv_t zap;
+	int error;
 
 	zap.key = key;
 	zap.value = 0;
 	zap.size = sizeof (uint64_t);
 
-	uzfs_read_zap_entry(zv, &zap);
-	return (zap.value);
+	error = uzfs_read_zap_entry(zv, &zap);
+	if (ionum != NULL)
+		*ionum = zap.value;
+
+	return (error);
 }
 
 static void

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -519,8 +519,13 @@ uzfs_zvol_rebuild_dw_replica(void *arg)
 	rc = 0;
 
 	/* Set state in-progess state now */
-	checkpointed_ionum = uzfs_zvol_get_last_committed_io_no(
-	    zinfo->main_zv, HEALTHY_IO_SEQNUM);
+	rc = uzfs_zvol_get_last_committed_io_no(
+	    zinfo->main_zv, HEALTHY_IO_SEQNUM, &checkpointed_ionum);
+	if (rc != 0) {
+		LOG_ERR("unable to get checkpointed num");
+		goto exit;
+	}
+
 	zvol_state = zinfo->main_zv;
 	bzero(&hdr, sizeof (hdr));
 	hdr.status = ZVOL_OP_STATUS_OK;
@@ -617,8 +622,13 @@ next_step:
 				goto exit;
 			}
 			offset = 0;
-			checkpointed_ionum = uzfs_zvol_get_last_committed_io_no(
-			    zinfo->main_zv, HEALTHY_IO_SEQNUM);
+			rc = uzfs_zvol_get_last_committed_io_no(zinfo->main_zv,
+			    HEALTHY_IO_SEQNUM, &checkpointed_ionum);
+			if (rc != 0) {
+				LOG_ERR("unable to get checkpointed num on "
+				    "snap done");
+				goto exit;
+			}
 			goto next_step;
 		}
 
@@ -631,8 +641,13 @@ next_step:
 			uzfs_zvol_set_rebuild_status(zinfo->main_zv,
 			    ZVOL_REBUILDING_AFS);
 			offset = 0;
-			checkpointed_ionum = uzfs_zvol_get_last_committed_io_no(
-			    zinfo->main_zv, HEALTHY_IO_SEQNUM);
+			rc = uzfs_zvol_get_last_committed_io_no(zinfo->main_zv,
+			    HEALTHY_IO_SEQNUM, &checkpointed_ionum);
+			if (rc != 0) {
+				LOG_ERR("unable to get checkpointed num on "
+				    "all snap done");
+				goto exit;
+			}
 			goto next_step;
 		}
 		ASSERT((hdr.opcode == ZVOL_OPCODE_READ) &&

--- a/lib/libzrepl/mgmt_conn.c
+++ b/lib/libzrepl/mgmt_conn.c
@@ -460,6 +460,7 @@ uzfs_zvol_mgmt_do_handshake(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 	zvol_state_t	*zv = zinfo->main_zv;
 	mgmt_ack_t 	mgmt_ack;
 	zvol_io_hdr_t	hdr;
+	int error1, error2;
 
 	bzero(&mgmt_ack, sizeof (mgmt_ack));
 	if (uzfs_zvol_get_ip(mgmt_ack.ip, MAX_IP_LEN) == -1) {
@@ -485,6 +486,16 @@ uzfs_zvol_mgmt_do_handshake(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 		}
 	}
 
+	error1 = uzfs_zvol_get_last_committed_io_no(zv, HEALTHY_IO_SEQNUM,
+	    &zinfo->checkpointed_ionum);
+	error2 = uzfs_zvol_get_last_committed_io_no(zv, DEGRADED_IO_SEQNUM,
+	    &zinfo->degraded_checkpointed_ionum);
+	if ((error1 != 0) || (error2 != 0)) {
+		LOG_ERR("Failed to read io_seqnum %s", zinfo->name);
+		return (reply_nodata(conn, ZVOL_OP_STATUS_FAILED,
+		    hdrp->opcode, hdrp->io_seq));
+	}
+
 	/*
 	 * We don't use fsid_guid because that one is not guaranteed
 	 * to stay the same (it is changed in case of conflicts).
@@ -502,10 +513,6 @@ uzfs_zvol_mgmt_do_handshake(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 	hdr.len = sizeof (mgmt_ack);
 	hdr.status = ZVOL_OP_STATUS_OK;
 
-	zinfo->checkpointed_ionum =
-	    uzfs_zvol_get_last_committed_io_no(zv, HEALTHY_IO_SEQNUM);
-	zinfo->degraded_checkpointed_ionum =
-	    uzfs_zvol_get_last_committed_io_no(zv, DEGRADED_IO_SEQNUM);
 	zinfo->stored_healthy_ionum = zinfo->checkpointed_ionum;
 	zinfo->running_ionum = zinfo->degraded_checkpointed_ionum;
 	LOG_INFO("IO sequence number:%lu Degraded IO sequence number:%lu",
@@ -643,12 +650,13 @@ uzfs_zvol_create_snapshot_update_zap(zvol_info_t *zinfo,
  * Note: caller should do uzfs_close_dataset of zv, and,
  * caller need to take care of any ongoing snap requests
  */
-zvol_state_t *
-uzfs_get_snap_zv_ionum(zvol_info_t *zinfo, uint64_t ionum)
+int
+uzfs_get_snap_zv_ionum(zvol_info_t *zinfo, uint64_t ionum,
+    zvol_state_t **psnapzv)
 {
 	if ((zinfo == NULL) || (zinfo->main_zv == NULL) ||
 	    (zinfo->main_zv->zv_objset == NULL))
-		return (NULL);
+		return (-1);
 
 	uint64_t obj = 0, cookie = 0;
 	zvol_state_t *zv = zinfo->main_zv;
@@ -673,8 +681,10 @@ uzfs_get_snap_zv_ionum(zvol_info_t *zinfo, uint64_t ionum)
 		error = get_snapshot_zv(zv, snapname, &snap_zv);
 		if (error)
 			break;
-		healthy_ionum = uzfs_zvol_get_last_committed_io_no(snap_zv,
-		    HEALTHY_IO_SEQNUM);
+		error = uzfs_zvol_get_last_committed_io_no(snap_zv,
+		    HEALTHY_IO_SEQNUM, &healthy_ionum);
+		if (error)
+			break;
 		if ((healthy_ionum > ionum) &&
 		    ((smallest_higher_snapzv == NULL) ||
 		    (smallest_higher_ionum > healthy_ionum))) {
@@ -685,7 +695,15 @@ uzfs_get_snap_zv_ionum(zvol_info_t *zinfo, uint64_t ionum)
 		} else
 			uzfs_close_dataset(snap_zv);
 	}
-	return (smallest_higher_snapzv);
+	if (error) {
+		if (smallest_higher_snapzv != NULL) {
+			uzfs_close_dataset(smallest_higher_snapzv);
+			smallest_higher_snapzv = NULL;
+		}
+	} else if (psnapzv != NULL)
+		*psnapzv = smallest_higher_snapzv;
+
+	return (error);
 }
 
 /*
@@ -717,8 +735,8 @@ uzfs_zvol_get_snap_dataset_with_io(zvol_info_t *zinfo,
 		return (ret);
 	}
 
-	(*snapshot_io_num) = uzfs_zvol_get_last_committed_io_no(*snap_zv,
-	    HEALTHY_IO_SEQNUM);
+	ret = uzfs_zvol_get_last_committed_io_no(*snap_zv,
+	    HEALTHY_IO_SEQNUM, snapshot_io_num);
 	return (ret);
 }
 


### PR DESCRIPTION
This PR is to refactor code and add error response to below APIs:
- uzfs_get_snap_zv_io_num, which returns snapshot whose healthy_io_seqnum is just greater than given ionum
- uzfs_zvol_get_last_committed_io_no, which reads and returns zap entry from ZAP obj

Signed-off-by: Vishnu Itta <vitta@mayadata.io>