### PR TITLE
TA2549 feat(snap_rebuild) handle snapshot command.

### DIFF
--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -162,6 +162,7 @@ typedef struct zvol_info_s {
 	/* Rebuild flags to quiesce IOs */
 	uint8_t		quiesce_requested;
 	uint8_t		quiesce_done;
+	int32_t		io_fd;
 
 	/* Pointer to mgmt connection for this zinfo */
 	void		*mgmt_conn;

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -1979,6 +1979,7 @@ exit:
 	zinfo->quiesce_requested = 0;
 	zinfo->quiesce_done = 1;
 	uzfs_zinfo_drop_refcnt(zinfo);
+	zinfo->io_fd = -1;
 thread_exit:
 	close(fd);
 	LOG_INFO("Data connection closed on fd: %d", fd);

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -1886,6 +1886,8 @@ uzfs_zvol_io_receiver(void *arg)
 		}
 	}
 
+	zinfo->io_fd = fd;
+
 	LOG_INFO("Data connection associated with zvol %s fd: %d",
 	    zinfo->name, fd);
 

--- a/lib/libzrepl/mgmt_conn.c
+++ b/lib/libzrepl/mgmt_conn.c
@@ -959,7 +959,8 @@ uzfs_zvol_execute_async_command(void *arg)
 			 * snap create command failed, close the io
 			 * connection so that it can start the rebuilding
 			 */
-			VERIFY0(shutdown(zinfo->io_fd, SHUT_RDWR));
+			if (zinfo->io_fd >= 0)
+				VERIFY0(shutdown(zinfo->io_fd, SHUT_RDWR));
 			LOG_ERR("Failed to create %s@%s: %d",
 			    zinfo->name, snap, rc);
 			async_task->status = ZVOL_OP_STATUS_FAILED;
@@ -1409,6 +1410,9 @@ process_message(uzfs_mgmt_conn_t *conn)
 		    ZVOL_STATUS_HEALTHY) {
 			if (hdrp->opcode == ZVOL_OPCODE_SNAP_CREATE &&
 			    ZVOL_IS_REBUILDING_AFS(zinfo->main_zv)) {
+				LOG_INFO("zvol %s is not healthy and rebuild"
+				"is going on, can't take the %s snapshot,"
+				"erroring out the rebuild", zvol_name, snap);
 				mutex_enter(&zinfo->main_zv->rebuild_mtx);
 				uzfs_zvol_set_rebuild_status(zinfo->main_zv,
 				    ZVOL_REBUILDING_ERRORED);

--- a/lib/libzrepl/mgmt_conn.c
+++ b/lib/libzrepl/mgmt_conn.c
@@ -955,6 +955,11 @@ uzfs_zvol_execute_async_command(void *arg)
 		rc = uzfs_zvol_create_snapshot_update_zap(zinfo, snap,
 		    async_task->hdr.io_seq);
 		if (rc != 0) {
+			/*
+			 * snap create command failed, close the io
+			 * connection so that it can start the rebuilding
+			 */
+			VERIFY0(shutdown(zinfo->io_fd, SHUT_RDWR));
 			LOG_ERR("Failed to create %s@%s: %d",
 			    zinfo->name, snap, rc);
 			async_task->status = ZVOL_OP_STATUS_FAILED;
@@ -1402,6 +1407,13 @@ process_message(uzfs_mgmt_conn_t *conn)
 		}
 		if (uzfs_zvol_get_status(zinfo->main_zv) !=
 		    ZVOL_STATUS_HEALTHY) {
+			if (hdrp->opcode == ZVOL_OPCODE_SNAP_CREATE &&
+			    ZVOL_IS_REBUILDING_AFS(zinfo->main_zv)) {
+				mutex_enter(&zinfo->main_zv->rebuild_mtx);
+				uzfs_zvol_set_rebuild_status(zinfo->main_zv,
+				    ZVOL_REBUILDING_ERRORED);
+				mutex_exit(&zinfo->main_zv->rebuild_mtx);
+			}
 			uzfs_zinfo_drop_refcnt(zinfo);
 			LOG_ERR("zvol %s is not healthy to take %s snapshot",
 			    zvol_name, snap);


### PR DESCRIPTION
If we are syncing from the cloned replica and we get a snapshot command,
we can not take the snapshot immediately nor we can delay it.
So we have to resync that snapshot from rebuild replica and
then again sync from the clone replica,

We have to handle few more scenario as describe below :-

1. If snapshot command is failed on a healthy replica, it has to disconnect
it so that it can start the rebuilding the process and syncs the snapshot.

2. In AFS mode of replica, when it receives snapshot command,
replica has to disconnect (similar to healthy replica case)

3. In SNAP mode of replica, replica returns error, but,
it will not take any action on data/rebuild connections.

Signed-off-by: Pawan <pawanprakash101@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
