### PR TITLE
fix(test) fixing incorrect test case

### DIFF
--- a/tests/cbtest/gtest/test_uzfs.cc
+++ b/tests/cbtest/gtest/test_uzfs.cc
@@ -515,6 +515,8 @@ verify_app_io_read_write(int fd, zvol_info_t *zinfo)
 		memcpy(write_buf + i, cbuf, clen);
 	}
 
+	pthread_mutex_lock(&done_thread_count_mtx);
+
 	GtestUtils::write_data_and_verify_resp(fd, ioseq, write_buf, offset, len, io_num);
 
 	uzfs_read_data(read_zv, read_buf, offset, len, &md);
@@ -532,6 +534,7 @@ verify_app_io_read_write(int fd, zvol_info_t *zinfo)
 		EXPECT_EQ(memcmp(write_buf, read_buf, sizeof (read_buf)), 0);
 		FREE_METADATA_LIST(md);
 	}
+	pthread_mutex_unlock(&done_thread_count_mtx);
 }
 
 void


### PR DESCRIPTION
there are two parallel threads trying to write
the data to the volume, one is clone_zv rebuild thread
and other is dw rebuild thread. If the data is overwritten
by other thread, the verification will fail as it verifies
whatever I have written is there on the volume or not.

Fixed it by protecting it by a lock.

Signed-off-by: Pawan <pawanprakash101@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
