### PR TITLE
fix(zfs) double close of the fd and zfs history missing few commands

### DIFF
--- a/include/libuzfs.h
+++ b/include/libuzfs.h
@@ -67,7 +67,13 @@ typedef struct uzfs_monitor {
     _UZFS_IOC(ZFS_IOC_SEND_PROGRESS, 0, 0, "print zfs send stats")             \
     _UZFS_IOC(ZFS_IOC_VDEV_ADD, 1, 0, "add vdev to the pool")                  \
     _UZFS_IOC(ZFS_IOC_VDEV_REMOVE, 1, 0, "remove vdev from the pool")          \
-    _UZFS_IOC(ZFS_IOC_ERROR_LOG, 0, 0, "get the error log")
+    _UZFS_IOC(ZFS_IOC_VDEV_ATTACH, 1, 0, "attached a disk to the pool")        \
+    _UZFS_IOC(ZFS_IOC_VDEV_DETACH, 1, 0, "detached a disk from the pool")      \
+    _UZFS_IOC(ZFS_IOC_VDEV_SET_STATE, 1, 0, "set vdev state")                  \
+    _UZFS_IOC(ZFS_IOC_PROMOTE, 1, 0, "promote the volume")                     \
+    _UZFS_IOC(ZFS_IOC_CLONE, 1, 1, "clone the volume")                         \
+    _UZFS_IOC(ZFS_IOC_ERROR_LOG, 0, 0, "get the error log")                    \
+    _UZFS_IOC(ZFS_IOC_STATS, 0, 0, "get the zfs volume stats")
 
 
 #define	MAX_NVLIST_SRC_SIZE (128 * 1024 * 1024)

--- a/lib/libzfs/libuzfs_handle.c
+++ b/lib/libzfs/libuzfs_handle.c
@@ -286,7 +286,6 @@ uzfs_recv_ioctl(int fd, zfs_cmd_t *zc, uzfs_info_t *ucmd_info)
 	    uzfs_cmd->ioc_num == ZFS_IOC_RECV_NEW ||
 	    uzfs_cmd->ioc_num == ZFS_IOC_SEND_NEW) {
 		if ((ucmd_info->uzfs_recvfd = do_recvfd(fd)) < 0) {
-			VERIFY0(close(fd));
 			goto err;
 		}
 	}


### PR DESCRIPTION
In case of error we are closing the sock fd immediately, but as part
of error handling, the caller itself closes the fd. So no need to
close the fd and let the caller handle it.

Also few commands are not logged in the zfs history command as they
are not listed as config command in the uzfs IOCTL list, fixed it
by adding them to the uzfs IOCTL list.

Signed-off-by: Pawan <pawanprakash101@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
