### PR TITLE
feat(coalesce): tune coalescing IOs in zfs with env

### DIFF
--- a/cmd/zrepl/zrepl.c
+++ b/cmd/zrepl/zrepl.c
@@ -27,6 +27,7 @@
 extern unsigned long zfs_arc_max;
 extern unsigned long zfs_arc_min;
 extern int zfs_autoimport_disable;
+extern int zfs_do_coalesce;
 
 #if DEBUG
 inject_error_t	inject_error;
@@ -110,7 +111,7 @@ int
 main(int argc, char **argv)
 {
 	int	rc;
-
+	char	*env;
 	int fd = open(LOCK_FILE, O_CREAT | O_RDWR, 0644);
 	if (fd < 0) {
 		fprintf(stderr, "%s open failed: %s\n", LOCK_FILE,
@@ -145,6 +146,14 @@ main(int argc, char **argv)
 		LOG_INFO("disabled auto import (reading of zpool.cache)");
 		zfs_autoimport_disable = 1;
 	}
+
+	zfs_do_coalesce = 1;
+	env = getenv("DISABLE_COALESCE");
+	if (env != NULL)
+		if(strcmp(env, "1") == 0) {
+			LOG_INFO("Disabling coalescing IOs");
+			zfs_do_coalesce = 0;
+		}
 
 	SLIST_INIT(&uzfs_mgmt_conns);
 	mutex_init(&conn_list_mtx, NULL, MUTEX_DEFAULT, NULL);

--- a/cmd/zrepl/zrepl.c
+++ b/cmd/zrepl/zrepl.c
@@ -150,7 +150,7 @@ main(int argc, char **argv)
 	zfs_do_coalesce = 1;
 	env = getenv("DISABLE_COALESCE");
 	if (env != NULL)
-		if(strcmp(env, "1") == 0) {
+		if (strcmp(env, "1") == 0) {
 			LOG_INFO("Disabling coalescing IOs");
 			zfs_do_coalesce = 0;
 		}

--- a/cmd/zrepl/zrepl.c
+++ b/cmd/zrepl/zrepl.c
@@ -27,7 +27,7 @@
 extern unsigned long zfs_arc_max;
 extern unsigned long zfs_arc_min;
 extern int zfs_autoimport_disable;
-extern int zfs_do_coalesce;
+extern int zfs_do_write_coalesce;
 
 #if DEBUG
 inject_error_t	inject_error;
@@ -147,12 +147,12 @@ main(int argc, char **argv)
 		zfs_autoimport_disable = 1;
 	}
 
-	zfs_do_coalesce = 1;
-	env = getenv("DISABLE_COALESCE");
+	zfs_do_write_coalesce = 1;
+	env = getenv("DISABLE_WRITE_COALESCE");
 	if (env != NULL)
 		if (strcmp(env, "1") == 0) {
-			LOG_INFO("Disabling coalescing IOs");
-			zfs_do_coalesce = 0;
+			LOG_INFO("Disabling write IOs coalescing");
+			zfs_do_write_coalesce = 0;
 		}
 
 	SLIST_INIT(&uzfs_mgmt_conns);

--- a/module/zfs/spa_config.c
+++ b/module/zfs/spa_config.c
@@ -67,6 +67,7 @@ static uint64_t spa_config_generation = 1;
  */
 char *spa_config_path = ZPOOL_CACHE;
 int zfs_autoimport_disable = 0;
+int zfs_do_coalesce = 1;
 
 /*
  * Called when the module is first loaded, this routine loads the configuration
@@ -610,5 +611,8 @@ MODULE_PARM_DESC(spa_config_path, "SPA config file (/etc/zfs/zpool.cache)");
 
 module_param(zfs_autoimport_disable, int, 0644);
 MODULE_PARM_DESC(zfs_autoimport_disable, "Disable pool import at module load");
+
+module_param(zfs_do_coalesce, int, 0644);
+MODULE_PARM_DESC(zfs_do_coalesce, "Coalesce IOs at ZFS");
 
 #endif

--- a/module/zfs/spa_config.c
+++ b/module/zfs/spa_config.c
@@ -67,7 +67,7 @@ static uint64_t spa_config_generation = 1;
  */
 char *spa_config_path = ZPOOL_CACHE;
 int zfs_autoimport_disable = 0;
-int zfs_do_coalesce = 1;
+int zfs_do_write_coalesce = 1;
 
 /*
  * Called when the module is first loaded, this routine loads the configuration
@@ -612,7 +612,7 @@ MODULE_PARM_DESC(spa_config_path, "SPA config file (/etc/zfs/zpool.cache)");
 module_param(zfs_autoimport_disable, int, 0644);
 MODULE_PARM_DESC(zfs_autoimport_disable, "Disable pool import at module load");
 
-module_param(zfs_do_coalesce, int, 0644);
-MODULE_PARM_DESC(zfs_do_coalesce, "Coalesce IOs at ZFS");
+module_param(zfs_do_write_coalesce, int, 0644);
+MODULE_PARM_DESC(zfs_do_write_coalesce, "Coalesce write IOs at ZIO");
 
 #endif

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -44,7 +44,7 @@
 #include <sys/trace_zio.h>
 #include <sys/abd.h>
 
-extern int zfs_do_coalesce;
+extern int zfs_do_write_coalesce;
 
 /*
  * ==========================================================================
@@ -3280,7 +3280,8 @@ zio_vdev_io_start(zio_t *zio)
 		if (zio->io_type == ZIO_TYPE_READ && vdev_cache_read(zio))
 			return (ZIO_PIPELINE_CONTINUE);
 
-		if (zfs_do_coalesce == 0)
+		if ((zfs_do_write_coalesce == 0) &&
+		    (zio->io_type == ZIO_TYPE_WRITE))
 			zio->io_flags |= ZIO_FLAG_DONT_QUEUE;
 
 		if ((zio = vdev_queue_io(zio)) == NULL)

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -44,6 +44,8 @@
 #include <sys/trace_zio.h>
 #include <sys/abd.h>
 
+extern int zfs_do_coalesce;
+
 /*
  * ==========================================================================
  * I/O type descriptions
@@ -3277,6 +3279,9 @@ zio_vdev_io_start(zio_t *zio)
 
 		if (zio->io_type == ZIO_TYPE_READ && vdev_cache_read(zio))
 			return (ZIO_PIPELINE_CONTINUE);
+
+		if (zfs_do_coalesce == 0)
+			zio->io_flags |= ZIO_FLAG_DONT_QUEUE;
 
 		if ((zio = vdev_queue_io(zio)) == NULL)
 			return (ZIO_PIPELINE_STOP);


### PR DESCRIPTION
This PR is to disable coalescing of IOs in ZIO pipeline, which can be tunable with environment variable `DISABLE_WRITE_COALESCE`.

This env variable need to be set to 1 to disable coalescing IOs in ZIO pipeline. There is no change in default behavior, and, it will be to do coalesce.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>