### PR TITLE
[ISS2062] fix(vol_destroy): race fixed between IO receiver and ack sender threads

### DIFF
--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -73,6 +73,7 @@ typedef struct inject_delay_s {
 	int helping_replica_rebuild_step;
 	int pre_uzfs_write_data;
 	int downgraded_replica_rebuild_size_set;
+	int io_receiver_exit;
 } inject_delay_t;
 
 typedef struct inject_error_s {
@@ -100,6 +101,11 @@ typedef struct zvol_info_s {
 	zvol_state_t    *rebuild_zv; // current snapshot which is rebuilding
 	uint64_t	refcnt;
 
+	/*
+	 * While checking for these big flags, do as below,
+	 * if (zinfo->is_io_ack_sender_created) (or)
+	 * if (!zinfo->is_io_ack_sender_created)
+	 */
 	union {
 		struct {
 			int	is_io_ack_sender_created	: 1;

--- a/lib/libzpool/zrepl_mgmt.c
+++ b/lib/libzpool/zrepl_mgmt.c
@@ -214,8 +214,8 @@ uzfs_mark_offline_and_free_zinfo(zvol_info_t *zinfo)
 
 	/* Wait for refcounts to be drained */
 	while (zinfo->refcnt > 0) {
-		LOG_DEBUG("Waiting for refcount to go down to"
-		    " zero on zvol:%s", zinfo->name);
+		LOG_INFO("Waiting for refcount (%d) to go down to"
+		    " zero on zvol:%s", zinfo->refcnt, zinfo->name);
 		sleep(5);
 	}
 	(void) uzfs_zvol_release_internal_clone(

--- a/tests/cbtest/gtest/test_uzfs.cc
+++ b/tests/cbtest/gtest/test_uzfs.cc
@@ -37,6 +37,7 @@
 #include <mgmt_conn.h>
 #include <data_conn.h>
 #include <uzfs_mgmt.h>
+#include <sys/eventfd.h>
 #include <sys/epoll.h>
 #include <sys/dsl_destroy.h>
 #include <uzfs_rebuilding.h>
@@ -45,10 +46,12 @@
 
 char *ds_name;
 char *ds_name2;
+char *ds_name_todelete;
 char *pool;
 spa_t *spa;
 zvol_state_t *zv;
 zvol_state_t *zv2;
+zvol_state_t *zv_todelete;
 zvol_info_t *zinfo;
 zvol_info_t *zinfo2;
 int rebuild_test_case = 0;
@@ -58,6 +61,7 @@ int mgmt_test_case = 0;
 int done_thread_count = 0;
 pthread_mutex_t done_thread_count_mtx = PTHREAD_MUTEX_INITIALIZER;
 int data_conn_fd = -1;
+int data_conn_fd_todelete = -1;
 
 extern void (*zinfo_create_hook)(zvol_info_t *, nvlist_t *);
 extern void (*zinfo_destroy_hook)(zvol_info_t *);
@@ -358,7 +362,7 @@ uzfs_mock_rebuild_scanner_rebuild_comp(void *arg)
 		conn_fd = data_conn_fd;
 		data_conn_fd = -1;
 		close(conn_fd);
-		while (zinfo->is_io_receiver_created == B_TRUE)
+		while (zinfo->is_io_receiver_created)
 			sleep(2);
 		sleep(5);
 	}
@@ -543,10 +547,13 @@ TEST(uZFS, Setup) {
 	int ret;
 	char *pool_ds;
 	char *pool_ds2;
+	char *pool_ds_todelete;
 	ds_name = (char *)malloc(MAXNAMELEN);
 	ds_name2 = (char *)malloc(MAXNAMELEN);
+	ds_name_todelete = (char *)malloc(MAXNAMELEN);
 	pool_ds = (char *)malloc(MAXNAMELEN);
 	pool_ds2 = (char *)malloc(MAXNAMELEN);
+	pool_ds_todelete = (char *)malloc(MAXNAMELEN);
 	path = (char *)malloc(MAXNAMELEN);
 	pool = (char *)malloc(MAXNAMELEN);
 
@@ -554,14 +561,17 @@ TEST(uZFS, Setup) {
 	GtestUtils::strlcpy(pool, "pool1", MAXNAMELEN);
 	GtestUtils::strlcpy(ds_name, "vol1", MAXNAMELEN);
 	GtestUtils::strlcpy(ds_name2, "vol3", MAXNAMELEN);
+	GtestUtils::strlcpy(ds_name_todelete, "vol_todelete", MAXNAMELEN);
 	GtestUtils::strlcpy(pool_ds, "pool1/vol1", MAXNAMELEN);
 	GtestUtils::strlcpy(pool_ds2, "pool1/vol3", MAXNAMELEN);
+	GtestUtils::strlcpy(pool_ds_todelete, "pool1/vol_todelete", MAXNAMELEN);
 	signal(SIGPIPE, SIG_IGN);
 
 	mutex_init(&conn_list_mtx, NULL, MUTEX_DEFAULT, NULL);
 	SLIST_INIT(&uzfs_mgmt_conns);
 	mutex_init(&async_tasks_mtx, NULL, MUTEX_DEFAULT, NULL);
-	mgmt_eventfd = -1;
+
+	mgmt_eventfd = eventfd(0, EFD_NONBLOCK);
 
 	uzfs_init();
 	init_zrepl();
@@ -591,6 +601,12 @@ TEST(uZFS, Setup) {
 	uzfs_zinfo_init(zv2, pool_ds2, NULL);
 	zinfo2 = uzfs_zinfo_lookup(ds_name2);
 	EXPECT_EQ(0, !zinfo2);
+
+	uzfs_create_dataset(spa, ds_name_todelete, 1024*1024*1024, 512, &zv_todelete);
+	uzfs_hold_dataset(zv_todelete);
+	uzfs_update_metadata_granularity(zv_todelete, 512);
+	strncpy(zv_todelete->zv_target_host,"127.0.0.1:5959", MAXNAMELEN);
+	uzfs_zinfo_init(zv_todelete, pool_ds_todelete, NULL);
 
 	uzfs_zinfo_init(zv, pool_ds, NULL);
 	zinfo = uzfs_zinfo_lookup(ds_name);
@@ -714,12 +730,12 @@ TEST(uZFS, asyncTaskProps) {
 TEST(uZFS, EmptyCreateProps) {
 	uzfs_mgmt_conn_t *conn;
 
-	EXPECT_EQ(2, uzfs_mgmt_conn_list_count(&uzfs_mgmt_conns));
+	EXPECT_EQ(3, uzfs_mgmt_conn_list_count(&uzfs_mgmt_conns));
 	conn = SLIST_FIRST(&uzfs_mgmt_conns);
 	EXPECT_EQ(1, conn->conn_refcount);
 
 	zinfo_create_cb(zinfo, NULL);
-	EXPECT_EQ(2, uzfs_mgmt_conn_list_count(&uzfs_mgmt_conns));
+	EXPECT_EQ(3, uzfs_mgmt_conn_list_count(&uzfs_mgmt_conns));
 	conn = SLIST_FIRST(&uzfs_mgmt_conns);
 	EXPECT_EQ(2, conn->conn_refcount);
 }
@@ -1041,7 +1057,7 @@ TEST(uZFSRebuildStart, TestStartRebuild) {
 	rebuild_status[3] = ZVOL_REBUILDING_ERRORED;
 	rebuild_status[4] = ZVOL_REBUILDING_FAILED;
 
-	EXPECT_EQ(2, uzfs_mgmt_conn_list_count(&uzfs_mgmt_conns));
+	EXPECT_EQ(3, uzfs_mgmt_conn_list_count(&uzfs_mgmt_conns));
 	EXPECT_EQ(2, zinfo->refcnt);
 	conn = SLIST_FIRST(&uzfs_mgmt_conns);
 
@@ -1662,6 +1678,20 @@ TEST(uZFSRebuild, TestRebuildExitAfterValidWrite) {
 	    ZVOL_REBUILDING_SNAP, ZVOL_REBUILDING_FAILED);
 }
 
+TEST(uZFS, CreateAndDestroyDelayIOReceiverExit) {
+	io_receiver = &uzfs_zvol_io_receiver;
+	do_data_connection(data_conn_fd_todelete, "127.0.0.1", IO_SERVER_PORT, "vol_todelete");
+#if DEBUG
+	inject_error.delay.io_receiver_exit = 1;
+#endif
+	close(data_conn_fd_todelete);
+	uzfs_zinfo_destroy("pool1/vol_todelete", spa);
+#if DEBUG
+	sleep(5);
+	inject_error.delay.io_receiver_exit = 0;
+#endif
+}
+
 TEST(uZFSRebuild, TestRebuildCompleteWithDataConn) {
 	io_receiver = &uzfs_zvol_io_receiver;
 	rebuild_scanner = &uzfs_mock_rebuild_scanner_rebuild_comp;
@@ -1698,7 +1728,7 @@ TEST(uZFSRebuild, TestRebuildComplete) {
 	EXPECT_EQ(ZVOL_STATUS_HEALTHY, uzfs_zvol_get_status(zinfo->main_zv));
 
 	close(data_conn_fd);
-	while (zinfo->is_io_receiver_created == B_TRUE)
+	while (zinfo->is_io_receiver_created)
 		sleep(2);
 	sleep(5);
 	memset(&zinfo->main_zv->rebuild_info, 0, sizeof (zvol_rebuild_info_t));

--- a/tests/cbtest/gtest/test_uzfs.cc
+++ b/tests/cbtest/gtest/test_uzfs.cc
@@ -1678,7 +1678,7 @@ TEST(uZFSRebuild, TestRebuildExitAfterValidWrite) {
 	    ZVOL_REBUILDING_SNAP, ZVOL_REBUILDING_FAILED);
 }
 
-TEST(uZFS, CreateAndDestroyDelayIOReceiverExit) {
+TEST(uZFSIOConnAccept, CreateAndDestroyDelayIOReceiverExit) {
 	io_receiver = &uzfs_zvol_io_receiver;
 	do_data_connection(data_conn_fd_todelete, "127.0.0.1", IO_SERVER_PORT, "vol_todelete");
 #if DEBUG
@@ -2226,7 +2226,7 @@ void mgmt_thread_test_case(int test_case)
 
 kthread_t	*mgmt_thread;
 TEST(MgmtThreadTest, MgmtThreadCreation) {
-	EXPECT_EQ(2, uzfs_mgmt_conn_list_count(&uzfs_mgmt_conns));
+	EXPECT_EQ(3, uzfs_mgmt_conn_list_count(&uzfs_mgmt_conns));
 	EXPECT_EQ(2, zinfo->refcnt);
 
 	mgmt_thread = zk_thread_create(NULL, 0, uzfs_zvol_mgmt_thread,


### PR DESCRIPTION
Changes : 
Cherry-pick fix from `v0.7.x`
```
commit d1860d81153c30e94a4f65acd0f464fea25cbc39
Author: Vishnu Itta <vitta@mayadata.io>
Date:   Wed Oct 10 10:50:41 2018 +0530

    [ISS2062] fix(vol_destroy): race fixed between IO receiver and ack sender threads (#130)
    
    Signed-off-by: Vishnu Itta <vitta@mayadata.io>
```

Signed-off-by: Vishnu Itta <vitta@mayadata.io>
