### PR TITLE
feat(snap_rebuild): ignore internally created snapshots while returni…

### DIFF
--- a/lib/libzrepl/mgmt_conn.c
+++ b/lib/libzrepl/mgmt_conn.c
@@ -651,6 +651,17 @@ uzfs_append_snapshot_properties(nvlist_t *nv, struct json_object *robj,
 	}
 }
 
+/* Returns TRUE if given is name of internally created snapshot */
+static boolean_t
+internal_snapshot(char *snap)
+{
+	if ((strcmp(snap, REBUILD_SNAPSHOT_SNAPNAME) == 0) ||
+	    (strncmp(snap, IO_DIFF_SNAPNAME, sizeof (IO_DIFF_SNAPNAME) - 1)
+	    == 0))
+		return (B_TRUE);
+	return (B_FALSE);
+}
+
 static int
 uzfs_zvol_fetch_snapshot_list(zvol_info_t *zinfo, void **buf,
     size_t *buflen)
@@ -685,6 +696,11 @@ uzfs_zvol_fetch_snapshot_list(zvol_info_t *zinfo, void **buf,
 			goto out;
 		}
 
+		if (internal_snapshot(snapname)) {
+			dsl_pool_config_exit(dmu_objset_pool(os), FTAG);
+			continue;
+		}
+
 		error = dsl_dataset_hold_obj(dp, id, FTAG, &ds);
 		if (error == 0) {
 			error = dmu_objset_from_ds(ds, &snap_os);
@@ -700,14 +716,6 @@ uzfs_zvol_fetch_snapshot_list(zvol_info_t *zinfo, void **buf,
 			dsl_dataset_rele(ds, FTAG);
 		}
 		dsl_pool_config_exit(dmu_objset_pool(os), FTAG);
-
-		if (strcmp(snapname, REBUILD_SNAPSHOT_SNAPNAME) == 0 ||
-		    strncmp(snapname, IO_DIFF_SNAPNAME,
-		    sizeof (IO_DIFF_SNAPNAME)) == 0) {
-			if (!prop_error)
-				nvlist_free(nv);
-			continue;
-		}
 
 		jobj = json_object_new_object();
 		json_object_object_add(jobj, "name",
@@ -861,6 +869,8 @@ uzfs_get_snap_zv_ionum(zvol_info_t *zinfo, uint64_t ionum,
 				error = 0;
 			break;
 		}
+		if (internal_snapshot(snapname))
+			continue;
 		error = get_snapshot_zv(zv, snapname, &snap_zv);
 		if (error)
 			break;

--- a/tests/cbtest/gtest/test_uzfs.cc
+++ b/tests/cbtest/gtest/test_uzfs.cc
@@ -856,10 +856,22 @@ TEST(SnapCreate, SnapCreateSuccess) {
 	EXPECT_EQ(999, ionum);
 
 	EXPECT_EQ(0, uzfs_zvol_create_snapshot_update_zap(zinfo,
+	    (char *)REBUILD_SNAPSHOT_SNAPNAME, 1800));
+	EXPECT_EQ(0, uzfs_zvol_get_last_committed_io_no(zinfo->main_zv,
+	    (char *)HEALTHY_IO_SEQNUM, &ionum));
+	EXPECT_EQ(1799, ionum);
+
+	EXPECT_EQ(0, uzfs_zvol_create_snapshot_update_zap(zinfo,
 	    snapname1, 2000));
 	EXPECT_EQ(0, uzfs_zvol_get_last_committed_io_no(zinfo->main_zv,
 	    (char *)HEALTHY_IO_SEQNUM, &ionum));
 	EXPECT_EQ(1999, ionum);
+
+	EXPECT_EQ(0, uzfs_zvol_create_snapshot_update_zap(zinfo,
+	    (char *)".io_snap100", 2800));
+	EXPECT_EQ(0, uzfs_zvol_get_last_committed_io_no(zinfo->main_zv,
+	    (char *)HEALTHY_IO_SEQNUM, &ionum));
+	EXPECT_EQ(2799, ionum);
 
 	EXPECT_EQ(0, uzfs_zvol_create_snapshot_update_zap(zinfo,
 	    snapname2, 3000));
@@ -877,6 +889,11 @@ TEST(SnapCreate, SnapCreateSuccess) {
 TEST(GetSnapFromIO, GetDestroySnap) {
 	zvol_state_t *zv;
 	int ret;
+
+	EXPECT_EQ(0, uzfs_get_snap_zv_ionum(zinfo, 1698, &zv));
+	ret = strcmp(zv->zv_name, "pool1/vol1@snapa");
+	EXPECT_EQ(ret, 0);
+	uzfs_close_dataset(zv);
 
 	EXPECT_EQ(0, uzfs_get_snap_zv_ionum(zinfo, 1998, &zv));
 	ret = strcmp(zv->zv_name, "pool1/vol1@snapa");


### PR DESCRIPTION
…ng snap_zv

API, that returns snap_zv whose io_seq is just greater than the given io_num, should ignore the internally created snapshots.

This PR is to ignore internally created snapshots while returning snapzv.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>