### PR TITLE
Adding support of dumping the object to respective files in zstreamdump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 COPY cmd/zrepl/.libs/zrepl /usr/local/bin/
 COPY cmd/zpool/.libs/zpool /usr/local/bin/
 COPY cmd/zfs/.libs/zfs /usr/local/bin/
+COPY cmd/zstreamdump/.libs/zstreamdump /usr/local/bin/
 
 COPY lib/libzrepl/.libs/*.so* /usr/lib/
 COPY lib/libzpool/.libs/*.so* /usr/lib/

--- a/build_image.sh
+++ b/build_image.sh
@@ -17,6 +17,7 @@ mkdir -p ./docker/zfs/lib
 cp cmd/zrepl/.libs/zrepl ./docker/zfs/bin
 cp cmd/zpool/.libs/zpool ./docker/zfs/bin
 cp cmd/zfs/.libs/zfs ./docker/zfs/bin
+cp cmd/zstreamdump/.libs/zstreamdump ./docker/zfs/bin
 
 cp lib/libzrepl/.libs/*.so* ./docker/zfs/lib
 cp lib/libzpool/.libs/*.so* ./docker/zfs/lib

--- a/cmd/zstreamdump/zstreamdump.c
+++ b/cmd/zstreamdump/zstreamdump.c
@@ -309,12 +309,6 @@ main(int argc, char *argv[])
 	}
 
 	fletcher_4_init();
-	int fp = -1;
-	fp = open("/tmp/adump", O_RDWR|O_CREAT|O_APPEND, O_RDWR);
-	if (fp == -1) {
-		printf("errored\n");
-		exit(1);
-	}
 
 	send_stream = stdin;
 	while (read_hdr(drr, &zc)) {

--- a/cmd/zstreamdump/zstreamdump.c
+++ b/cmd/zstreamdump/zstreamdump.c
@@ -67,6 +67,9 @@ usage(void)
 	(void) fprintf(stderr, "\t -C -- suppress checksum verification\n");
 	(void) fprintf(stderr, "\t -d -- dump contents of blocks modified, "
 	    "implies verbose\n");
+#ifdef	_UZFS
+	(void) fprintf(stderr, "\t -w -- create dump files per object\n");
+#endif
 	exit(1);
 }
 
@@ -104,6 +107,33 @@ ssread(void *buf, size_t len, zio_cksum_t *cksum)
 	total_stream_len += len;
 	return (outlen);
 }
+
+#ifdef	_UZFS
+int object_fd = -1;
+uint64_t last_object;
+
+static int
+dump_object_to_file(uint64_t object, char *buf, uint64_t len)
+{
+	char object_file[32];
+
+	if (object_fd == -1 || last_object != object) {
+		snprintf(object_file, sizeof (object_file),
+		    "%lu.dump", object);
+		if (object_fd != -1)
+			close(object_fd);
+		object_fd = open(object_file, O_RDWR|O_CREAT|O_APPEND, O_RDWR);
+		if (object_fd == -1) {
+			fprintf(stderr, "Failed to open object dump "
+			    "file '%s' err:%d\n", object_file, errno);
+			return (errno);
+		}
+		last_object = object;
+	}
+
+	return (write(object_fd, buf, len));
+}
+#endif
 
 static size_t
 read_hdr(dmu_replay_record_t *drr, zio_cksum_t *cksum)
@@ -219,6 +249,10 @@ main(int argc, char *argv[])
 	boolean_t verbose = B_FALSE;
 	boolean_t very_verbose = B_FALSE;
 	boolean_t first = B_TRUE;
+#ifdef	_UZFS
+	boolean_t dump_object = B_FALSE;
+#endif
+
 	/*
 	 * dump flag controls whether the contents of any modified data blocks
 	 * are printed to the console during processing of the stream. Warning:
@@ -229,7 +263,11 @@ main(int argc, char *argv[])
 	zio_cksum_t zc = { { 0 } };
 	zio_cksum_t pcksum = { { 0 } };
 
+#ifdef	_UZFS
+	while ((c = getopt(argc, argv, ":vCdw")) != -1) {
+#else
 	while ((c = getopt(argc, argv, ":vCd")) != -1) {
+#endif
 		switch (c) {
 		case 'C':
 			do_cksum = B_FALSE;
@@ -244,6 +282,11 @@ main(int argc, char *argv[])
 			verbose = B_TRUE;
 			very_verbose = B_TRUE;
 			break;
+#ifdef	_UZFS
+		case 'w':
+			dump_object = B_TRUE;
+			break;
+#endif
 		case ':':
 			(void) fprintf(stderr,
 			    "missing argument for '%c' option\n", optopt);
@@ -266,6 +309,13 @@ main(int argc, char *argv[])
 	}
 
 	fletcher_4_init();
+	int fp = -1;
+	fp = open("/tmp/adump", O_RDWR|O_CREAT|O_APPEND, O_RDWR);
+	if (fp == -1) {
+		printf("errored\n");
+		exit(1);
+	}
+
 	send_stream = stdin;
 	while (read_hdr(drr, &zc)) {
 
@@ -499,6 +549,20 @@ main(int argc, char *argv[])
 			 * Read the contents of the block in from STDIN to buf
 			 */
 			(void) ssread(buf, payload_size, &zc);
+
+#ifdef	_UZFS
+			/*
+			 * dump object data to a file
+			 */
+			if (dump_object == B_TRUE) {
+				if (dump_object_to_file(drrw->drr_object,
+				    buf, payload_size) == -1) {
+					fprintf(stderr, "Failed to dump "
+					    "object:%lu\n", drrw->drr_object);
+					exit(1);
+				}
+			}
+#endif
 			/*
 			 * If in dump mode
 			 */


### PR DESCRIPTION
Changes:
- Adding  support of dumping the object to respective files(object_number.dump) in zstreamdump
      _Command_  : `zstreamdump -w object_number < stream_data`
      _To dump all the objects, use object_number (`-1`)_

- Copying zstreamdump to docker image

Signed-off-by: mayank <mayank.patel@cloudbyte.com>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
