### PR TITLE
feat(perf) adding env for write block size

### DIFF
--- a/cmd/zrepl/zrepl.c
+++ b/cmd/zrepl/zrepl.c
@@ -149,11 +149,19 @@ main(int argc, char **argv)
 
 	zfs_do_write_coalesce = 1;
 	env = getenv("DISABLE_WRITE_COALESCE");
-	if (env != NULL)
+	if (env != NULL) {
 		if (strcmp(env, "1") == 0) {
 			LOG_INFO("Disabling write IOs coalescing");
 			zfs_do_write_coalesce = 0;
 		}
+	}
+
+	uzfs_write_size = 0;
+	env = getenv("UZFS_WRITE_SIZE");
+	if (env != NULL) {
+		uzfs_write_size = atoi(env);
+		LOG_INFO("uzfs write size = %d", uzfs_write_size);
+	}
 
 	SLIST_INIT(&uzfs_mgmt_conns);
 	mutex_init(&conn_list_mtx, NULL, MUTEX_DEFAULT, NULL);

--- a/include/uzfs_io.h
+++ b/include/uzfs_io.h
@@ -29,6 +29,8 @@
 extern "C" {
 #endif
 
+extern int uzfs_write_size;
+
 struct metadata_desc;
 
 /*

--- a/lib/libzpool/uzfs_io.c
+++ b/lib/libzpool/uzfs_io.c
@@ -27,6 +27,8 @@
 #include <uzfs_io.h>
 #include <zrepl_mgmt.h>
 
+int uzfs_write_size;
+
 #if DEBUG
 inject_error_t	inject_error;
 #endif
@@ -82,6 +84,10 @@ uzfs_write_data(zvol_state_t *zv, char *buf, uint64_t offset, uint64_t len,
 	uint64_t orig_offset = offset;
 	char *mdata = NULL, *tmdata = NULL, *tmdataend = NULL;
 
+	if (uzfs_write_size) {
+		// align it in the multiple of blocksize
+		blocksize = (uzfs_write_size / blocksize) * blocksize;
+	}
 	/*
 	 * If trying IO on fresh zvol before metadata granularity is set return
 	 * error.

--- a/lib/libzpool/uzfs_io.c
+++ b/lib/libzpool/uzfs_io.c
@@ -86,7 +86,7 @@ uzfs_write_data(zvol_state_t *zv, char *buf, uint64_t offset, uint64_t len,
 
 	if (uzfs_write_size) {
 		// align it in the multiple of blocksize
-		blocksize = (uzfs_write_size / blocksize) * blocksize;
+		blocksize *= ((uzfs_write_size + blocksize - 1) / blocksize);
 	}
 	/*
 	 * If trying IO on fresh zvol before metadata granularity is set return


### PR DESCRIPTION
currently we divide each IO into chunk of blocksize and assign transaction to each chunk and write the data, Instead if we can break the IOs into a little bigger chunk, we only need to do few IOs only and quiescing of IOs will also be mitigated  which will give us better throughput also.

Signed-off-by: Pawan <pawanprakash101@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
