### PR TITLE
[US3445] cherrypick to 0.7.1

### DIFF
--- a/include/gtest_utils.h
+++ b/include/gtest_utils.h
@@ -19,6 +19,7 @@
 
 namespace GtestUtils {
 
+void graceful_close(int sockfd);
 std::string execCmd(std::string const &zfsCmd, std::string const &args);
 std::string getCmdPath(std::string zfsCmd);
 int verify_buf(void *buf, int len, const char *pattern);

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -71,6 +71,7 @@ struct zvol_io_cmd_s;
 #if DEBUG
 typedef struct inject_delay_s {
 	int helping_replica_rebuild_step;
+	int pre_uzfs_write_data;
 } inject_delay_t;
 
 typedef struct inject_error_s {

--- a/tests/cbtest/gtest/gtest_utils.cc
+++ b/tests/cbtest/gtest/gtest_utils.cc
@@ -16,6 +16,25 @@
 #define	POOL_SIZE	(100 * 1024 * 1024)
 #define	ZVOL_SIZE	(10 * 1024 * 1024)
 
+/*
+ * We have to wait for the other end to close the connection, because the
+ * next test case could initiate a new connection before this one is
+ * fully closed and cause a handshake error. Or it could result in EBUSY
+ * error when destroying zpool if it is not released in time by zrepl.
+ */
+void GtestUtils::graceful_close(int sockfd)
+{
+	int rc;
+	char val;
+
+	if (sockfd < 0)
+		return;
+	shutdown(sockfd, SHUT_WR);
+	rc = read(sockfd, &val, sizeof (val));
+	ASSERT_EQ(rc, 0);
+	close(sockfd);
+}
+
 void GtestUtils::init_buf(void *buf, int len, const char *pattern) {
 	int i;
 	char c;

--- a/tests/cbtest/gtest/test_uzfs.cc
+++ b/tests/cbtest/gtest/test_uzfs.cc
@@ -202,6 +202,8 @@ uzfs_mock_rebuild_scanner(void *arg)
 
 	if (rebuild_test_case == 6) {
 		close(data_conn_fd);
+		while (zinfo->is_io_receiver_created == B_TRUE)
+			sleep(2);
 		sleep(5);
 	}
 
@@ -236,8 +238,10 @@ uzfs_mock_rebuild_scanner(void *arg)
 exit:
 	shutdown(fd, SHUT_RDWR);
 exit1:
-	rebuild_test_case = 0;
 	close(fd);
+
+	rebuild_test_case = 0;
+
 	zk_thread_exit();
 }
 
@@ -950,6 +954,7 @@ next_step:
 #if DEBUG
 			inject_error.delay.helping_replica_rebuild_step = 0;
 #endif
+			LOG_INFO("Resetting delay to zero");
 		}
 
 		rc = uzfs_zvol_socket_read(sfd, (char *)&hdr, sizeof (hdr));
@@ -1044,7 +1049,8 @@ exit:
 }
 
 void execute_rebuild_test_case(const char *s, int test_case,
-    zvol_rebuild_status_t status, zvol_rebuild_status_t verify_status)
+    zvol_rebuild_status_t status, zvol_rebuild_status_t verify_status,
+    int verify_refcnt = 2)
 {
 	kthread_t *thrd;
 	rebuild_thread_arg_t *rebuild_args;
@@ -1069,7 +1075,7 @@ void execute_rebuild_test_case(const char *s, int test_case,
 			break;
 	}
 
-	EXPECT_EQ(2, zinfo->refcnt);
+	EXPECT_EQ(verify_refcnt, zinfo->refcnt);
 
 	EXPECT_EQ(verify_status, uzfs_zvol_get_rebuild_status(zinfo->zv));
 }
@@ -1171,19 +1177,23 @@ retry:
 TEST(uZFS, TestRebuildCompleteWithDataConn) {
 	io_receiver = &uzfs_zvol_io_receiver;
 
-	uzfs_update_metadata_granularity(zv, 0);
 	uzfs_zvol_set_rebuild_status(zv, ZVOL_REBUILDING_INIT);
-	do_data_connection(data_conn_fd, "127.0.0.1", 3232, "vol1");
+	do_data_connection(data_conn_fd, "127.0.0.1", IO_SERVER_PORT, "vol1");
 	/* thread helping rebuild will exit after writing valid write IO and REBUILD_STEP_DONE, and reads REBUILD_STEP, writes REBUILD_STEP_DONE */
 	execute_rebuild_test_case("complete rebuild with data conn", 6, ZVOL_REBUILDING_IN_PROGRESS, ZVOL_REBUILDING_INIT);
 }
 
 TEST(uZFS, TestRebuildComplete) {
-	uzfs_update_metadata_granularity(zv, 512);
+	uzfs_zvol_set_rebuild_status(zv, ZVOL_REBUILDING_INIT);
+	do_data_connection(data_conn_fd, "127.0.0.1", IO_SERVER_PORT, "vol1");
 	/* thread helping rebuild will exit after writing valid write IO and REBUILD_STEP_DONE, and reads REBUILD_STEP, writes REBUILD_STEP_DONE */
-	execute_rebuild_test_case("complete rebuild", 7, ZVOL_REBUILDING_IN_PROGRESS, ZVOL_REBUILDING_DONE);
+	execute_rebuild_test_case("complete rebuild", 7, ZVOL_REBUILDING_IN_PROGRESS, ZVOL_REBUILDING_DONE, 4);
 	EXPECT_EQ(ZVOL_STATUS_HEALTHY, uzfs_zvol_get_status(zinfo->zv));
 
+	close(data_conn_fd);
+	while (zinfo->is_io_receiver_created == B_TRUE)
+		sleep(2);
+	sleep(5);
 	memset(&zinfo->zv->rebuild_info, 0, sizeof (zvol_rebuild_info_t));
 }
 
@@ -1243,29 +1253,59 @@ TEST(RebuildScanner, AckSenderCreatedFalse) {
 	zinfo2->is_io_ack_sender_created = B_TRUE;
 	execute_rebuild_test_case("Ack Sender Created False", 8,
 	    ZVOL_REBUILDING_IN_PROGRESS, ZVOL_REBUILDING_FAILED);
-	zinfo2->is_io_ack_sender_created = B_FALSE;
+	zinfo2->is_io_ack_sender_created = B_TRUE;
 }
 
 TEST(RebuildScanner, ShutdownRebuildFd) {
 	/* Set io_ack_sender_created as B_FALSE */
-	uzfs_update_metadata_granularity(zv2, 0);
+	zinfo2->is_io_ack_sender_created = B_FALSE;
 	uzfs_zvol_set_rebuild_status(zv2, ZVOL_REBUILDING_INIT);
-	do_data_connection(data_conn_fd, "127.0.0.1", 3232, "vol3");
+	do_data_connection(data_conn_fd, "127.0.0.1", IO_SERVER_PORT, "vol3");
 	execute_rebuild_test_case("Shutdown Rebuild FD", 9,
 	    ZVOL_REBUILDING_IN_PROGRESS, ZVOL_REBUILDING_FAILED);
 }
 
 TEST(RebuildScanner, RebuildSuccess) {
-	uzfs_update_metadata_granularity(zv2, 0);
 	uzfs_zvol_set_rebuild_status(zv2, ZVOL_REBUILDING_INIT);
-	do_data_connection(data_conn_fd, "127.0.0.1", 3232, "vol3");
+	do_data_connection(data_conn_fd, "127.0.0.1", IO_SERVER_PORT, "vol3");
 	zvol_rebuild_step_size = (1024ULL * 1024ULL * 100);
 
-	/* Rebuild thread sendinc complete opcode */
+	/* Rebuild thread sending complete opcode */
 	execute_rebuild_test_case("complete rebuild", 10,
 	    ZVOL_REBUILDING_IN_PROGRESS, ZVOL_REBUILDING_DONE);
 	EXPECT_EQ(ZVOL_STATUS_HEALTHY, uzfs_zvol_get_status(zinfo->zv));
 	memset(&zinfo->zv->rebuild_info, 0, sizeof (zvol_rebuild_info_t));
+}
+
+TEST(Misc, DelayWriteAndBreakConn) {
+	struct zvol_io_rw_hdr *io_hdr;
+	zvol_io_cmd_t *zio_cmd;
+
+#if DEBUG
+	inject_error.delay.pre_uzfs_write_data = 1;
+#endif
+	zvol_io_hdr_t hdr;
+	bzero(&hdr, sizeof (hdr));
+	hdr.status = ZVOL_OP_STATUS_OK;
+	hdr.version = REPLICA_VERSION;
+	hdr.opcode = ZVOL_OPCODE_WRITE;
+	hdr.len = 512 + sizeof(struct zvol_io_rw_hdr);
+	zio_cmd = zio_cmd_alloc(&hdr, -1);
+
+	io_hdr = (struct zvol_io_rw_hdr *)zio_cmd->buf;
+	io_hdr->io_num = 100;
+	io_hdr->len = 512;
+
+	uzfs_zinfo_take_refcnt(zinfo2);
+	zio_cmd->zv = zinfo2;
+
+	taskq_dispatch(zinfo2->uzfs_zvol_taskq, uzfs_zvol_worker, zio_cmd, TQ_SLEEP);
+	sleep(5);
+	GtestUtils::graceful_close(data_conn_fd);
+	sleep(10);
+#if DEBUG
+	inject_error.delay.pre_uzfs_write_data = 0;
+#endif
 }
 
 /* Volume name stored in zinfo is "pool1/vol1" */

--- a/tests/cbtest/gtest/test_zrepl_prot.cc
+++ b/tests/cbtest/gtest/test_zrepl_prot.cc
@@ -406,25 +406,6 @@ static void transition_zvol_to_online(int &ioseq, int control_fd,
 	EXPECT_EQ(hdr_in.len, 0);
 }
 
-/*
- * We have to wait for the other end to close the connection, because the
- * next test case could initiate a new connection before this one is
- * fully closed and cause a handshake error. Or it could result in EBUSY
- * error when destroying zpool if it is not released in time by zrepl.
- */
-static void graceful_close(int sockfd)
-{
-	int rc;
-	char val;
-
-	if (sockfd < 0)
-		return;
-	shutdown(sockfd, SHUT_WR);
-	rc = read(sockfd, &val, sizeof (val));
-	ASSERT_EQ(rc, 0);
-	close(sockfd);
-}
-
 static std::string getPoolState(std::string pname)
 {
 	return (execCmd("zpool", std::string("list -Ho health ") + pname));


### PR DESCRIPTION
Changes :

    Commits from `zfs-0.7-release` branch

```
commit 9ce1f3b6ac5d933c2c27b5e2c354deb8b08ea970
Author: Vishnu Itta <vitta@mayadata.io>
Date:   Wed Sep 12 18:08:10 2018 +0530

     [DE94]fix(zfs):zrepl crash during data conn break (#109)
    
    When data connection breaks, volume's metavolblocksize is made to 0.
    If any IOs are pending during this time, executing them will use this
    and causes floating point exception.
    
    Fix is NOT to make metavolblocksize as 0, as this is not required.
    
    Signed-off-by: Vishnu Itta <vitta@mayadata.io>
```