### PR TITLE
[TA3684] fix(rebuild): create new internal snap for every rebuild

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -1,8 +1,8 @@
-SUBDIRS  = zfs zpool zdb zhack zinject zstreamdump ztest uzfs_test zpios
+SUBDIRS  = zfs zpool zdb zhack zinject zstreamdump ztest zpios
 SUBDIRS += mount_zfs fsck_zfs zvol_id vdev_id arcstat dbufstat zed
 SUBDIRS += arc_summary raidz_test zgenhostid
 
 if ENABLE_UZFS
-SUBDIRS += zrepl
+SUBDIRS += zrepl uzfs_test
 endif
 

--- a/cmd/uzfs_test/Makefile.am
+++ b/cmd/uzfs_test/Makefile.am
@@ -22,6 +22,7 @@ uzfs_test_LDADD = \
 	$(top_builddir)/lib/libnvpair/libnvpair.la \
 	$(top_builddir)/lib/libuutil/libuutil.la \
 	$(top_builddir)/lib/libzpool/libzpool.la \
+	$(top_builddir)/lib/libzpool/libzrepl.la \
 	$(top_builddir)/lib/libzfs/libzfs.la \
 	$(top_builddir)/lib/libzfs_core/libzfs_core.la
 

--- a/cmd/uzfs_test/Makefile.am
+++ b/cmd/uzfs_test/Makefile.am
@@ -22,7 +22,7 @@ uzfs_test_LDADD = \
 	$(top_builddir)/lib/libnvpair/libnvpair.la \
 	$(top_builddir)/lib/libuutil/libuutil.la \
 	$(top_builddir)/lib/libzpool/libzpool.la \
-	$(top_builddir)/lib/libzpool/libzrepl.la \
+	$(top_builddir)/lib/libzrepl/libzrepl.la \
 	$(top_builddir)/lib/libzfs/libzfs.la \
 	$(top_builddir)/lib/libzfs_core/libzfs_core.la
 

--- a/include/data_conn.h
+++ b/include/data_conn.h
@@ -71,6 +71,8 @@ void uzfs_zvol_rebuild_dw_replica(void *arg);
 void uzfs_zvol_rebuild_scanner(void *arg);
 void uzfs_update_ionum_interval(zvol_info_t *zinfo, uint32_t timeout);
 void uzfs_zvol_timer_thread(void);
+int uzfs_zvol_create_internal_snapshot(zvol_state_t *zv, zvol_state_t **snap_zv,
+    uint64_t io_num);
 
 void signal_fds_related_to_zinfo(zvol_info_t *zinfo);
 void quiesce_wait(zvol_info_t *zinfo, uint8_t delete_clone);

--- a/include/data_conn.h
+++ b/include/data_conn.h
@@ -75,6 +75,9 @@ void uzfs_zvol_timer_thread(void);
 void signal_fds_related_to_zinfo(zvol_info_t *zinfo);
 void quiesce_wait(zvol_info_t *zinfo, uint8_t delete_clone);
 
+int uzfs_zvol_create_internal_snapshot(zvol_state_t *zv, zvol_state_t **snap_zv,
+    uint64_t io_num);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/uzfs_mgmt.h
+++ b/include/uzfs_mgmt.h
@@ -46,7 +46,8 @@ extern void uzfs_fini(void);
 extern uint64_t uzfs_random(uint64_t);
 extern int uzfs_hold_dataset(zvol_state_t *zv);
 extern void uzfs_rele_dataset(zvol_state_t *zv);
-int get_snapshot_zv(zvol_state_t *zv, char *snap_name, zvol_state_t **snap_zv);
+int get_snapshot_zv(zvol_state_t *zv, const char *snap_name,
+    zvol_state_t **snap_zv, boolean_t fail_exists, boolean_t fail_notexists);
 extern void destroy_snapshot_zv(zvol_state_t *zv, char *snap_name);
 
 int uzfs_pool_create(const char *name, char *path, spa_t **spa);

--- a/lib/libzpool/uzfs_mgmt.c
+++ b/lib/libzpool/uzfs_mgmt.c
@@ -565,8 +565,15 @@ uzfs_zvol_create_minors(spa_t *spa, const char *name)
 	kmem_free(pool_name, MAXNAMELEN);
 }
 
+/*
+ * For given zv, a snapshot with snap_name will be created if doesn't exists.
+ * Opens/holds the snapshot and fills the snap_zv.
+ * fail_exists being true returns EEXIST if snapshot already exists.
+ * fail_notexists being true returns ENOENT if snapshot doesn't exists.
+ */
 int
-get_snapshot_zv(zvol_state_t *zv, char *snap_name, zvol_state_t **snap_zv)
+get_snapshot_zv(zvol_state_t *zv, const char *snap_name, zvol_state_t **snap_zv,
+    boolean_t fail_exists, boolean_t fail_notexists)
 {
 	char *dataset;
 	int ret = 0;
@@ -576,10 +583,17 @@ get_snapshot_zv(zvol_state_t *zv, char *snap_name, zvol_state_t **snap_zv)
 
 	ret = uzfs_open_dataset(zv->zv_spa, dataset, snap_zv);
 	if (ret == ENOENT) {
+		if (fail_notexists) {
+			LOG_ERR("fail on unavailable snapshot %s",
+			    dataset);
+			strfree(dataset);
+			ret = SET_ERROR(ENOENT);
+			return (ret);
+		}
 		ret = dmu_objset_snapshot_one(zv->zv_name, snap_name);
 		if (ret) {
-			LOG_ERR("Failed to create snapshot %s@%s: %d",
-			    zv->zv_name, snap_name, ret);
+			LOG_ERR("Failed to create snapshot %s: %d",
+			    dataset, ret);
 			strfree(dataset);
 			return (ret);
 		}
@@ -588,20 +602,31 @@ get_snapshot_zv(zvol_state_t *zv, char *snap_name, zvol_state_t **snap_zv)
 		if (ret == 0) {
 			ret = uzfs_hold_dataset(*snap_zv);
 			if (ret != 0) {
-				LOG_ERR("Failed to hold snapshot: %d", ret);
+				LOG_ERR("Failed to hold snapshot %s: %d",
+				    dataset, ret);
 				uzfs_close_dataset(*snap_zv);
+				*snap_zv = NULL;
 			}
 		}
 		else
 			LOG_ERR("Failed to open snapshot: %d", ret);
 	} else if (ret == 0) {
-		LOG_INFO("holding already available snapshot %s@%s",
-		    zv->zv_name, snap_name);
-		ret = uzfs_hold_dataset(*snap_zv);
-		if (ret != 0) {
-			LOG_ERR("Failed to hold already existing snapshot: %d",
-			    ret);
+		if (fail_exists) {
+			LOG_ERR("fail on already available snapshot %s",
+			    dataset);
 			uzfs_close_dataset(*snap_zv);
+			*snap_zv = NULL;
+			ret = SET_ERROR(EEXIST);
+		} else {
+			LOG_INFO("holding already available snapshot %s",
+			    dataset);
+			ret = uzfs_hold_dataset(*snap_zv);
+			if (ret != 0) {
+				LOG_ERR("Failed to hold already existing "
+				    "snapshot %s: %d", dataset, ret);
+				uzfs_close_dataset(*snap_zv);
+				*snap_zv = NULL;
+			}
 		}
 	} else
 		LOG_ERR("Failed to open snapshot: %d", ret);

--- a/lib/libzpool/uzfs_rebuilding.c
+++ b/lib/libzpool/uzfs_rebuilding.c
@@ -79,7 +79,7 @@ uzfs_get_io_diff(zvol_state_t *zv, blk_metadata_t *low, zvol_state_t *snap,
 	uint64_t metaobjectsize = (zv->zv_volsize / zv->zv_metavolblocksize) *
 	    zv->zv_volmetadatasize;
 	uint64_t metadatasize = zv->zv_volmetadatasize;
-	char *buf, *snap_name = NULL;
+	char *buf;
 	uint64_t i, read;
 	uint64_t offset, len, end;
 	int ret = 0;
@@ -89,7 +89,7 @@ uzfs_get_io_diff(zvol_state_t *zv, blk_metadata_t *low, zvol_state_t *snap,
 	zvol_state_t *snap_zv;
 	metaobj_blk_offset_t snap_metablk;
 
-	if (!func || (lun_offset + lun_len) > zv->zv_volsize)
+	if (!func || (lun_offset + lun_len) > zv->zv_volsize || snap == NULL)
 		return (EINVAL);
 
 	get_zv_metaobj_block_details(&snap_metablk, zv, lun_offset, lun_len);
@@ -98,19 +98,7 @@ uzfs_get_io_diff(zvol_state_t *zv, blk_metadata_t *low, zvol_state_t *snap,
 
 	if (end > metaobjectsize)
 		end = metaobjectsize;
-	if (snap == NULL) {
-		snap_name = kmem_asprintf("%s%llu", IO_DIFF_SNAPNAME,
-		    low->io_num);
-		ret = get_snapshot_zv(zv, snap_name, &snap_zv);
-		if (ret != 0) {
-			LOG_ERR("Failed to get info about %s@%s io_num %lu",
-			    zv->zv_name, snap_name, low->io_num);
-			strfree(snap_name);
-			return (ret);
-		}
-	} else {
-		snap_zv = snap;
-	}
+	snap_zv = snap;
 
 	metadata_read_chunk_size = (metadata_read_chunk_size / metadatasize) *
 	    metadatasize;
@@ -186,19 +174,6 @@ uzfs_get_io_diff(zvol_state_t *zv, blk_metadata_t *low, zvol_state_t *snap,
 			if (ret != 0)
 				break;
 		}
-	}
-
-	if (snap == NULL) {
-		uzfs_close_dataset(snap_zv);
-
-		/*
-		 * TODO: if we failed to destroy snapshot here then
-		 * this should be handled separately from application.
-		 */
-		if (end == metaobjectsize)
-			destroy_snapshot_zv(zv, snap_name);
-
-		strfree(snap_name);
 	}
 	umem_free(buf, metadata_read_chunk_size);
 	return (ret);
@@ -359,7 +334,8 @@ uzfs_zvol_get_or_create_internal_clone(zvol_state_t *zv,
 	char *clonename = NULL;
 	char *clone_subname = NULL;
 
-	ret = get_snapshot_zv(zv, REBUILD_SNAPSHOT_SNAPNAME, snap_zv);
+	ret = get_snapshot_zv(zv, REBUILD_SNAPSHOT_SNAPNAME, snap_zv, B_FALSE,
+	    B_FALSE);
 	if (ret != 0) {
 		LOG_ERR("Failed to get info about %s@%s",
 		    zv->zv_name, REBUILD_SNAPSHOT_SNAPNAME);
@@ -391,6 +367,11 @@ uzfs_zvol_get_or_create_internal_clone(zvol_state_t *zv,
 				LOG_ERR("Failed to hold clone: %d", ret);
 				uzfs_close_dataset(*clone_zv);
 				*clone_zv = NULL;
+				/*
+				 * commenting out destroy clone for sake
+				 * of NOT to lose data
+				 */
+#if 0
 				/* Destroy clone */
 				ret = dsl_destroy_head(clonename);
 				if (ret != 0)
@@ -400,18 +381,24 @@ uzfs_zvol_get_or_create_internal_clone(zvol_state_t *zv,
 				uzfs_close_dataset(*snap_zv);
 				destroy_snapshot_zv(zv,
 				    REBUILD_SNAPSHOT_SNAPNAME);
+#endif
 				*snap_zv = NULL;
 			}
 		} else {
 			uzfs_close_dataset(*snap_zv);
-			destroy_snapshot_zv(zv, REBUILD_SNAPSHOT_SNAPNAME);
+/*
+ *			destroy_snapshot_zv(zv, REBUILD_SNAPSHOT_SNAPNAME);
+ */
 			*snap_zv = NULL;
 			LOG_INFO("Clone:%s not able to open", clone_subname);
 		}
 	} else if (ret != 0) {
 		uzfs_close_dataset(*snap_zv);
-		destroy_snapshot_zv(zv, REBUILD_SNAPSHOT_SNAPNAME);
+/*
+ *		destroy_snapshot_zv(zv, REBUILD_SNAPSHOT_SNAPNAME);
+ */
 		*snap_zv = NULL;
+		LOG_INFO("Clone:%s from snap %s fails", clonename, snapname);
 	}
 
 	strfree(clone_subname);

--- a/lib/libzpool/uzfs_rebuilding.c
+++ b/lib/libzpool/uzfs_rebuilding.c
@@ -378,7 +378,9 @@ uzfs_zvol_get_or_create_internal_clone(zvol_state_t *zv,
 					LOG_ERRNO("Rebuild_clone destroy "
 					    "failed on:%s with err:%d",
 					    zv->zv_name, ret);
+#endif
 				uzfs_close_dataset(*snap_zv);
+#if 0
 				destroy_snapshot_zv(zv,
 				    REBUILD_SNAPSHOT_SNAPNAME);
 #endif

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -1156,7 +1156,8 @@ uzfs_zvol_io_conn_acceptor(void *arg)
 			rc = 0;
 
 			if (events[i].data.fd == io_sfd) {
-				LOG_INFO("New data connection");
+				LOG_INFO("New data connection on fd %d",
+				    new_fd);
 				thrd_info = zk_thread_create(NULL, 0,
 				    (thread_func_t)io_receiver,
 				    (void *)new_fd, 0, NULL, TS_RUN, 0,
@@ -2029,14 +2030,14 @@ exit:
 
 	taskq_wait(zinfo->uzfs_zvol_taskq);
 	reinitialize_zv_state(zinfo->main_zv);
-	zinfo->is_io_receiver_created = 0;
 	(void) uzfs_zvol_release_internal_clone(zinfo->main_zv,
 	    &zinfo->snap_zv, &zinfo->clone_zv);
 
 	zinfo->quiesce_requested = 0;
 	zinfo->quiesce_done = 1;
-	uzfs_zinfo_drop_refcnt(zinfo);
+	zinfo->is_io_receiver_created = 0;
 	zinfo->io_fd = -1;
+	uzfs_zinfo_drop_refcnt(zinfo);
 thread_exit:
 	close(fd);
 	LOG_INFO("Data connection closed on fd: %d", fd);

--- a/lib/libzrepl/mgmt_conn.c
+++ b/lib/libzrepl/mgmt_conn.c
@@ -871,13 +871,21 @@ uzfs_get_snap_zv_ionum(zvol_info_t *zinfo, uint64_t ionum,
 		}
 		if (internal_snapshot(snapname))
 			continue;
-		error = get_snapshot_zv(zv, snapname, &snap_zv);
-		if (error)
+		error = get_snapshot_zv(zv, snapname, &snap_zv, B_FALSE,
+		    B_TRUE);
+		if (error) {
+			LOG_ERR("err %d in getting snap %s", error, snapname);
 			break;
+		}
 		error = uzfs_zvol_get_last_committed_io_no(snap_zv,
 		    HEALTHY_IO_SEQNUM, &healthy_ionum);
-		if (error)
+		if (error) {
+			LOG_ERR("err %d in getting last commited for snap %s",
+			    error, snap_zv->zv_name);
+			uzfs_close_dataset(snap_zv);
+			snap_zv = NULL;
 			break;
+		}
 		if ((healthy_ionum > ionum) &&
 		    ((smallest_higher_snapzv == NULL) ||
 		    (smallest_higher_ionum > healthy_ionum))) {


### PR DESCRIPTION
For every rebuild, a new internal snapshot need to be created on the helping replica. But, currently, if a new internal snapshots exists, it will use it in the rebuild process.
This PR creates new internal snapshot on the helping replica for every rebuild request.

Also, currently, on any error of opening/holding the rebuild snapshot or clone, rebuild snapshot and clone gets deleted. This PR comments out that code.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>