### PR TITLE
debug(log): added log message when snap destroy fails

### DIFF
--- a/include/uzfs_mgmt.h
+++ b/include/uzfs_mgmt.h
@@ -48,7 +48,7 @@ extern int uzfs_hold_dataset(zvol_state_t *zv);
 extern void uzfs_rele_dataset(zvol_state_t *zv);
 int get_snapshot_zv(zvol_state_t *zv, const char *snap_name,
     zvol_state_t **snap_zv, boolean_t fail_exists, boolean_t fail_notexists);
-extern void destroy_snapshot_zv(zvol_state_t *zv, char *snap_name);
+extern int destroy_snapshot_zv(zvol_state_t *zv, char *snap_name);
 
 int uzfs_pool_create(const char *name, char *path, spa_t **spa);
 #ifdef __cplusplus

--- a/lib/libzpool/uzfs_mgmt.c
+++ b/lib/libzpool/uzfs_mgmt.c
@@ -635,14 +635,16 @@ get_snapshot_zv(zvol_state_t *zv, const char *snap_name, zvol_state_t **snap_zv,
 	return (ret);
 }
 
-void
+int
 destroy_snapshot_zv(zvol_state_t *zv, char *snap_name)
 {
 	char *dataset;
+	int ret;
 
 	dataset = kmem_asprintf("%s@%s", zv->zv_name, snap_name);
-	(void) dsl_destroy_snapshot(dataset, B_FALSE);
+	ret = dsl_destroy_snapshot(dataset, B_FALSE);
 	strfree(dataset);
+	return (ret);
 }
 
 /* uZFS Zvol destroy call back function */

--- a/lib/libzpool/uzfs_rebuilding.c
+++ b/lib/libzpool/uzfs_rebuilding.c
@@ -285,6 +285,7 @@ uzfs_zvol_destroy_internal_clone(zvol_state_t *zv,
     zvol_state_t **snap_zv, zvol_state_t **clone_zv)
 {
 	int ret = 0;
+	int ret1 = 0;
 	char *clonename;
 
 	if (*snap_zv == NULL) {
@@ -313,10 +314,12 @@ uzfs_zvol_destroy_internal_clone(zvol_state_t *zv,
 	*snap_zv = NULL;
 
 	/* Destroy snapshot */
-	ret = destroy_snapshot_zv(zv, REBUILD_SNAPSHOT_SNAPNAME);
-	if (ret != 0)
+	ret1 = destroy_snapshot_zv(zv, REBUILD_SNAPSHOT_SNAPNAME);
+	if (ret1 != 0) {
 		LOG_ERR("Rebuild_snap destroy failed on:%s"
-		    " with err:%d", zv->zv_name, ret);
+		    " with err:%d", zv->zv_name, ret1);
+		ret = ret1;
+	}
 
 	strfree(clonename);
 

--- a/lib/libzpool/uzfs_rebuilding.c
+++ b/lib/libzpool/uzfs_rebuilding.c
@@ -305,7 +305,7 @@ uzfs_zvol_destroy_internal_clone(zvol_state_t *zv,
 	/* Destroy clone */
 	ret = dsl_destroy_head(clonename);
 	if (ret != 0)
-		LOG_ERRNO("Rebuild_clone destroy failed on:%s"
+		LOG_ERR("Rebuild_clone destroy failed on:%s"
 		    " with err:%d", zv->zv_name, ret);
 
 	/* Close snapshot dataset */
@@ -313,7 +313,11 @@ uzfs_zvol_destroy_internal_clone(zvol_state_t *zv,
 	*snap_zv = NULL;
 
 	/* Destroy snapshot */
-	destroy_snapshot_zv(zv, REBUILD_SNAPSHOT_SNAPNAME);
+	ret = destroy_snapshot_zv(zv, REBUILD_SNAPSHOT_SNAPNAME);
+	if (ret != 0)
+		LOG_ERR("Rebuild_snap destroy failed on:%s"
+		    " with err:%d", zv->zv_name, ret);
+
 	strfree(clonename);
 
 	return (ret);


### PR DESCRIPTION
This PR is to add a log message when snapshot destroy fails. This also changes the signature of the function `destroy_snapshot_zv` API to return error.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>