### PR TITLE
fix(cvrStatus): considering mgmt conn into health of zinfo

### DIFF
--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -333,6 +333,8 @@ static const char *
 status_to_str(zvol_info_t *zv)
 {
 	zvol_rebuild_status_t rebuild_status;
+	if (zv->mgmt_conn == NULL)
+		return ("Offline");
 	if ((zv->is_io_receiver_created == 0) ||
 	    (zv->is_io_ack_sender_created == 0))
 		return ("Offline");


### PR DESCRIPTION
This PR is to consider health of mgmt connection while calculating the health of a volume's zinfo.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>