### PR TITLE
feat(replica_status) adding support to get the replica status

### DIFF
--- a/cmd/zfs/Makefile.am
+++ b/cmd/zfs/Makefile.am
@@ -19,4 +19,4 @@ zfs_LDADD = \
 	$(top_builddir)/lib/libzfs/libzfs.la \
 	$(top_builddir)/lib/libzfs_core/libzfs_core.la
 
-zfs_LDFLAGS = -pthread
+zfs_LDFLAGS = -pthread -ljson-c

--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -331,7 +331,7 @@ get_usage(zfs_help_t idx)
 	case HELP_BOOKMARK:
 		return (gettext("\tbookmark <snapshot> <bookmark>\n"));
 	case HELP_STATS:
-		return (gettext("\tstats <dataset>\n"));
+		return (gettext("\tstats [dataset]\n"));
 	}
 
 	abort();
@@ -7066,8 +7066,11 @@ zfs_do_stats(int argc, char **argv)
 			case DATA_TYPE_UINT64:
 				nvpair_value_uint64(elem, &val);
 				jobj = json_object_new_object();
-				json_object_object_add(jobj, "name", json_object_new_string((nvpair_name(elem))));
-				json_object_object_add(jobj, "rebuild", json_object_new_string(val?"inprogress":"done"));
+				json_object_object_add(jobj, "name",
+				    json_object_new_string(nvpair_name(elem)));
+				json_object_object_add(jobj, "rebuild",
+				    json_object_new_string(
+				    val ? "inprogress" : "done"));
 				json_object_array_add(jarray, jobj);
 				break;
 			default:
@@ -7078,10 +7081,10 @@ zfs_do_stats(int argc, char **argv)
 
 	jobj = json_object_new_object();
 	json_object_object_add(jobj, "status", jarray);
-        const char *json_string = json_object_to_json_string_ext(jobj,
-            JSON_C_TO_STRING_PLAIN);
+	const char *json_string = json_object_to_json_string_ext(jobj,
+	    JSON_C_TO_STRING_PLAIN);
 
-	fprintf(stderr, "json=%s\n", json_string);
+	fprintf(stdout, "%s\n", json_string);
 	json_object_put(jobj);
 
 	return (0);

--- a/include/libuzfs.h
+++ b/include/libuzfs.h
@@ -83,6 +83,7 @@ extern int libuzfs_client_init(libzfs_handle_t *g_zfs);
 extern int uzfs_recv_response(int fd, zfs_cmd_t *zc);
 extern int uzfs_client_init(const char *sock_path);
 extern int is_main_thread(void);
+int uzfs_ioc_stats(zfs_cmd_t *zc, nvlist_t *nvl);
 
 extern int do_sendfd(int sock, int fd);
 extern int do_recvfd(int sock);

--- a/include/libzfs_core.h
+++ b/include/libzfs_core.h
@@ -95,6 +95,8 @@ int lzc_rollback_to(const char *, const char *);
 
 int lzc_sync(const char *, nvlist_t *, nvlist_t **);
 
+int lzc_stats(const char *dataset, nvlist_t *innvl, nvlist_t **outnvl);
+
 #ifdef	__cplusplus
 }
 #endif

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -1062,6 +1062,7 @@ typedef enum zfs_ioc {
 	ZFS_IOC_DESTROY_BOOKMARKS,
 	ZFS_IOC_RECV_NEW,
 	ZFS_IOC_POOL_SYNC,
+	ZFS_IOC_STATS,
 
 	/*
 	 * Linux - 3/64 numbers reserved.

--- a/include/sys/uzfs_zvol.h
+++ b/include/sys/uzfs_zvol.h
@@ -114,6 +114,7 @@ typedef struct zvol_state zvol_state_t;
 	(zv->rebuild_info.zv_rebuild_status == ZVOL_REBUILDING_FAILED)
 
 extern int zvol_get_data(void *arg, lr_write_t *lr, char *buf, zio_t *zio);
+const char *rebuild_status_to_str(zvol_rebuild_status_t status);
 
 /*
  * writes data and metadata

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -400,6 +400,12 @@ lzc_sync(const char *pool_name, nvlist_t *innvl, nvlist_t **outnvl)
 	return (lzc_ioctl(ZFS_IOC_POOL_SYNC, pool_name, innvl, NULL));
 }
 
+int
+lzc_stats(const char *dataset, nvlist_t *innvl, nvlist_t **outnvl)
+{
+	return (lzc_ioctl(ZFS_IOC_STATS, dataset, NULL, outnvl));
+}
+
 /*
  * Create "user holds" on snapshots.  If there is a hold on a snapshot,
  * the snapshot can not be destroyed.  (However, it can be marked for deletion

--- a/lib/libzpool/uzfs_io.c
+++ b/lib/libzpool/uzfs_io.c
@@ -367,7 +367,7 @@ zvol_status_to_str(zvol_status_t status)
 	return ("UNKNOWN");
 }
 
-static const char *
+const char *
 rebuild_status_to_str(zvol_rebuild_status_t status)
 {
 	switch (status) {

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -7351,6 +7351,7 @@ uzfs_handle_ioctl(const char *pool, zfs_cmd_t *zc, uzfs_info_t *ucmd_info)
 		err = uzfs_ioc_stats(zc, outnvl);
 		if (err == 0)
 			err = put_nvlist(zc, outnvl);
+		nvlist_free(outnvl);
 		break;
 	}
 	default:

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -7354,7 +7354,8 @@ uzfs_handle_ioctl(const char *pool, zfs_cmd_t *zc, uzfs_info_t *ucmd_info)
 		break;
 	}
 	default:
-		fprintf(stderr, "ioctl(0x%lx) not supported!\n", uzfs_cmd->ioc_num);
+		fprintf(stderr, "ioctl(0x%lx) not supported!\n",
+		    uzfs_cmd->ioc_num);
 		break;
 	}
 

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -7346,8 +7346,15 @@ uzfs_handle_ioctl(const char *pool, zfs_cmd_t *zc, uzfs_info_t *ucmd_info)
 	case ZFS_IOC_ERROR_LOG:
 		err = zfs_ioc_error_log(zc);
 		break;
+	case ZFS_IOC_STATS: {
+		nvlist_t *outnvl = fnvlist_alloc();
+		err = uzfs_ioc_stats(zc, outnvl);
+		if (err == 0)
+			err = put_nvlist(zc, outnvl);
+		break;
+	}
 	default:
-		fprintf(stderr, "ioctl(%ld) not supported!", uzfs_cmd->ioc_num);
+		fprintf(stderr, "ioctl(0x%lx) not supported!\n", uzfs_cmd->ioc_num);
 		break;
 	}
 

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -327,7 +327,8 @@ zvol_create_cb(objset_t *os, void *arg, cred_t *cr, dmu_tx_t *tx)
 #endif
 }
 
-int uzfs_ioc_stats(zfs_cmd_t *zc, nvlist_t *nvl)
+int
+uzfs_ioc_stats(zfs_cmd_t *zc, nvlist_t *nvl)
 {
 	zvol_info_t *zv = NULL;
 
@@ -335,7 +336,8 @@ int uzfs_ioc_stats(zfs_cmd_t *zc, nvlist_t *nvl)
 	SLIST_FOREACH(zv, &zvol_list, zinfo_next) {
 		if (zc->zc_name[0] == '\0' ||
 		    (uzfs_zvol_name_compare(zv, zc->zc_name) == 0)) {
-			fnvlist_add_uint64(nvl, zv->name, ZVOL_IS_REBUILDING(zv->main_zv));
+			fnvlist_add_uint64(nvl, zv->name,
+			    ZVOL_IS_REBUILDING(zv->main_zv));
 		}
 	}
 	(void) mutex_exit(&zvol_list_mutex);

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -327,6 +327,7 @@ zvol_create_cb(objset_t *os, void *arg, cred_t *cr, dmu_tx_t *tx)
 #endif
 }
 
+#if !defined(_KERNEL)
 int
 uzfs_ioc_stats(zfs_cmd_t *zc, nvlist_t *nvl)
 {
@@ -336,14 +337,49 @@ uzfs_ioc_stats(zfs_cmd_t *zc, nvlist_t *nvl)
 	SLIST_FOREACH(zv, &zvol_list, zinfo_next) {
 		if (zc->zc_name[0] == '\0' ||
 		    (uzfs_zvol_name_compare(zv, zc->zc_name) == 0)) {
-			fnvlist_add_uint64(nvl, zv->name,
-			    ZVOL_IS_REBUILDING(zv->main_zv));
+			nvlist_t *innvl = fnvlist_alloc();
+
+			fnvlist_add_string(innvl, "name", zv->name);
+
+			fnvlist_add_string(innvl, "status",
+			    ZINFO_IS_HEALTHY(zv) ?
+			    "healthy" : "degraded");
+
+			fnvlist_add_string(innvl, "rebuild",
+			    rebuild_status_to_str(
+			    zv->main_zv->rebuild_info.zv_rebuild_status));
+
+			fnvlist_add_uint64(innvl, "is_io_ack_sender_created",
+			    zv->is_io_ack_sender_created);
+			fnvlist_add_uint64(innvl, "is_io_receiver_created",
+			    zv->is_io_receiver_created);
+			fnvlist_add_uint64(innvl, "running_ionum",
+			    zv->running_ionum);
+			fnvlist_add_uint64(innvl, "checkpointed_ionum",
+			    zv->checkpointed_ionum);
+			fnvlist_add_uint64(innvl, "degraded_checkpointed_ionum",
+			    zv->degraded_checkpointed_ionum);
+			fnvlist_add_uint64(innvl, "checkpointed_time",
+			    zv->checkpointed_time);
+
+			fnvlist_add_uint64(innvl, "rebuild_bytes",
+			    zv->main_zv->rebuild_info.rebuild_bytes);
+			fnvlist_add_uint64(innvl, "rebuild_cnt",
+			    zv->main_zv->rebuild_info.rebuild_cnt);
+			fnvlist_add_uint64(innvl, "rebuild_done_cnt",
+			    zv->main_zv->rebuild_info.rebuild_done_cnt);
+			fnvlist_add_uint64(innvl, "rebuild_failed_cnt",
+			    zv->main_zv->rebuild_info.rebuild_failed_cnt);
+
+			fnvlist_add_nvlist(nvl, zv->name, innvl);
+			fnvlist_free(innvl);
 		}
 	}
 	(void) mutex_exit(&zvol_list_mutex);
 
 	return (0);
 }
+#endif
 
 /*
  * ZFS_IOC_OBJSET_STATS entry point.

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -327,6 +327,22 @@ zvol_create_cb(objset_t *os, void *arg, cred_t *cr, dmu_tx_t *tx)
 #endif
 }
 
+int uzfs_ioc_stats(zfs_cmd_t *zc, nvlist_t *nvl)
+{
+	zvol_info_t *zv = NULL;
+
+	(void) mutex_enter(&zvol_list_mutex);
+	SLIST_FOREACH(zv, &zvol_list, zinfo_next) {
+		if (zc->zc_name[0] == '\0' ||
+		    (uzfs_zvol_name_compare(zv, zc->zc_name) == 0)) {
+			fnvlist_add_uint64(nvl, zv->name, ZVOL_IS_REBUILDING(zv->main_zv));
+		}
+	}
+	(void) mutex_exit(&zvol_list_mutex);
+
+	return (0);
+}
+
 /*
  * ZFS_IOC_OBJSET_STATS entry point.
  */


### PR DESCRIPTION
```
pawan@pawan-openebs:~/openebs/zfs/cmd/zfs$ sudo ./zfs stats 
{"stats":[{"name":"pool1\/vol2","status":"degraded","rebuild":"INIT","is_io_ack_sender_created":0,"is_io_receiver_created":0,"running_ionum":0,"checkpointed_ionum":0,"degraded_checkpointed_ionum":0,"checkpointed_time":0,"rebuild_bytes":0,"rebuild_cnt":0,"rebuild_done_cnt":0,"rebuild_failed_cnt":0},{"name":"pool1\/vol1","status":"degraded","rebuild":"INIT","is_io_ack_sender_created":0,"is_io_receiver_created":0,"running_ionum":0,"checkpointed_ionum":0,"degraded_checkpointed_ionum":0,"checkpointed_time":0,"rebuild_bytes":0,"rebuild_cnt":0,"rebuild_done_cnt":0,"rebuild_failed_cnt":0}]}
```

```
pawan@pawan-openebs:~/openebs/zfs/cmd/zfs$ sudo ./zfs stats  | jq
{
  "stats": [
    {
      "name": "pool1/vol2",
      "status": "degraded",
      "rebuild": "INIT",
      "is_io_ack_sender_created": 0,
      "is_io_receiver_created": 0,
      "running_ionum": 0,
      "checkpointed_ionum": 0,
      "degraded_checkpointed_ionum": 0,
      "checkpointed_time": 0,
      "rebuild_bytes": 0,
      "rebuild_cnt": 0,
      "rebuild_done_cnt": 0,
      "rebuild_failed_cnt": 0
    },
    {
      "name": "pool1/vol1",
      "status": "degraded",
      "rebuild": "INIT",
      "is_io_ack_sender_created": 0,
      "is_io_receiver_created": 0,
      "running_ionum": 0,
      "checkpointed_ionum": 0,
      "degraded_checkpointed_ionum": 0,
      "checkpointed_time": 0,
      "rebuild_bytes": 0,
      "rebuild_cnt": 0,
      "rebuild_done_cnt": 0,
      "rebuild_failed_cnt": 0
    }
  ]
}
```

```
pawan@pawan-openebs:~/openebs/zfs/cmd/zfs$ sudo ./zfs stats  pool1/vol1
{"stats":[{"name":"pool1\/vol1","status":"degraded","rebuild":"INIT","is_io_ack_sender_created":0,"is_io_receiver_created":0,"running_ionum":0,"checkpointed_ionum":0,"degraded_checkpointed_ionum":0,"checkpointed_time":0,"rebuild_bytes":0,"rebuild_cnt":0,"rebuild_done_cnt":0,"rebuild_failed_cnt":0}]}
```
```
pawan@pawan-openebs:~/openebs/zfs/cmd/zfs$ sudo ./zfs stats  pool1/vol1 | jq
{
  "stats": [
    {
      "name": "pool1/vol1",
      "status": "degraded",
      "rebuild": "INIT",
      "is_io_ack_sender_created": 0,
      "is_io_receiver_created": 0,
      "running_ionum": 0,
      "checkpointed_ionum": 0,
      "degraded_checkpointed_ionum": 0,
      "checkpointed_time": 0,
      "rebuild_bytes": 0,
      "rebuild_cnt": 0,
      "rebuild_done_cnt": 0,
      "rebuild_failed_cnt": 0
    }
  ]
}
```
