### PR TITLE
[TA3148] feat(snap_rebuild): doing rebuild from AFS after ALL_SNAP_DONE

### DIFF
--- a/include/mgmt_conn.h
+++ b/include/mgmt_conn.h
@@ -106,7 +106,7 @@ void zinfo_create_cb(zvol_info_t *zinfo, nvlist_t *create_props);
 void zinfo_destroy_cb(zvol_info_t *zinfo);
 void uzfs_zvol_mgmt_thread(void *arg);
 int finish_async_tasks(void);
-
+int uzfs_zinfo_rebuild_from_clone(zvol_info_t *zinfo);
 int uzfs_zvol_create_snapshot_update_zap(zvol_info_t *zinfo,
     char *snapname, uint64_t snapshot_io_num);
 int uzfs_get_snap_zv_ionum(zvol_info_t *, uint64_t, zvol_state_t **);

--- a/include/sys/uzfs_zvol.h
+++ b/include/sys/uzfs_zvol.h
@@ -82,6 +82,8 @@ struct zvol_state {
 	 * This should not be greater than volblocksize
 	 */
 	uint64_t zv_metavolblocksize;
+
+	/* Don't use status directly. Use getter/setter of zvol_info */
 	zvol_status_t zv_status;		/* zvol status */
 	kmutex_t rebuild_mtx;
 	zvol_rebuild_info_t rebuild_info;
@@ -94,7 +96,9 @@ typedef struct zvol_state zvol_state_t;
 #define	UZFS_IO_READ_FAIL	2
 #define	UZFS_IO_MREAD_FAIL	3
 
+#define	ZINFO_IS_DEGRADED(zinfo)	(ZVOL_IS_DEGRADED(zinfo->main_zv))
 #define	ZVOL_IS_DEGRADED(zv)	(zv->zv_status == ZVOL_STATUS_DEGRADED)
+
 #define	ZVOL_IS_REBUILDING(zv)		\
 	((zv->rebuild_info.zv_rebuild_status == ZVOL_REBUILDING_SNAP) || \
 	(zv->rebuild_info.zv_rebuild_status == ZVOL_REBUILDING_AFS))

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -210,15 +210,18 @@ extern zvol_info_t *uzfs_zinfo_lookup(const char *name);
 extern void uzfs_zinfo_replay_zil_all(void);
 extern int uzfs_zinfo_destroy(const char *ds_name, spa_t *spa);
 int uzfs_zvol_get_last_committed_io_no(zvol_state_t *, char *, uint64_t *);
-void uzfs_zvol_store_last_committed_healthy_io_no(zvol_info_t *zinfo,
+void uzfs_zinfo_store_last_committed_healthy_io_no(zvol_info_t *zinfo,
     uint64_t io_seq);
-void uzfs_zvol_store_last_committed_degraded_io_no(zvol_info_t *zv,
+void uzfs_zinfo_store_last_committed_degraded_io_no(zvol_info_t *zv,
     uint64_t io_seq);
 extern int set_socket_keepalive(int sfd);
 extern int create_and_bind(const char *port, int bind_needed,
     boolean_t nonblocking);
 int uzfs_zvol_name_compare(zvol_info_t *zv, const char *name);
 void shutdown_fds_related_to_zinfo(zvol_info_t *zinfo);
+
+extern void uzfs_zinfo_set_status(zvol_info_t *zinfo, zvol_status_t status);
+extern zvol_status_t uzfs_zinfo_get_status(zvol_info_t *zinfo);
 
 /*
  * API to drop refcnt on zinfo. If refcnt

--- a/include/zrepl_prot.h
+++ b/include/zrepl_prot.h
@@ -99,7 +99,9 @@ struct zvol_io_hdr {
 	uint8_t 	flags;
 	uint8_t 	padding[3];
 	union {
+		/* IOnum as sent from target */
 		uint64_t	io_seq;
+		/* IOnum from which rebuild need to be done */
 		uint64_t	checkpointed_io_seq;
 	};
 	/* only used for read/write */

--- a/lib/libzpool/uzfs_io.c
+++ b/lib/libzpool/uzfs_io.c
@@ -406,6 +406,7 @@ uzfs_zvol_get_status(zvol_state_t *zv)
 {
 	return (zv->zv_status);
 }
+
 void
 uzfs_zvol_set_rebuild_status(zvol_state_t *zv, zvol_rebuild_status_t status)
 {

--- a/lib/libzpool/zrepl_mgmt.c
+++ b/lib/libzpool/zrepl_mgmt.c
@@ -442,7 +442,7 @@ uzfs_zvol_store_kv_pair(zvol_state_t *zv, char *key,
 }
 
 void
-uzfs_zvol_store_last_committed_degraded_io_no(zvol_info_t *zinfo,
+uzfs_zinfo_store_last_committed_degraded_io_no(zvol_info_t *zinfo,
     uint64_t io_seq)
 {
 	uzfs_zvol_store_kv_pair(zinfo->main_zv,
@@ -455,7 +455,7 @@ uzfs_zvol_store_last_committed_degraded_io_no(zvol_info_t *zinfo,
  * Updates in-memory committed io_num.
  */
 void
-uzfs_zvol_store_last_committed_healthy_io_no(zvol_info_t *zinfo,
+uzfs_zinfo_store_last_committed_healthy_io_no(zvol_info_t *zinfo,
     uint64_t io_seq)
 {
 	if (io_seq == 0)
@@ -470,4 +470,16 @@ uzfs_zvol_store_last_committed_healthy_io_no(zvol_info_t *zinfo,
 	uzfs_zvol_store_kv_pair(zinfo->main_zv,
 	    HEALTHY_IO_SEQNUM, io_seq);
 	pthread_mutex_unlock(&zinfo->zinfo_ionum_mutex);
+}
+
+void
+uzfs_zinfo_set_status(zvol_info_t *zinfo, zvol_status_t status)
+{
+	uzfs_zvol_set_status(zinfo->main_zv, status);
+}
+
+zvol_status_t
+uzfs_zinfo_get_status(zvol_info_t *zinfo)
+{
+	return (uzfs_zvol_get_status(zinfo->main_zv));
 }


### PR DESCRIPTION
Once the degraded replica received all snapshots from helping replica, it need to rebuild from its own clone as well, while cloning from AFS of helping replica.
This PR is to start rebuild from active file system of helping replica which can be clone in case of degraded replica or main volume in case of healthy replica, and also, to start rebuild from its own clone.

This PR also changed few function names as uzfs_zinfo_* from uzfs_zvol_* if they take 'zinfo' as input rather than 'zvol'.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>