### PR TITLE
refactor(image): fix base ubuntu image for cstor containers

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -3,7 +3,7 @@
 # libraries.
 #
 
-FROM ubuntu:16.04
+FROM openebs/cstor-ubuntu:xenial-20181005
 
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \ 


### PR DESCRIPTION
Using ubuntu:16.04 as base image results in flaky builds
if the mutable tag (16.04) is updated with a newer image.

With ci images built, the following error is being thrown
when container is started.
```
Message:     oci runtime error: container_linux.go:265:
starting container process caused "process_linux.go:368:
 container init caused \"rootfs_linux.go:57: mounting \\
\"/var/lib/docker/containers/59ffd088.../shm\\\" to rootfs \\
\"/var/lib/docker/overlay2/313c71f.../merged\\\" at \\\"/dev/shm\\\"
 caused \\\"evalSymlinksInScope: too many links in
/var/lib/docker/overlay2/313c71fe.../merged/dev/shm\\\"\""
```

Between the working images of 11/20 and current images, it is
observed the ubuntu layers have changed:

Latest Ubuntu layers:
```
            "Layers": [
                "sha256:41c002c8a6fd36397892dc6dc36813aaa1be3298be4de93e4fe1f40b9c358d99",
                "sha256:647265b9d8bc572a858ab25a300c07c0567c9124390fd91935430bf947ee5c2a",
                "sha256:819a824caf709f224c414a56a2fa0240ea15797ee180e73abe4ad63d3806cae5",
                "sha256:3db5746c911ad8c3398a6b72aa30580b25b6edb130a148beed4d405d9c345a29"
            ]
```

previous layers:
```
            "Layers": [
                "sha256:b8c891f0ffec910a12757d733b178e3f62d81dbbde2b31d3b754071c416108ed",
                "sha256:33db8ccd260b025f6778ac555e05430a5f61a7211cd712e971d372afd2fa87ef",
                "sha256:79109c0f8a0be18efd3812060bdd570c6007095045684cb5256aa6abdc06a2fd",
                "sha256:f1dfa8049aa60c426b275914bb9d38172cb6ce32c27ad5e08c7c2de348ff2b86"
            ]
```

Saved the ubuntu image that was working as openebs/cstor-ubuntu:xenial-20181005

Signed-off-by: kmova <kiran.mova@openebs.io>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
