### PR TITLE
feat(build): build cstor-pool and cstor-base docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,6 @@ script:
 after_failure:
     - find /var/tmp/test_results/current/log -type f -name '*' -printf "%f\n" -exec cut -c -$ZFS_TEST_TRAVIS_LOG_MAX_LENGTH {} \;
 after_success:
-    - if [ $ZFS_BUILD_TAGS = 1 ]; then ./build_image.sh; fi
+    - if [ $ZFS_BUILD_TAGS = 0 ]; then ./build_image.sh; fi
     - find /var/tmp/test_results/current/log -type f -name '*' -printf "%f\n" -exec cut -c -$ZFS_TEST_TRAVIS_LOG_MAX_LENGTH {} \;
     - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: required
 branches:
   only:
     - zfs-0.7-release
+    - /^\d+\.\d+(\.\d+)?(-\S*)?$/
+    - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
 env:
   global:
     # Travis limits maximum log size, we have to cut tests output 
@@ -78,5 +80,8 @@ script:
 after_failure:
     - find /var/tmp/test_results/current/log -type f -name '*' -printf "%f\n" -exec cut -c -$ZFS_TEST_TRAVIS_LOG_MAX_LENGTH {} \;
 after_success:
+    - if [ $ZFS_BUILD_TAGS = 1 ]; then
+        ./build_image.sh
+      fi
     - find /var/tmp/test_results/current/log -type f -name '*' -printf "%f\n" -exec cut -c -$ZFS_TEST_TRAVIS_LOG_MAX_LENGTH {} \;
     - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,8 +80,6 @@ script:
 after_failure:
     - find /var/tmp/test_results/current/log -type f -name '*' -printf "%f\n" -exec cut -c -$ZFS_TEST_TRAVIS_LOG_MAX_LENGTH {} \;
 after_success:
-    - if [ $ZFS_BUILD_TAGS = 1 ]; then
-        ./build_image.sh
-      fi
+    - if [ $ZFS_BUILD_TAGS = 1 ]; then ./build_image.sh; fi
     - find /var/tmp/test_results/current/log -type f -name '*' -printf "%f\n" -exec cut -c -$ZFS_TEST_TRAVIS_LOG_MAX_LENGTH {} \;
     - bash <(curl -s https://codecov.io/bash)

--- a/build_image.sh
+++ b/build_image.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+
+BUILD_DATE=$(date +'%Y%m%d%H%M%S')
+REPO_NAME="openebs/cstor-base"
+
+mkdir -p ./docker/zfs/bin
+mkdir -p ./docker/zfs/lib
+
+cp cmd/zrepl/.libs/zrepl ./docker/zfs/bin
+cp cmd/zpool/.libs/zpool ./docker/zfs/bin
+cp cmd/zfs/.libs/zfs ./docker/zfs/bin
+
+cp lib/libzrepl/.libs/*.so* ./docker/zfs/lib
+cp lib/libzpool/.libs/*.so* ./docker/zfs/lib
+cp lib/libuutil/.libs/*.so* ./docker/zfs/lib
+cp lib/libnvpair/.libs/*.so* ./docker/zfs/lib
+cp lib/libzfs/.libs/*.so* ./docker/zfs/lib
+cp lib/libzfs_core/.libs/*.so* ./docker/zfs/lib
+
+sudo docker version
+sudo docker build --help
+
+echo "Build image ${REPO_NAME}:ci with BUILD_DATE=${BUILD_DATE}"
+cd docker && \
+ sudo docker build -f Dockerfile.base -t ${REPO_NAME}:ci --build-arg BUILD_DATE=${BUILD_DATE} . && \
+ IMAGE_REPO=${REPO_NAME} ./push && \
+ cd ..
+
+REPO_NAME="openebs/cstor-pool"
+echo "Build image ${REPO_NAME}:ci with BUILD_DATE=${BUILD_DATE}"
+cd docker && \
+ sudo docker build -f Dockerfile -t ${REPO_NAME}:ci --build-arg BUILD_DATE=${BUILD_DATE} . && \
+ IMAGE_REPO=${REPO_NAME} ./push && \
+ cd ..
+
+rm -rf ./docker/zfs
+

--- a/build_image.sh
+++ b/build_image.sh
@@ -35,4 +35,3 @@ cd docker && \
  cd ..
 
 rm -rf ./docker/zfs
-

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,20 @@
+#
+# This Dockerfile builds cstor main container running zrepl from base image
+#
+
+FROM openebs/cstor-base:ci
+
+COPY entrypoint-poolimage.sh /usr/local/bin/
+
+RUN chmod +x /usr/local/bin/entrypoint-poolimage.sh
+
+ARG BUILD_DATE
+LABEL org.label-schema.name="cstor"
+LABEL org.label-schema.description="OpenEBS cStor"
+LABEL org.label-schema.url="http://www.openebs.io/"
+LABEL org.label-schema.vcs-url="https://github.com/openebs/openebs"
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.build-date=$BUILD_DATE
+
+ENTRYPOINT entrypoint-poolimage.sh
+EXPOSE 7676

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,0 +1,26 @@
+#
+# This Dockerfile builds a recent base image containing cstor binaries and 
+# libraries.
+#
+
+FROM ubuntu:16.04
+
+RUN apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \ 
+    apt-get update && apt-get install -y \
+    libaio1 libaio-dev \
+    libkqueue-dev libssl1.0.0 rsyslog net-tools gdb apt-utils \
+    sed libjemalloc-dev openssh-server
+
+COPY zfs/bin/* /usr/local/bin/
+COPY zfs/lib/* /usr/lib/
+
+ARG BUILD_DATE
+LABEL org.label-schema.name="cstor"
+LABEL org.label-schema.description="OpenEBS cStor"
+LABEL org.label-schema.url="http://www.openebs.io/"
+LABEL org.label-schema.vcs-url="https://github.com/openebs/openebs"
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.build-date=$BUILD_DATE
+
+EXPOSE 7676

--- a/docker/entrypoint-poolimage.sh
+++ b/docker/entrypoint-poolimage.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -o errexit
+trap 'call_exit $LINE_NO' EXIT
+
+call_exit()
+{
+echo "at call_exit.."     
+echo  "exit code:" $?
+echo "reference: "  $0 
+}
+
+service ssh start
+
+if [ -z "$LOGLEVEL" ]; then
+	LOGLEVEL=info
+fi
+echo "sleeping for 2 sec"
+sleep 2
+export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
+exec /usr/local/bin/zrepl -l $LOGLEVEL

--- a/docker/push
+++ b/docker/push
@@ -1,0 +1,94 @@
+#!/bin/bash
+set -e
+
+if [ -z ${IMAGE_REPO} ];
+then
+  echo "Error: IMAGE_REPO is not specified";
+  exit 1
+fi
+
+IMAGEID=$( sudo docker images -q ${IMAGE_REPO}:ci )
+echo $IMAGEID 
+if [ -z ${IMAGEID} ];
+then
+  echo "Error: unable to get IMAGEID for ${IMAGE_REPO}:ci";
+  exit 1
+fi
+
+# In case of cstor, the commit id doesn't change so using date. 
+BUILD_ID=$(git describe --tags --always)
+
+# Determine the current branch
+CURRENT_BRANCH=""
+if [ -z ${TRAVIS_BRANCH} ];
+then
+  CURRENT_BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
+else
+  CURRENT_BRANCH=${TRAVIS_BRANCH}
+fi
+
+#Depending on the branch where builds are generated, 
+# set the tag CI (fixed) and build tags.
+BUILD_TAG="${CURRENT_BRANCH}-${BUILD_ID}"
+CI_TAG="${CURRENT_BRANCH}-ci"
+if [ ${CURRENT_BRANCH} = "zfs-0.7-release" ]; then
+  CI_TAG="ci"
+fi
+
+echo "Set the fixed ci image tag as: ${CI_TAG}"
+echo "Set the build/unique image tag as: ${BUILD_TAG}"
+
+function TagAndPushImage() {
+  REPO="$1"
+  TAG="$2"
+  
+  IMAGE_URI="${REPO}:${TAG}";
+  sudo docker tag ${IMAGEID} ${IMAGE_URI};
+  echo "Pushing ${IMAGE_URI}";
+  sudo docker push ${IMAGE_URI};
+}
+
+if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ];
+then
+  sudo docker login -u "${DNAME}" -p "${DPASS}";
+
+  # Push CI tagged image - :ci or :branch-ci
+  TagAndPushImage "${IMAGE_REPO}" "${CI_TAG}"
+
+  # Push unique tagged image - :master-<uuid> or :branch-<uuid>
+  # This unique/build image will be pushed to corresponding ci repo. 
+  TagAndPushImage "${IMAGE_REPO}-ci" "${BUILD_TAG}"
+
+
+  if [ ! -z "${TRAVIS_TAG}" ] ;
+  then
+    # Push with different tags if tagged as a release
+    # When github is tagged with a release, then Travis will
+    # set the release tag in env TRAVIS_TAG
+    TagAndPushImage "${IMAGE_REPO}" "${TRAVIS_TAG}"
+    TagAndPushImage "${IMAGE_REPO}" "latest"
+  fi;
+else
+  echo "No docker credentials provided. Skip uploading ${IMAGE_REPO} to docker hub";
+fi;
+
+# Push ci image to quay.io for security scanning
+if [ ! -z "${QNAME}" ] && [ ! -z "${QPASS}" ]; 
+then 
+  sudo docker login -u "${QNAME}" -p "${QPASS}" quay.io;
+
+  # Push CI tagged image - :ci or :branch-ci
+  TagAndPushImage "quay.io/${IMAGE_REPO}" "${CI_TAG}"
+
+  if [ ! -z "${TRAVIS_TAG}" ] ;
+  then
+    # Push with different tags if tagged as a release
+    # When github is tagged with a release, then Travis will
+    # set the release tag in env TRAVIS_TAG
+    TagAndPushImage "quay.io/${IMAGE_REPO}" "${TRAVIS_TAG}"
+    TagAndPushImage "quay.io/${IMAGE_REPO}" "latest"
+  fi;
+else
+  echo "No docker credentials provided. Skip uploading ${IMAGE_REPO} to quay";
+fi;
+

--- a/docker/push
+++ b/docker/push
@@ -15,7 +15,7 @@ then
   exit 1
 fi
 
-# In case of cstor, the commit id doesn't change so using date. 
+# Get an unique id based on commit and tag
 BUILD_ID=$(git describe --tags --always)
 
 # Determine the current branch


### PR DESCRIPTION
Moving the code for building cstor images from openebs/cstor
to this openebs/zfs repo. This will ensure that images are
built per commit and CI can be run with these intermediate
images

Also enabled travis builds to run on release branch and
release tags

Signed-off-by: kmova <kiran.mova@openebs.io>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
