### PR TITLE
fix(upgrade_issue): upgrade issue from 0.7 to 0.8 due to strick check on degrade_io_seq key

### DIFF
--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -189,8 +189,13 @@ typedef struct zvol_info_s {
 	uint64_t 	write_req_received_cnt;
 	uint64_t 	sync_req_received_cnt;
 	uint64_t 	read_req_ack_cnt;
+	uint64_t 	read_latency;
+	uint64_t 	read_byte;
 	uint64_t	write_req_ack_cnt;
+	uint64_t 	write_latency;
+	uint64_t 	write_byte;
 	uint64_t	sync_req_ack_cnt;
+	uint64_t 	sync_latency;
 } zvol_info_t;
 
 typedef struct thread_args_s {
@@ -213,6 +218,7 @@ typedef struct zvol_io_cmd_s {
 	zvol_info_t	*zinfo;
 	void		*buf;
 	uint64_t	buf_len;
+	uint64_t 	io_start_time;
 	metadata_desc_t	*metadata_desc;
 	int		conn;
 } zvol_io_cmd_t;

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -246,6 +246,9 @@ int uzfs_zvol_destroy_snapshot_clone(zvol_state_t *zv, zvol_state_t *snap_zv,
     zvol_state_t *clone_zv);
 int uzfs_zinfo_destroy_internal_clone(zvol_info_t *zv);
 
+uint8_t uzfs_zinfo_get_quorum(zvol_info_t *zinfo);
+int uzfs_zinfo_set_quorum(zvol_info_t *zinfo, uint64_t val);
+
 /*
  * API to drop refcnt on zinfo. If refcnt
  * dropped to zero then free zinfo.

--- a/include/zrepl_prot.h
+++ b/include/zrepl_prot.h
@@ -45,7 +45,7 @@ extern "C" {
  * properly aligned (and packed).
  */
 
-#define	REPLICA_VERSION	2
+#define	REPLICA_VERSION	3
 #define	MAX_NAME_LEN	256
 #define	MAX_IP_LEN	64
 #define	TARGET_PORT	6060
@@ -134,6 +134,8 @@ struct mgmt_ack {
 	uint64_t	pool_guid;
 	uint64_t	zvol_guid;
 	uint16_t	port;
+	uint8_t		quorum;
+	uint8_t		reserved[5];
 	char		ip[MAX_IP_LEN];
 	char		volname[MAX_NAME_LEN]; // zvol helping rebuild
 	char		dw_volname[MAX_NAME_LEN]; // zvol being rebuilt

--- a/lib/libzpool/zrepl_mgmt.c
+++ b/lib/libzpool/zrepl_mgmt.c
@@ -133,7 +133,7 @@ create_and_bind(const char *port, int bind_needed, boolean_t nonblock)
 
 	for (rp = result; rp != NULL; rp = rp->ai_next) {
 		int flags = rp->ai_socktype;
-		int enable = 1;
+		int enable;
 
 		if (nonblock)
 			flags |= SOCK_NONBLOCK;
@@ -142,10 +142,17 @@ create_and_bind(const char *port, int bind_needed, boolean_t nonblock)
 			continue;
 		}
 
+		enable = 1;
+		if (setsockopt(sfd, IPPROTO_TCP, TCP_NODELAY, &enable,
+		    sizeof (enable) < 0)) {
+			perror("setsockopt(TCP_NODELAY) failed");
+		}
+
 		if (bind_needed == 0) {
 			break;
 		}
 
+		enable = 1;
 		if (setsockopt(sfd, SOL_SOCKET, SO_REUSEADDR, &enable,
 		    sizeof (int)) < 0) {
 			perror("setsockopt(SO_REUSEADDR) failed");

--- a/lib/libzpool/zrepl_mgmt.c
+++ b/lib/libzpool/zrepl_mgmt.c
@@ -5,6 +5,8 @@
 #include <sys/uzfs_zvol.h>
 #include <sys/dnode.h>
 #include <sys/dsl_destroy.h>
+#include <sys/dsl_prop.h>
+#include <sys/dsl_dir.h>
 #include <zrepl_mgmt.h>
 #include <uzfs_mgmt.h>
 #include <uzfs_zap.h>
@@ -455,6 +457,25 @@ uzfs_zinfo_store_last_committed_degraded_io_no(zvol_info_t *zinfo,
 {
 	uzfs_zvol_store_kv_pair(zinfo->main_zv,
 	    DEGRADED_IO_SEQNUM, io_seq);
+}
+
+uint8_t
+uzfs_zinfo_get_quorum(zvol_info_t *zinfo)
+{
+	uint64_t quorum;
+	VERIFY0(dsl_prop_get_integer(zinfo->main_zv->zv_name,
+	    zfs_prop_to_name(ZFS_PROP_QUORUM), &quorum, NULL));
+	return (!!quorum);
+}
+
+int
+uzfs_zinfo_set_quorum(zvol_info_t *zinfo, uint64_t val)
+{
+	int err = dsl_dataset_set_quorum(zinfo->main_zv->zv_name,
+	    ZPROP_SRC_LOCAL, 1);
+	if (err)
+		return (err);
+	return (0);
 }
 
 /*

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -841,8 +841,7 @@ exit:
 		 * set the quorum to 1 once rebuild is done. istgt will
 		 * start considering it in the quorum decision.
 		 */
-		VERIFY0(dsl_dataset_set_quorum(zinfo->main_zv->zv_name,
-		    ZPROP_SRC_LOCAL, 1));
+		VERIFY0(uzfs_zinfo_set_quorum(zinfo, 1));
 
 		mutex_enter(&zinfo->main_zv->rebuild_mtx);
 		/* Mark replica healthy now */

--- a/lib/libzrepl/mgmt_conn.c
+++ b/lib/libzrepl/mgmt_conn.c
@@ -483,9 +483,27 @@ uzfs_zvol_mgmt_get_handshake_info(zvol_io_hdr_t *in_hdr, const char *name,
 	    &zinfo->checkpointed_ionum);
 	error2 = uzfs_zvol_get_last_committed_io_no(zv, DEGRADED_IO_SEQNUM,
 	    &zinfo->degraded_checkpointed_ionum);
-	if ((error1 != 0) || (error2 != 0)) {
-		LOG_ERR("Failed to read io_seqnum %s", zinfo->name);
+	if (error1 != 0) {
+		LOG_ERR("Failed to read io_seqnum %s, err1: %d err2: %d",
+		    zinfo->name, error1, error2);
 		return (-1);
+	}
+
+	/*
+	 * Success condition for error2
+	 * error2 can be 0 (or)
+	 * error2 can be ENOENT when REPLICA_VERSION <= 3
+	*/
+	if (!((error2 == 0) || (error2 == ENOENT && REPLICA_VERSION <= 3))) {
+		LOG_ERR("Failed to read degraded_io %s, err1: %d err2: %d",
+		    zinfo->name, error1, error2);
+		return (-1);
+	}
+
+	if (error2 != 0) {
+		LOG_ERR("Failed to read degraded_io %sd err: %d", zinfo->name,
+		    error2);
+		zinfo->degraded_checkpointed_ionum = 0;
 	}
 
 	/*

--- a/lib/libzrepl/mgmt_conn.c
+++ b/lib/libzrepl/mgmt_conn.c
@@ -513,6 +513,7 @@ uzfs_zvol_mgmt_get_handshake_info(zvol_io_hdr_t *in_hdr, const char *name,
 	mgmt_ack->checkpointed_io_seq = zinfo->checkpointed_ionum;
 	mgmt_ack->checkpointed_degraded_io_seq =
 	    zinfo->degraded_checkpointed_ionum;
+	mgmt_ack->quorum = uzfs_zinfo_get_quorum(zinfo);
 
 	return (0);
 }

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -393,6 +393,23 @@ uzfs_ioc_stats(zfs_cmd_t *zc, nvlist_t *nvl)
 			fnvlist_add_uint64(innvl, "rebuildFailedCnt",
 			    zv->main_zv->rebuild_info.rebuild_failed_cnt);
 
+			fnvlist_add_uint64(innvl, "readCount",
+			    zv->read_req_ack_cnt);
+			fnvlist_add_uint64(innvl, "readLatency",
+			    zv->read_latency);
+			fnvlist_add_uint64(innvl, "readByte",
+			    zv->read_byte);
+			fnvlist_add_uint64(innvl, "writeCount",
+			    zv->write_req_ack_cnt);
+			fnvlist_add_uint64(innvl, "writeLatency",
+			    zv->write_latency);
+			fnvlist_add_uint64(innvl, "writeByte",
+			    zv->write_byte);
+			fnvlist_add_uint64(innvl, "syncCount",
+			    zv->sync_req_ack_cnt);
+			fnvlist_add_uint64(innvl, "syncLatency",
+			    zv->sync_latency);
+
 			fnvlist_add_nvlist(nvl, zv->name, innvl);
 			fnvlist_free(innvl);
 			if (zc->zc_name[0] != '\0')

--- a/tests/cbtest/gtest/test_uzfs.cc
+++ b/tests/cbtest/gtest/test_uzfs.cc
@@ -2571,7 +2571,7 @@ void mock_tgt_thread(void *arg)
 
 	/* Send wrong protocol version */
 	if (mgmt_test_case == 2)
-		hdr.version = 3;
+		hdr.version = -1;
 
 	/* Header len is greater than MAX_NAME_LEN */
 	if (mgmt_test_case == 4)


### PR DESCRIPTION
In 0.8, there is addition of `degraded_io_seq` to zvol properties.
This is causing upgrade issue from 0.7 to 0.8 due to strict check on the existence of above key.

This PR is to remove the strict check for `degraded_io_seq` zvol property.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>