### PR TITLE
bug(pool_corruption) preventing pool getting imported twice

### DIFF
--- a/cmd/zrepl/zrepl.c
+++ b/cmd/zrepl/zrepl.c
@@ -16,6 +16,9 @@
 #include <uzfs_zap.h>
 #include <mgmt_conn.h>
 #include <data_conn.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
 
 #include "zfs_events.h"
 
@@ -107,6 +110,17 @@ int
 main(int argc, char **argv)
 {
 	int	rc;
+
+	int fd = open(LOCK_FILE, O_CREAT | O_RDWR, 0644);
+	if (fd < 0) {
+		fprintf(stderr, "%s open failed: %s\n", LOCK_FILE,
+		    strerror(errno));
+		return (-1);
+	}
+	if (flock(fd, LOCK_EX) < 0) {
+		fprintf(stderr, "flock failed: %s\n", strerror(errno));
+		return (-1);
+	}
 
 	/* Use opt parsing lib if we have more options */
 	zrepl_log_level = LOG_LEVEL_INFO;

--- a/include/libuzfs.h
+++ b/include/libuzfs.h
@@ -13,6 +13,7 @@ extern int kthread_nr;
 #define	PEND_CONNECTIONS 10
 
 #define	UZFS_SOCK "/tmp/uzfs.sock"
+#define	LOCK_FILE "/tmp/zrepl.lock"
 
 #define	SET_ERR(err) (errno = err, -1)
 


### PR DESCRIPTION
If we are deleteing a pod, kubrnetes puts this pod into terminating
state and redeploys a new pod. There is a chance that the pool is
imported at two places. Here we are taking a lock on /tmp/zrepl.lock
file to ensure that only one guy can import the pool. This file will
be there on the persistent storage so that all can see the same file.

Signed-off-by: Pawan <pawanprakash101@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
