### PR TITLE
Edit Dockerfile.demo to install iproute2 package

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -8,6 +8,7 @@ FROM ubuntu:16.04
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \ 
     apt-get update && apt-get install -y \
+    iproute2 \
     libaio1 libaio-dev \
     libkqueue-dev libssl1.0.0 rsyslog net-tools gdb apt-utils \
     sed libjemalloc-dev openssh-server


### PR DESCRIPTION
**This PR does the following**:
- Adds a line in Dockerfile ```(Dockerfile.demo)``` to include **iproute2** package.
**Why we need iproute ?**
- In order to test **cstor** we can have a scenario where we some network delay will be induced on the cstor pool conatiner with the help of a tool called **PUMBA**.
- This PUMBA tool uses tc-command (traffic contoller) to induce such delays.
