### PR TITLE
feat (snap_rebuild): writing all rebuild IOs to main volume

### DIFF
--- a/include/sys/uzfs_zvol.h
+++ b/include/sys/uzfs_zvol.h
@@ -96,7 +96,8 @@ typedef struct zvol_state zvol_state_t;
 #define	UZFS_IO_READ_FAIL	2
 #define	UZFS_IO_MREAD_FAIL	3
 
-#define	ZINFO_IS_DEGRADED(zinfo)	(ZVOL_IS_DEGRADED(zinfo->main_zv))
+#define	ZINFO_IS_HEALTHY(zinfo)		(ZVOL_IS_HEALTHY(zinfo->main_zv))
+#define	ZINFO_IS_DEGRADED(zinfo)	(!(ZINFO_IS_HEALTHY(zinfo)))
 #define	ZVOL_IS_DEGRADED(zv)		(zv->zv_status == ZVOL_STATUS_DEGRADED)
 #define	ZVOL_IS_HEALTHY(zv)		(zv->zv_status == ZVOL_STATUS_HEALTHY)
 

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -236,6 +236,13 @@ uzfs_submit_writes(zvol_info_t *zinfo, zvol_io_cmd_t *zio_cmd)
 	uint64_t running_ionum;
 	is_rebuild = hdr->flags & ZVOL_OP_FLAG_REBUILD;
 
+#ifdef DEBUG
+	if (is_rebuild) {
+		ASSERT(ZVOL_IS_REBUILDING(zinfo->main_zv));
+		ASSERT(ZINFO_IS_DEGRADED(zinfo));
+	}
+#endif
+
 	while (remain > 0) {
 		if (remain < sizeof (*write_hdr))
 			return (-1);
@@ -251,7 +258,7 @@ uzfs_submit_writes(zvol_info_t *zinfo, zvol_io_cmd_t *zio_cmd)
 		 * Write to main_zv when volume is either
 		 * healthy or in REBUILD_AFS state of rebuild
 		 */
-		if (ZVOL_IS_REBUILDING_AFS(zinfo->main_zv) ||
+		if (is_rebuild || ZVOL_IS_REBUILDING_AFS(zinfo->main_zv) ||
 		    ZVOL_IS_HEALTHY(zinfo->main_zv)) {
 			rc = uzfs_write_data(zinfo->main_zv, datap, data_offset,
 			    write_hdr->len, &metadata, is_rebuild);

--- a/tests/cbtest/script/test_uzfs.sh
+++ b/tests/cbtest/script/test_uzfs.sh
@@ -114,8 +114,8 @@ stop_zrepl()
 
 wait_for_pids()
 {
-	for p in "$@"; do
-		wait $p
+	for (( i = 1; i <= $#; i++ )) do
+		wait -n $@
 		status=$?
 		if [ $status -ne 0 ] && [ $status -ne 127 ]; then
 			exit 1


### PR DESCRIPTION
With snap_rebuild feature i.e., rebuilding snapshots to other pool which are taken when it was done, all rebuild IOs should go to main volume, and, any application IOs should to clone volume.

This PR is to write all rebuild related IOs to main volume.

This also contains changes to test script that checks for error status from the child processes.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>