### PR TITLE
feat(vol_status): zfs stats to give integrated status of volume

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -7108,7 +7108,7 @@ zfs_do_stats(int argc, char **argv)
 	}
 
 	jobj = json_object_new_object();
-	json_object_object_add(jobj, "stats", jarray);
+	json_object_object_add(jobj, "Stats", jarray);
 	const char *json_string = json_object_to_json_string_ext(jobj,
 	    JSON_C_TO_STRING_PLAIN);
 

--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -7108,7 +7108,7 @@ zfs_do_stats(int argc, char **argv)
 	}
 
 	jobj = json_object_new_object();
-	json_object_object_add(jobj, "Stats", jarray);
+	json_object_object_add(jobj, "stats", jarray);
 	const char *json_string = json_object_to_json_string_ext(jobj,
 	    JSON_C_TO_STRING_PLAIN);
 

--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -7079,14 +7079,16 @@ zfs_do_stats(int argc, char **argv)
 	nvlist_t *outnvl = NULL, *cnv = NULL;
 	nvpair_t *elem = NULL;
 	struct json_object *jobj;
+	int error;
 
 	if (argc < 1) {
 		fprintf(stderr, "got stats command %d\n", argc);
 		usage(B_FALSE);
 		return (-1);
 	}
-	if (lzc_stats(argv[1], NULL, &outnvl) != 0) {
-		fprintf(stderr, "failed stats command for %s\n", argv[1]);
+	if ((error = lzc_stats(argv[1], NULL, &outnvl)) != 0) {
+		fprintf(stderr, "failed stats command for %s with err %d\n",
+		    argv[1], error);
 		return (-1);
 	}
 

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -356,35 +356,35 @@ uzfs_ioc_stats(zfs_cmd_t *zc, nvlist_t *nvl)
 		    (uzfs_zvol_name_compare(zv, zc->zc_name) == 0)) {
 			nvlist_t *innvl = fnvlist_alloc();
 
-			fnvlist_add_string(innvl, "name", zv->name);
+			fnvlist_add_string(innvl, "Name", zv->name);
 
-			fnvlist_add_string(innvl, "status",
+			fnvlist_add_string(innvl, "Status",
 			    status_to_str(zv));
 
-			fnvlist_add_string(innvl, "rebuild",
+			fnvlist_add_string(innvl, "Rebuild",
 			    rebuild_status_to_str(
 			    zv->main_zv->rebuild_info.zv_rebuild_status));
 
-			fnvlist_add_uint64(innvl, "is_io_ack_sender_created",
+			fnvlist_add_uint64(innvl, "isIOAckSenderCreated",
 			    zv->is_io_ack_sender_created);
-			fnvlist_add_uint64(innvl, "is_io_receiver_created",
+			fnvlist_add_uint64(innvl, "isIOReceiverCreated",
 			    zv->is_io_receiver_created);
-			fnvlist_add_uint64(innvl, "running_ionum",
+			fnvlist_add_uint64(innvl, "RunningIONum",
 			    zv->running_ionum);
-			fnvlist_add_uint64(innvl, "checkpointed_ionum",
+			fnvlist_add_uint64(innvl, "CheckpointedIONum",
 			    zv->checkpointed_ionum);
-			fnvlist_add_uint64(innvl, "degraded_checkpointed_ionum",
+			fnvlist_add_uint64(innvl, "DegradedCheckpointedIONum",
 			    zv->degraded_checkpointed_ionum);
-			fnvlist_add_uint64(innvl, "checkpointed_time",
+			fnvlist_add_uint64(innvl, "CheckpointedTime",
 			    zv->checkpointed_time);
 
-			fnvlist_add_uint64(innvl, "rebuild_bytes",
+			fnvlist_add_uint64(innvl, "RebuildBytes",
 			    zv->main_zv->rebuild_info.rebuild_bytes);
-			fnvlist_add_uint64(innvl, "rebuild_cnt",
+			fnvlist_add_uint64(innvl, "RebuildCnt",
 			    zv->main_zv->rebuild_info.rebuild_cnt);
-			fnvlist_add_uint64(innvl, "rebuild_done_cnt",
+			fnvlist_add_uint64(innvl, "RebuildDoneCnt",
 			    zv->main_zv->rebuild_info.rebuild_done_cnt);
-			fnvlist_add_uint64(innvl, "rebuild_failed_cnt",
+			fnvlist_add_uint64(innvl, "RebuildFailedCnt",
 			    zv->main_zv->rebuild_info.rebuild_failed_cnt);
 
 			fnvlist_add_nvlist(nvl, zv->name, innvl);

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -352,6 +352,10 @@ uzfs_ioc_stats(zfs_cmd_t *zc, nvlist_t *nvl)
 
 	(void) mutex_enter(&zvol_list_mutex);
 	SLIST_FOREACH(zv, &zvol_list, zinfo_next) {
+
+		/*
+		 * No need to take lock of zv, as long as this is part of list
+		 */
 		if (zc->zc_name[0] == '\0' ||
 		    (uzfs_zvol_name_compare(zv, zc->zc_name) == 0)) {
 			nvlist_t *innvl = fnvlist_alloc();
@@ -389,6 +393,8 @@ uzfs_ioc_stats(zfs_cmd_t *zc, nvlist_t *nvl)
 
 			fnvlist_add_nvlist(nvl, zv->name, innvl);
 			fnvlist_free(innvl);
+			if (zc->zc_name[0] != '\0')
+				break;
 		}
 	}
 	(void) mutex_exit(&zvol_list_mutex);

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -360,12 +360,12 @@ uzfs_ioc_stats(zfs_cmd_t *zc, nvlist_t *nvl)
 		    (uzfs_zvol_name_compare(zv, zc->zc_name) == 0)) {
 			nvlist_t *innvl = fnvlist_alloc();
 
-			fnvlist_add_string(innvl, "Name", zv->name);
+			fnvlist_add_string(innvl, "name", zv->name);
 
-			fnvlist_add_string(innvl, "Status",
+			fnvlist_add_string(innvl, "status",
 			    status_to_str(zv));
 
-			fnvlist_add_string(innvl, "Rebuild",
+			fnvlist_add_string(innvl, "rebuildStatus",
 			    rebuild_status_to_str(
 			    zv->main_zv->rebuild_info.zv_rebuild_status));
 
@@ -373,22 +373,22 @@ uzfs_ioc_stats(zfs_cmd_t *zc, nvlist_t *nvl)
 			    zv->is_io_ack_sender_created);
 			fnvlist_add_uint64(innvl, "isIOReceiverCreated",
 			    zv->is_io_receiver_created);
-			fnvlist_add_uint64(innvl, "RunningIONum",
+			fnvlist_add_uint64(innvl, "runningIONum",
 			    zv->running_ionum);
-			fnvlist_add_uint64(innvl, "CheckpointedIONum",
+			fnvlist_add_uint64(innvl, "checkpointedIONum",
 			    zv->checkpointed_ionum);
-			fnvlist_add_uint64(innvl, "DegradedCheckpointedIONum",
+			fnvlist_add_uint64(innvl, "degradedCheckpointedIONum",
 			    zv->degraded_checkpointed_ionum);
-			fnvlist_add_uint64(innvl, "CheckpointedTime",
+			fnvlist_add_uint64(innvl, "checkpointedTime",
 			    zv->checkpointed_time);
 
-			fnvlist_add_uint64(innvl, "RebuildBytes",
+			fnvlist_add_uint64(innvl, "rebuildBytes",
 			    zv->main_zv->rebuild_info.rebuild_bytes);
-			fnvlist_add_uint64(innvl, "RebuildCnt",
+			fnvlist_add_uint64(innvl, "rebuildCnt",
 			    zv->main_zv->rebuild_info.rebuild_cnt);
-			fnvlist_add_uint64(innvl, "RebuildDoneCnt",
+			fnvlist_add_uint64(innvl, "rebuildDoneCnt",
 			    zv->main_zv->rebuild_info.rebuild_done_cnt);
-			fnvlist_add_uint64(innvl, "RebuildFailedCnt",
+			fnvlist_add_uint64(innvl, "rebuildFailedCnt",
 			    zv->main_zv->rebuild_info.rebuild_failed_cnt);
 
 			fnvlist_add_nvlist(nvl, zv->name, innvl);

--- a/tests/cbtest/gtest/test_zrepl_prot.cc
+++ b/tests/cbtest/gtest/test_zrepl_prot.cc
@@ -1005,6 +1005,8 @@ TEST_F(ZreplDataTest, RebuildFlag) {
 	struct mgmt_ack mgmt_ack;
 	char buf[4096];
 	int rc;
+	std::string output;
+	std::string::size_type n;
 
 	/* write a data block with known ionum */
 	write_data_and_verify_resp(m_datasock1.fd(), m_ioseq1, 0, 654);
@@ -1012,12 +1014,25 @@ TEST_F(ZreplDataTest, RebuildFlag) {
 	/* Get zvol status before rebuild */
 	get_zvol_status(m_zvol_name1, m_ioseq1, m_control_fd1, ZVOL_STATUS_DEGRADED, ZVOL_REBUILDING_INIT);
 
+	output = execCmd("zfs", std::string("stats ") + m_zvol_name1);
+	ASSERT_NE(output.find("DegradedPerformance"), std::string::npos);
+
 	/* transition the zvol to online state */
 	transition_zvol_to_online(m_ioseq1, m_control_fd1, m_zvol_name1);
+
+	output = execCmd("zfs", std::string("stats ") + m_zvol_name1);
+	n = output.find("RebuildDuringDegrade");
+	if (n == std::string::npos)
+		ASSERT_NE(output.find("Healthy"), std::string::npos);
+	else
+		ASSERT_NE(output.find("RebuildDuringDegrade"), std::string::npos);
 	sleep(5);
 
 	/* Get zvol status after rebuild */
 	get_zvol_status(m_zvol_name1, m_ioseq1, m_control_fd1, ZVOL_STATUS_HEALTHY, ZVOL_REBUILDING_DONE);
+
+	output = execCmd("zfs", std::string("stats ") + m_zvol_name1);
+	ASSERT_NE(output.find("Healthy"), std::string::npos);
 
 	/* read the block without rebuild flag */
 	read_data_start(m_datasock1.fd(), m_ioseq1, 0, sizeof (buf), &hdr_in, 0);
@@ -1093,11 +1108,16 @@ TEST(TargetIPTest, CreateAndDestroy) {
 	int fdImpl, fdExpl;
 	char buf[1];
 	int rc;
+	std::string output;
 
 	zrepl.start();
 	pool.create();
 	pool.createZvol("implicit1", "-o io.openebs:targetip=127.0.0.1:6060");
 	pool.createZvol("explicit1", "-o io.openebs:targetip=127.0.0.1:12345");
+
+	output = execCmd("zfs", std::string("stats ") + pool.getZvolName("implicit1"));
+	ASSERT_NE(output.find("Offline"), std::string::npos);
+
 	zrepl.kill();
 
 	rc = targetImpl.listen();


### PR DESCRIPTION
This PR is to give integrated status of volume in `zfs stats pool1/vol1` output.
Below is the output:
```
{
  "stats": [
    {
      "name": "pool1/vol1",
      "status": "Degraded",
      "rebuildStatus": "INIT",
      "isIOAckSenderCreated": -1,
      "isIOReceiverCreated": -1,
      "runningIONum": 0,
      "checkpointedIONum": 0,
      "degradedCheckpointedIONum": 0,
      "checkpointedTime": 0,
      "rebuildBytes": 0,
      "rebuildCnt": 0,
      "rebuildDoneCnt": 0,
      "rebuildFailedCnt": 0
    }
  ]
}
```
Possible values for status is:
```
Offline
Degraded
Rebuilding
Healthy
```
Unit test automation is covered.
Signed-off-by: Vishnu Itta <vitta@mayadata.io>