### PR TITLE
TA3149 (snap_rebuild) free the clone_zv once rebuilding is done.

### DIFF
--- a/lib/libzpool/zrepl_mgmt.c
+++ b/lib/libzpool/zrepl_mgmt.c
@@ -218,6 +218,8 @@ uzfs_mark_offline_and_free_zinfo(zvol_info_t *zinfo)
 		    " zero on zvol:%s", zinfo->name);
 		sleep(5);
 	}
+	(void) uzfs_zvol_release_internal_clone(
+	    zinfo->main_zv, &zinfo->snap_zv, &zinfo->clone_zv);
 
 	LOG_INFO("Freeing zvol %s", zinfo->name);
 	(void) uzfs_zinfo_free(zinfo);
@@ -302,8 +304,6 @@ uzfs_zinfo_destroy(const char *name, spa_t *spa)
 	zvol_info_t	*zinfo = NULL;
 	zvol_info_t    *zt = NULL;
 	int namelen = ((name) ? strlen(name) : 0);
-	zvol_state_t  *clone_zv = NULL;
-	zvol_state_t  *snap_zv = NULL;
 	zvol_state_t  *main_zv;
 	int destroyed = 0;
 
@@ -319,11 +319,7 @@ uzfs_zinfo_destroy(const char *name, spa_t *spa)
 
 				mutex_exit(&zvol_list_mutex);
 				main_zv = zinfo->main_zv;
-				clone_zv = zinfo->clone_zv;
-				snap_zv = zinfo->snap_zv;
 				uzfs_mark_offline_and_free_zinfo(zinfo);
-				(void) uzfs_zvol_release_internal_clone(
-				    main_zv, &snap_zv, &clone_zv);
 				uzfs_close_dataset(main_zv);
 				destroyed++;
 				mutex_enter(&zvol_list_mutex);
@@ -340,11 +336,7 @@ uzfs_zinfo_destroy(const char *name, spa_t *spa)
 
 				mutex_exit(&zvol_list_mutex);
 				main_zv = zinfo->main_zv;
-				clone_zv = zinfo->clone_zv;
-				snap_zv = zinfo->snap_zv;
 				uzfs_mark_offline_and_free_zinfo(zinfo);
-				(void) uzfs_zvol_release_internal_clone(
-				    main_zv, &snap_zv, &clone_zv);
 				uzfs_close_dataset(main_zv);
 				destroyed++;
 				goto end;

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -803,14 +803,13 @@ exit:
 		    zinfo->uzfs_zvol_taskq)) {
 			zinfo->quiesce_done = 1;
 			zinfo->quiesce_requested = 0;
+			uzfs_zvol_destroy_internal_clone(zinfo->main_zv,
+			    &zinfo->snap_zv, &zinfo->clone_zv);
 			break;
 		} else {
 			sleep(1);
 		}
 	}
-
-	uzfs_zvol_destroy_internal_clone(zinfo->main_zv,
-	    &zinfo->snap_zv, &zinfo->clone_zv);
 
 	kmem_free(arg, sizeof (rebuild_thread_arg_t));
 	if (zio_cmd != NULL)
@@ -1969,6 +1968,7 @@ exit:
 	zinfo->is_io_receiver_created = B_FALSE;
 	(void) uzfs_zvol_release_internal_clone(zinfo->main_zv,
 	    &zinfo->snap_zv, &zinfo->clone_zv);
+
 	zinfo->quiesce_requested = 0;
 	zinfo->quiesce_done = 1;
 	uzfs_zinfo_drop_refcnt(zinfo);

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -102,7 +102,6 @@ static inline void quiesce_wait(zvol_info_t *zinfo, uint8_t delete_clone)
 		else
 			sleep(1);
 	}
-	return;
 }
 
 /*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
Once rebuilding is done, we have to free the clone dataset and snapshot from where clone is created. We have to make sure there are no one referring to the clone zv.  

In this change the io receiver itself checks for the rebuilding done, and once it is done it will wait for the task_q to be drain and then delete the clone dataset and it's snapshot snapshot.