### PR TITLE
feat(resilvering): support for zpool clear command (#186)

### DIFF
--- a/include/libuzfs.h
+++ b/include/libuzfs.h
@@ -74,7 +74,8 @@ typedef struct uzfs_monitor {
     _UZFS_IOC(ZFS_IOC_PROMOTE, 1, 0, "promote the volume")                     \
     _UZFS_IOC(ZFS_IOC_CLONE, 1, 1, "clone the volume")                         \
     _UZFS_IOC(ZFS_IOC_ERROR_LOG, 0, 0, "get the error log")                    \
-    _UZFS_IOC(ZFS_IOC_STATS, 0, 0, "get the zfs volume stats")
+    _UZFS_IOC(ZFS_IOC_STATS, 0, 0, "get the zfs volume stats")                 \
+    _UZFS_IOC(ZFS_IOC_CLEAR, 1, 0, "clear the zpool error counters")
 
 
 #define	MAX_NVLIST_SRC_SIZE (128 * 1024 * 1024)

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -5156,7 +5156,6 @@ zfs_ioc_error_log(zfs_cmd_t *zc)
 	return (error);
 }
 
-#if defined(_KERNEL)
 static int
 zfs_ioc_clear(zfs_cmd_t *zc)
 {
@@ -5236,6 +5235,7 @@ zfs_ioc_clear(zfs_cmd_t *zc)
 	return (error);
 }
 
+#if defined(_KERNEL)
 static int
 zfs_ioc_pool_reopen(zfs_cmd_t *zc)
 {
@@ -7355,6 +7355,10 @@ uzfs_handle_ioctl(const char *pool, zfs_cmd_t *zc, uzfs_info_t *ucmd_info)
 		if (err == 0)
 			err = put_nvlist(zc, outnvl);
 		nvlist_free(outnvl);
+		break;
+	}
+	case ZFS_IOC_CLEAR: {
+		err = zfs_ioc_clear(zc);
 		break;
 	}
 	default:

--- a/tests/cbtest/script/test_uzfs.sh
+++ b/tests/cbtest/script/test_uzfs.sh
@@ -574,6 +574,9 @@ test_stripe_pool()
 	create_disk $src_pool_spare_disk
 	create_disk $dst_pool_spare_disk
 
+	# test clear pool
+	log_must $ZPOOL clear $src_pool
+
 	log_must $ZPOOL add -f $src_pool $src_pool_spare_disk
 	log_must $ZPOOL add -f $dst_pool $dst_pool_spare_disk
 
@@ -644,6 +647,9 @@ test_mirror_pool()
 	log_must $ZPOOL create -f $dst_pool mirror \
 	    -o cachefile="$TMPDIR/zpool_$dst_pool.cache" \
 	    $dst_pool_disk_a $dst_pool_disk_b
+
+	# test clear pool
+	log_must $ZPOOL clear $src_pool
 
 	# test pool expansion
 	create_disk $src_pool_spare_disk_a $src_pool_spare_disk_b
@@ -724,6 +730,9 @@ test_raidz_pool()
 	log_must $ZPOOL add -f $dst_pool \
 	    ${dst_pool_spare_disk[1]} ${dst_pool_spare_disk[2]} \
 	    ${dst_pool_spare_disk[3]} ${dst_pool_spare_disk[4]}
+
+	# test clear pool
+	log_must $ZPOOL clear $src_pool
 
 	# test vdev remove
 	log_must_not $ZPOOL remove $src_pool ${src_pool_spare_disk[2]}


### PR DESCRIPTION
Once disk is removed and reattached back, we should
trigger the zpool clear command to clear out the counters
which in turn will also trigger the resilvering.

Signed-off-by: Pawan <pawanprakash101@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
