### PR TITLE
feat(stats) adding IOs related counters in `zfs stats` command

### DIFF
--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -190,8 +190,10 @@ typedef struct zvol_info_s {
 	uint64_t 	sync_req_received_cnt;
 	uint64_t 	read_req_ack_cnt;
 	uint64_t 	read_latency;
+	uint64_t 	read_byte;
 	uint64_t	write_req_ack_cnt;
 	uint64_t 	write_latency;
+	uint64_t 	write_byte;
 	uint64_t	sync_req_ack_cnt;
 	uint64_t 	sync_latency;
 } zvol_info_t;

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -189,8 +189,11 @@ typedef struct zvol_info_s {
 	uint64_t 	write_req_received_cnt;
 	uint64_t 	sync_req_received_cnt;
 	uint64_t 	read_req_ack_cnt;
+	uint64_t 	read_latency;
 	uint64_t	write_req_ack_cnt;
+	uint64_t 	write_latency;
 	uint64_t	sync_req_ack_cnt;
+	uint64_t 	sync_latency;
 } zvol_info_t;
 
 typedef struct thread_args_s {
@@ -213,6 +216,7 @@ typedef struct zvol_io_cmd_s {
 	zvol_info_t	*zinfo;
 	void		*buf;
 	uint64_t	buf_len;
+	uint64_t 	io_start_time;
 	metadata_desc_t	*metadata_desc;
 	int		conn;
 } zvol_io_cmd_t;

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -1805,7 +1805,8 @@ error_check:
 		} else {
 			if (zio_cmd->hdr.opcode == ZVOL_OPCODE_WRITE) {
 				atomic_inc_64(&zinfo->write_req_ack_cnt);
-				atomic_add_64(&zinfo->write_byte, zio_cmd->hdr.len);
+				atomic_add_64(&zinfo->write_byte,
+				    zio_cmd->hdr.len);
 				atomic_add_64(&zinfo->write_latency,
 				    gethrtime() - zio_cmd->io_start_time);
 			} else if (zio_cmd->hdr.opcode == ZVOL_OPCODE_SYNC) {

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -352,6 +352,9 @@ uzfs_zvol_worker(void *arg)
 	} else {
 		metadata_desc = &zio_cmd->metadata_desc;
 	}
+
+	zio_cmd->io_start_time = gethrtime();
+
 	switch (hdr->opcode) {
 		case ZVOL_OPCODE_READ:
 			read_zv = zinfo->main_zv;
@@ -1796,11 +1799,18 @@ error_check:
 				}
 			}
 			atomic_inc_64(&zinfo->read_req_ack_cnt);
+			atomic_add_64(&zinfo->read_latency,
+			    gethrtime() - zio_cmd->io_start_time);
 		} else {
-			if (zio_cmd->hdr.opcode == ZVOL_OPCODE_WRITE)
+			if (zio_cmd->hdr.opcode == ZVOL_OPCODE_WRITE) {
 				atomic_inc_64(&zinfo->write_req_ack_cnt);
-			else if (zio_cmd->hdr.opcode == ZVOL_OPCODE_SYNC)
+				atomic_add_64(&zinfo->write_latency,
+				    gethrtime() - zio_cmd->io_start_time);
+			} else if (zio_cmd->hdr.opcode == ZVOL_OPCODE_SYNC) {
 				atomic_inc_64(&zinfo->sync_req_ack_cnt);
+				atomic_add_64(&zinfo->sync_latency,
+				    gethrtime() - zio_cmd->io_start_time);
+			}
 		}
 		zinfo->zio_cmd_in_ack = NULL;
 		zio_cmd_free(&zio_cmd);

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -1799,11 +1799,13 @@ error_check:
 				}
 			}
 			atomic_inc_64(&zinfo->read_req_ack_cnt);
+			atomic_add_64(&zinfo->read_byte, zio_cmd->hdr.len);
 			atomic_add_64(&zinfo->read_latency,
 			    gethrtime() - zio_cmd->io_start_time);
 		} else {
 			if (zio_cmd->hdr.opcode == ZVOL_OPCODE_WRITE) {
 				atomic_inc_64(&zinfo->write_req_ack_cnt);
+				atomic_add_64(&zinfo->write_byte, zio_cmd->hdr.len);
 				atomic_add_64(&zinfo->write_latency,
 				    gethrtime() - zio_cmd->io_start_time);
 			} else if (zio_cmd->hdr.opcode == ZVOL_OPCODE_SYNC) {

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -397,10 +397,14 @@ uzfs_ioc_stats(zfs_cmd_t *zc, nvlist_t *nvl)
 			    zv->read_req_ack_cnt);
 			fnvlist_add_uint64(innvl, "readLatency",
 			    zv->read_latency);
+			fnvlist_add_uint64(innvl, "readByte",
+			    zv->read_byte);
 			fnvlist_add_uint64(innvl, "writeCount",
 			    zv->write_req_ack_cnt);
 			fnvlist_add_uint64(innvl, "writeLatency",
 			    zv->write_latency);
+			fnvlist_add_uint64(innvl, "writeByte",
+			    zv->write_byte);
 			fnvlist_add_uint64(innvl, "syncCount",
 			    zv->sync_req_ack_cnt);
 			fnvlist_add_uint64(innvl, "syncLatency",

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -393,6 +393,19 @@ uzfs_ioc_stats(zfs_cmd_t *zc, nvlist_t *nvl)
 			fnvlist_add_uint64(innvl, "rebuildFailedCnt",
 			    zv->main_zv->rebuild_info.rebuild_failed_cnt);
 
+			fnvlist_add_uint64(innvl, "readCount",
+			    zv->read_req_ack_cnt);
+			fnvlist_add_uint64(innvl, "readLatency",
+			    zv->read_latency);
+			fnvlist_add_uint64(innvl, "writeCount",
+			    zv->write_req_ack_cnt);
+			fnvlist_add_uint64(innvl, "writeLatency",
+			    zv->write_latency);
+			fnvlist_add_uint64(innvl, "syncCount",
+			    zv->sync_req_ack_cnt);
+			fnvlist_add_uint64(innvl, "syncLatency",
+			    zv->sync_latency);
+
 			fnvlist_add_nvlist(nvl, zv->name, innvl);
 			fnvlist_free(innvl);
 			if (zc->zc_name[0] != '\0')


### PR DESCRIPTION
adding read/write/sync counters in `zfs stats` command 

```
./cmd/zfs/zfs stats | jq
{
  "stats": [
    {
      "name": "pool1/vol2",
      "status": "Offline",
      "rebuildStatus": "INIT",
      "isIOAckSenderCreated": 0,
      "isIOReceiverCreated": 0,
      "runningIONum": 0,
      "checkpointedIONum": 0,
      "degradedCheckpointedIONum": 0,
      "checkpointedTime": 0,
      "rebuildBytes": 0,
      "rebuildCnt": 0,
      "rebuildDoneCnt": 0,
      "rebuildFailedCnt": 0,
      "readCount": 0,
      "readLatency": 0,
      "readByte": 0,
      "writeCount": 0,
      "writeLatency": 0,
      "writeByte": 0,
      "syncCount": 0,
      "syncLatency": 0
    }
  ]
}
```

Signed-off-by: Pawan <pawanprakash101@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
