### PR TITLE
[TA2546] feat(snaprebuild) IOs on the cloned volume if it exists

### DIFF
--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -271,7 +271,7 @@ uzfs_zvol_worker(void *arg)
 {
 	zvol_io_cmd_t	*zio_cmd;
 	zvol_info_t	*zinfo;
-	zvol_state_t	*zvol_state, *read_zv;
+	zvol_state_t	*zvol_state, *read_zv, *io_zv;
 	zvol_io_hdr_t 	*hdr;
 	metadata_desc_t	**metadata_desc;
 	int		rc = 0;
@@ -284,6 +284,12 @@ uzfs_zvol_worker(void *arg)
 	zvol_state = zinfo->main_zv;
 	rebuild_cmd_req = hdr->flags & ZVOL_OP_FLAG_REBUILD;
 	read_metadata = hdr->flags & ZVOL_OP_FLAG_READ_METADATA;
+
+
+	if (zinfo->clone_zv)
+		io_zv = zinfo->clone_zv;
+	else
+		io_zv = zinfo->main_zv;
 
 	if (zinfo->is_io_ack_sender_created == B_FALSE) {
 		if (!(rebuild_cmd_req && (hdr->opcode == ZVOL_OPCODE_WRITE)))
@@ -318,7 +324,7 @@ uzfs_zvol_worker(void *arg)
 	}
 	switch (hdr->opcode) {
 		case ZVOL_OPCODE_READ:
-			read_zv = zinfo->main_zv;
+			read_zv = io_zv;
 			if (rebuild_cmd_req) {
 				/*
 				 * if we are rebuilding, we have
@@ -345,7 +351,7 @@ uzfs_zvol_worker(void *arg)
 			break;
 
 		case ZVOL_OPCODE_SYNC:
-			uzfs_flush_data(zinfo->main_zv);
+			uzfs_flush_data(io_zv);
 			atomic_inc_64(&zinfo->sync_req_received_cnt);
 			break;
 
@@ -683,6 +689,8 @@ exit:
 			uzfs_zvol_set_status(zinfo->main_zv,
 			    ZVOL_STATUS_HEALTHY);
 			uzfs_update_ionum_interval(zinfo, 0);
+			VERIFY0(uzfs_zvol_destroy_internal_clone(zinfo->main_zv,
+			    &zinfo->snap_zv, &zinfo->clone_zv));
 		}
 	}
 	mutex_exit(&zinfo->main_zv->rebuild_mtx);
@@ -1109,6 +1117,8 @@ uzfs_zvol_rebuild_scanner_callback(off_t offset, size_t len,
 	 * replica. Degraded replica will take care of breaking the connection
 	 */
 	uzfs_zvol_worker(zio_cmd);
+
+	zinfo->rebuild_zv = NULL;
 	return (0);
 }
 


### PR DESCRIPTION
All the read/write/sync IOs should go to clone volume since it will
be active file system(AFS) at the time of rebuilding.

Signed-off-by: Pawan <pawanprakash101@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
