### PR TITLE
fix(upgrade_issue): upgrade issue from 0.7 to 0.8 due to strick check…

### DIFF
--- a/lib/libzrepl/mgmt_conn.c
+++ b/lib/libzrepl/mgmt_conn.c
@@ -483,9 +483,27 @@ uzfs_zvol_mgmt_get_handshake_info(zvol_io_hdr_t *in_hdr, const char *name,
 	    &zinfo->checkpointed_ionum);
 	error2 = uzfs_zvol_get_last_committed_io_no(zv, DEGRADED_IO_SEQNUM,
 	    &zinfo->degraded_checkpointed_ionum);
-	if ((error1 != 0) || (error2 != 0)) {
-		LOG_ERR("Failed to read io_seqnum %s", zinfo->name);
+	if (error1 != 0) {
+		LOG_ERR("Failed to read io_seqnum %s, err1: %d err2: %d",
+		    zinfo->name, error1, error2);
 		return (-1);
+	}
+
+	/*
+	 * Success condition for error2
+	 * error2 can be 0 (or)
+	 * error2 can be ENOENT when REPLICA_VERSION <= 3
+	*/
+	if (!((error2 == 0) || (error2 == ENOENT && REPLICA_VERSION <= 3))) {
+		LOG_ERR("Failed to read degraded_io %s, err1: %d err2: %d",
+		    zinfo->name, error1, error2);
+		return (-1);
+	}
+
+	if (error2 != 0) {
+		LOG_ERR("Failed to read degraded_io %sd err: %d", zinfo->name,
+		    error2);
+		zinfo->degraded_checkpointed_ionum = 0;
 	}
 
 	/*

--- a/lib/libzrepl/mgmt_conn.c
+++ b/lib/libzrepl/mgmt_conn.c
@@ -493,7 +493,7 @@ uzfs_zvol_mgmt_get_handshake_info(zvol_io_hdr_t *in_hdr, const char *name,
 	 * Success condition for error2
 	 * error2 can be 0 (or)
 	 * error2 can be ENOENT when REPLICA_VERSION <= 3
-	*/
+	 */
 	if (!((error2 == 0) || (error2 == ENOENT && REPLICA_VERSION <= 3))) {
 		LOG_ERR("Failed to read degraded_io %s, err1: %d err2: %d",
 		    zinfo->name, error1, error2);


### PR DESCRIPTION
… on degrade_io_seq key

In 0.8, there is addition of degraded_io_seq to zvol properties.
This is causing upgrade issue from 0.7 to 0.8 due to strict check on the existence of above key.

This PR is to remove the strict check for degraded_io_seq zvol property.

Signed-off-by: Vishnu Itta vitta@mayadata.io