### PR TITLE
[TA3539]Fixing snapshot rebuild related bugs in zrepl

### DIFF
--- a/include/data_conn.h
+++ b/include/data_conn.h
@@ -73,6 +73,7 @@ void uzfs_update_ionum_interval(zvol_info_t *zinfo, uint32_t timeout);
 void uzfs_zvol_timer_thread(void);
 
 void signal_fds_related_to_zinfo(zvol_info_t *zinfo);
+void quiesce_wait(zvol_info_t *zinfo, uint8_t delete_clone);
 
 #ifdef __cplusplus
 }

--- a/include/uzfs_test.h
+++ b/include/uzfs_test.h
@@ -60,6 +60,7 @@ typedef struct worker_args {
 	int *threads_done;
 	uint64_t io_block_size;
 	uint64_t active_size;
+	uint64_t start_offset;
 	int sfd[2];
 	int max_iops;
 	int rebuild_test;

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -506,13 +506,8 @@ uzfs_zvol_handle_rebuild_snap_done(zvol_io_hdr_t *hdrp,
 	}
 
 	*snap++ = '\0';
-#if 0
-	/*
-	 * TODO: Not sure if we need this check as in test automation
-	 * we can not have multiple replica with same name, intention
-	 * is to pass snap name so that snapshot of same name can be
-	 * taken at DW replica
-	 */
+
+#if !defined(DEBUG)
 	if (strcmp(zinfo->name, zvol_name) != 0) {
 		LOG_ERR("Wrong volume, Received name: %s, Expected:%s",
 		    zvol_name, zinfo->name);

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -74,18 +74,21 @@ zio_cmd_alloc(zvol_io_hdr_t *hdr, int fd)
 	    sizeof (zvol_io_cmd_t), KM_SLEEP);
 
 	bcopy(hdr, &zio_cmd->hdr, sizeof (zio_cmd->hdr));
-	if ((hdr->opcode == ZVOL_OPCODE_READ) ||
-	    (hdr->opcode == ZVOL_OPCODE_WRITE) ||
-	    (hdr->opcode == ZVOL_OPCODE_OPEN)) {
+
+	if (hdr->len != 0) {
 		zio_cmd->buf = kmem_zalloc(sizeof (char) * hdr->len, KM_SLEEP);
 		zio_cmd->buf_len = hdr->len;
+		ASSERT((hdr->opcode == ZVOL_OPCODE_READ) ||
+		    (hdr->opcode == ZVOL_OPCODE_WRITE) ||
+		    (hdr->opcode == ZVOL_OPCODE_OPEN) ||
+		    (hdr->opcode == ZVOL_OPCODE_REBUILD_SNAP_DONE));
 	}
-
 	zio_cmd->conn = fd;
 	return (zio_cmd);
 }
 
-static inline void quiesce_wait(zvol_info_t *zinfo, uint8_t delete_clone)
+void
+quiesce_wait(zvol_info_t *zinfo, uint8_t delete_clone)
 {
 	while (1) {
 		if (zinfo->quiesce_done ||
@@ -503,13 +506,19 @@ uzfs_zvol_handle_rebuild_snap_done(zvol_io_hdr_t *hdrp,
 	}
 
 	*snap++ = '\0';
-
+#if 0
+	/*
+	 * TODO: Not sure if we need this check as in test automation
+	 * we can not have multiple replica with same name, intention
+	 * is to pass snap name so that snapshot of same name can be
+	 * taken at DW replica
+	 */
 	if (strcmp(zinfo->name, zvol_name) != 0) {
 		LOG_ERR("Wrong volume, Received name: %s, Expected:%s",
 		    zvol_name, zinfo->name);
 		return (rc = -1);
 	}
-
+#endif
 	rc = uzfs_zvol_create_snapshot_update_zap(zinfo, snap, hdrp->io_seq);
 	if (rc != 0) {
 		LOG_ERR("Failed to create %s@%s: %d", zinfo->name, snap, rc);
@@ -1621,7 +1630,7 @@ uzfs_zvol_io_ack_sender(void *arg)
 
 		if (zio_cmd->hdr.opcode == ZVOL_OPCODE_REBUILD_SNAP_DONE) {
 			rc = uzfs_zvol_socket_write(zio_cmd->conn,
-			    (char *)&zio_cmd->buf, sizeof (zio_cmd->hdr.len));
+			    zio_cmd->buf, zio_cmd->hdr.len);
 error_check:
 			if (rc == -1) {
 				LOG_ERRNO("socket write err");

--- a/lib/libzrepl/mgmt_conn.c
+++ b/lib/libzrepl/mgmt_conn.c
@@ -1237,6 +1237,7 @@ handle_start_rebuild_req(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 		uzfs_update_ionum_interval(zinfo, 0);
 		LOG_INFO("Rebuild of zvol %s completed",
 		    zinfo->name);
+		quiesce_wait(zinfo, 1);
 		uzfs_zinfo_drop_refcnt(zinfo);
 		rc = reply_nodata(conn, ZVOL_OP_STATUS_OK,
 		    hdrp->opcode, hdrp->io_seq);

--- a/tests/cbtest/gtest/test_uzfs.cc
+++ b/tests/cbtest/gtest/test_uzfs.cc
@@ -1740,7 +1740,12 @@ TEST(uZFSRebuild, TestRebuildSnapDoneFailureWrongSnapName) {
 	execute_rebuild_test_case("rebuild snap_done wrong snapname", 10,
 	    ZVOL_REBUILDING_SNAP, ZVOL_REBUILDING_FAILED);
 }
-
+#if 0
+/*
+ * TODO: Since we have removed volume name check from
+ * snap_done function, we have to live without it until
+ * we find a better way to make this check work
+ */
 TEST(uZFSRebuild, TestRebuildSnapDoneFailureWrongVolName) {
 	rebuild_scanner = &uzfs_mock_rebuild_scanner_snap_rebuild_related;
 	dw_replica_fn = &uzfs_zvol_rebuild_dw_replica;
@@ -1753,7 +1758,7 @@ TEST(uZFSRebuild, TestRebuildSnapDoneFailureWrongVolName) {
 	execute_rebuild_test_case("rebuild snap_done wrong volname", 11,
 	    ZVOL_REBUILDING_SNAP, ZVOL_REBUILDING_FAILED);
 }
-
+#endif
 TEST(uZFSRebuild, TestRebuildSnapDoneSuccess) {
 	rebuild_scanner = &uzfs_mock_rebuild_scanner_snap_rebuild_related;
 	dw_replica_fn = &uzfs_zvol_rebuild_dw_replica;


### PR DESCRIPTION
Fixing couple of bugs in rebuild code:
1. When there is single replica in pod, marking it healthy should also delete clone_zv.
2. IO_ack_sender, when sending SNAP_DONE opocode, it should take proper payload len(by mistake I was passing sizeof(cmd->hdr.len).
3. Fixed script related to rebuild, because with new check introduced in rebuild path at DW replica side, mesh rebuild is not working.


Signed-off-by: Satbir <satbir.chhikara@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
