### PR TITLE
[TA3363] hardening code, added assert to make sure clone_zv and snap_…

### DIFF
--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -262,8 +262,8 @@ uzfs_submit_writes(zvol_info_t *zinfo, zvol_io_cmd_t *zio_cmd)
 		 * Write to main_zv when volume is either
 		 * healthy or in REBUILD_AFS state of rebuild
 		 */
-		if (is_rebuild || ZVOL_IS_REBUILDING_AFS(zinfo->main_zv) ||
-		    ZVOL_IS_HEALTHY(zinfo->main_zv)) {
+		if (ZVOL_IS_HEALTHY(zinfo->main_zv) || is_rebuild ||
+		    ZVOL_IS_REBUILDING_AFS(zinfo->main_zv)) {
 			rc = uzfs_write_data(zinfo->main_zv, datap, data_offset,
 			    write_hdr->len, &metadata, is_rebuild);
 			if (rc != 0)

--- a/tests/cbtest/gtest/test_uzfs.cc
+++ b/tests/cbtest/gtest/test_uzfs.cc
@@ -1746,7 +1746,8 @@ TEST(uZFSRebuild, TestRebuildComplete) {
 
 	uzfs_zvol_set_rebuild_status(zv, ZVOL_REBUILDING_INIT);
 	do_data_connection(data_conn_fd, "127.0.0.1", IO_SERVER_PORT, "vol1");
-
+	EXPECT_EQ(NULL, !zinfo->clone_zv);
+	EXPECT_EQ(NULL, !zinfo->snap_zv);
 	/*
 	 * thread helping rebuild will exit after writing
 	 * valid write IO and REBUILD_STEP_DONE, and reads
@@ -1761,6 +1762,9 @@ TEST(uZFSRebuild, TestRebuildComplete) {
 	while (zinfo->is_io_receiver_created)
 		sleep(2);
 	sleep(5);
+
+	EXPECT_EQ(NULL, zinfo->clone_zv);
+	EXPECT_EQ(NULL, zinfo->snap_zv);
 	memset(&zinfo->main_zv->rebuild_info, 0, sizeof (zvol_rebuild_info_t));
 }
 


### PR DESCRIPTION

Signed-off-by: satbir <satbir.chhikara@gmail.com>

Clone_zv and snap_zv should be created with data connection. Both of should be freed/released at time of data disconnection. I have added assert in gtest to make sure it is happening. 