### PR TITLE
fix(snap_rebuild): mark clone as stale when rebuild is done

### DIFF
--- a/cmd/zrepl/zrepl.c
+++ b/cmd/zrepl/zrepl.c
@@ -144,6 +144,7 @@ main(int argc, char **argv)
 
 	io_receiver = uzfs_zvol_io_receiver;
 	rebuild_scanner = uzfs_zvol_rebuild_scanner;
+	dw_replica_fn = uzfs_zvol_rebuild_dw_replica;
 
 	SLIST_INIT(&uzfs_mgmt_conns);
 

--- a/include/data_conn.h
+++ b/include/data_conn.h
@@ -47,9 +47,11 @@ typedef struct conn_acceptors {
 
 thread_func_t io_receiver;
 thread_func_t rebuild_scanner;
+thread_func_t dw_replica_fn;
 
 extern void (*io_receiver)(void *arg);
 extern void (*rebuild_scanner)(void *arg);
+extern void (*dw_replica_fn)(void *arg);
 
 extern void uzfs_zvol_io_receiver(void *);
 
@@ -75,10 +77,11 @@ int uzfs_zvol_create_internal_snapshot(zvol_state_t *zv, zvol_state_t **snap_zv,
     uint64_t io_num);
 
 void signal_fds_related_to_zinfo(zvol_info_t *zinfo);
-void quiesce_wait(zvol_info_t *zinfo, uint8_t delete_clone);
+void quiesce_wait(zvol_info_t *zinfo);
 
 int uzfs_zvol_create_internal_snapshot(zvol_state_t *zv, zvol_state_t **snap_zv,
     uint64_t io_num);
+int uzfs_zvol_handle_rebuild_snap_done(zvol_io_hdr_t *, int, zvol_info_t *);
 
 #ifdef __cplusplus
 }

--- a/include/uzfs_rebuilding.h
+++ b/include/uzfs_rebuilding.h
@@ -28,6 +28,7 @@ extern "C" {
 #define	IO_DIFF_SNAPNAME		".io_snap"
 #define	REBUILD_SNAPSHOT_SNAPNAME	"rebuild_snap"
 #define	REBUILD_SNAPSHOT_CLONENAME	"rebuild_clone"
+#define	STALE				"stale"
 
 /*
  * API to compare metadata
@@ -55,15 +56,13 @@ int uzfs_get_io_diff(zvol_state_t *zv, blk_metadata_t *base_metadata,
  */
 int uzfs_get_nonoverlapping_ondisk_blks(zvol_state_t *zv, uint64_t offset,
     uint64_t len, blk_metadata_t *incoming_md, void **list);
-int
-uzfs_zvol_get_or_create_internal_clone(zvol_state_t *zv,
+int uzfs_zvol_get_or_create_internal_clone(zvol_state_t *zv,
     zvol_state_t **snap_zv, zvol_state_t **clone_zv, int *ret_val);
-int
-uzfs_zvol_release_internal_clone(zvol_state_t *zv,
-    zvol_state_t **snap_zv, zvol_state_t **clone_zv);
-int
-uzfs_zvol_destroy_internal_clone(zvol_state_t *zv,
-    zvol_state_t **snap_zv, zvol_state_t **clone_zv);
+int uzfs_zvol_release_internal_clone(zvol_state_t *zv,
+    zvol_state_t *snap_zv, zvol_state_t *clone_zv);
+
+boolean_t is_stale_clone(zvol_state_t *);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/uzfs_zap.h
+++ b/include/uzfs_zap.h
@@ -25,7 +25,7 @@
 #include <sys/spa.h>
 
 typedef struct {
-	char *key; 	/* zap key to update */
+	char *key;	/* zap key to update */
 	uint64_t value;	/* value to update against zap key */
 	size_t size;	/* size of value */
 } uzfs_zap_kv_t;

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -74,6 +74,7 @@ typedef struct inject_delay_s {
 	int pre_uzfs_write_data;
 	int downgraded_replica_rebuild_size_set;
 	int io_receiver_exit;
+	int helping_replica_rebuild_complete;
 } inject_delay_t;
 
 typedef struct inject_error_s {
@@ -97,7 +98,7 @@ typedef struct zvol_info_s {
 	char 		name[MAXPATHLEN];
 	zvol_state_t	*main_zv; // original volume
 	zvol_state_t	*clone_zv; // cloned volume for rebuilding
-	zvol_state_t	*snap_zv; // snap volume from where clone is created
+	zvol_state_t	*snapshot_zv; // snap volume from where clone is created
 	zvol_state_t    *rebuild_zv; // current snapshot which is rebuilding
 	uint64_t	refcnt;
 
@@ -224,8 +225,9 @@ extern int uzfs_zinfo_destroy(const char *ds_name, spa_t *spa);
 int uzfs_zvol_get_last_committed_io_no(zvol_state_t *, char *, uint64_t *);
 void uzfs_zinfo_store_last_committed_healthy_io_no(zvol_info_t *zinfo,
     uint64_t io_seq);
-void uzfs_zinfo_store_last_committed_degraded_io_no(zvol_info_t *zv,
+void uzfs_zinfo_store_last_committed_degraded_io_no(zvol_info_t *zinfo,
     uint64_t io_seq);
+int uzfs_zvol_get_kv_pair(zvol_state_t *zv, char *key, uint64_t *ionum);
 extern int set_socket_keepalive(int sfd);
 extern int create_and_bind(const char *port, int bind_needed,
     boolean_t nonblocking);
@@ -234,6 +236,10 @@ void shutdown_fds_related_to_zinfo(zvol_info_t *zinfo);
 
 extern void uzfs_zinfo_set_status(zvol_info_t *zinfo, zvol_status_t status);
 extern zvol_status_t uzfs_zinfo_get_status(zvol_info_t *zinfo);
+void uzfs_zvol_store_kv_pair(zvol_state_t *, char *, uint64_t);
+int uzfs_zvol_destroy_snapshot_clone(zvol_state_t *zv, zvol_state_t *snap_zv,
+    zvol_state_t *clone_zv);
+int uzfs_zinfo_destroy_internal_clone(zvol_info_t *zv);
 
 /*
  * API to drop refcnt on zinfo. If refcnt

--- a/lib/libzrepl/mgmt_conn.c
+++ b/lib/libzrepl/mgmt_conn.c
@@ -1129,7 +1129,7 @@ ret_error:
 		strlcpy(thrd_arg->ip, mack->ip, MAX_IP_LEN);
 		strlcpy(thrd_arg->zvol_name, mack->volname, MAXNAMELEN);
 		thrd_info = zk_thread_create(NULL, 0,
-		    uzfs_zvol_rebuild_dw_replica, thrd_arg, 0, NULL, TS_RUN, 0,
+		    dw_replica_fn, thrd_arg, 0, NULL, TS_RUN, 0,
 		    PTHREAD_CREATE_DETACHED);
 		VERIFY3P(thrd_info, !=, NULL);
 	}
@@ -1247,7 +1247,7 @@ handle_start_rebuild_req(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 		zinfo->quiesce_requested = 1;
 		mutex_exit(&zinfo->main_zv->rebuild_mtx);
 
-		quiesce_wait(zinfo, 0);
+		quiesce_wait(zinfo);
 		rc = uzfs_zinfo_rebuild_from_clone(zinfo);
 		if (rc != 0) {
 			LOG_ERR("Rebuild from clone for vol %s "

--- a/tests/cbtest/gtest/test_zrepl_prot.cc
+++ b/tests/cbtest/gtest/test_zrepl_prot.cc
@@ -1011,9 +1011,9 @@ TEST_F(ZreplDataTest, RebuildFlag) {
 
 	/* Get zvol status before rebuild */
 	get_zvol_status(m_zvol_name1, m_ioseq1, m_control_fd1, ZVOL_STATUS_DEGRADED, ZVOL_REBUILDING_INIT);
+
 	/* transition the zvol to online state */
 	transition_zvol_to_online(m_ioseq1, m_control_fd1, m_zvol_name1);
-
 	sleep(5);
 
 	/* Get zvol status after rebuild */


### PR DESCRIPTION
As part of rebuild process, snapshot will be created on the clone to sync the data from clone to main volume. This will be done in `rebuild_scanner` thread.
Another thread related to  `rebuild_dw_replica` will try to delete the clone once the rebuild is done.
Due to race between these two threads, there are chances of delete to fail in `rebuild_dw_replica` as the `rebuild_scanner` hadn't deleted the snapshot it created on clone.
In this state, if any restart of zrepl happens, existing clone will be used instead of creating a new one. This can make pool to serve old data (not the latest) from clone until the rebuild is done.

This PR is to mark the clone as 'stale' even before marking the volume as healthy. And, if any restart of zrepl happens, it checks for any existing stale clones. If any, zrepl deletes the clone and creates new one.

Added unit testcases and behavior driven testcase by adding delay in `rebuild_scanner` thread during the destroy of snapshot on the clone.

Also, changed a 'snap_zv' variable to 'snapshot_zv' in zvol_info.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>