### PR TITLE
zrepl(perf) adding cur and dispatched IO counter.

### DIFF
--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -197,8 +197,9 @@ typedef struct zvol_info_s {
 	uint64_t 	write_byte;
 	uint64_t	sync_req_ack_cnt;
 	uint64_t 	sync_latency;
-	uint64_t 	cur_io_cnt;
-	uint64_t	dispatched_io_cnt;
+	uint64_t 	inflight_io_cnt; // ongoing IOs count
+	uint64_t	dispatched_io_cnt; // total received but incomplete IOs
+
 
 	// histogram of IOs
 	zfs_histogram_t uzfs_rio_histogram[ZFS_HISTOGRAM_IO_SIZE /

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -197,6 +197,8 @@ typedef struct zvol_info_s {
 	uint64_t 	write_byte;
 	uint64_t	sync_req_ack_cnt;
 	uint64_t 	sync_latency;
+	uint64_t 	cur_io_cnt;
+	uint64_t	dispatched_io_cnt;
 
 	// histogram of IOs
 	zfs_histogram_t uzfs_rio_histogram[ZFS_HISTOGRAM_IO_SIZE /

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -340,7 +340,7 @@ uzfs_zvol_worker(void *arg)
 		goto drop_refcount;
 	}
 
-	atomic_inc_64(&zinfo->cur_io_cnt);
+	atomic_inc_64(&zinfo->inflight_io_cnt);
 
 	/*
 	 * If zvol hasn't passed rebuild phase or if read
@@ -436,7 +436,7 @@ uzfs_zvol_worker(void *arg)
 	(void) pthread_mutex_unlock(&zinfo->zinfo_mutex);
 
 drop_refcount:
-	atomic_add_64(&zinfo->cur_io_cnt, -1);
+	atomic_add_64(&zinfo->inflight_io_cnt, -1);
 	atomic_add_64(&zinfo->dispatched_io_cnt, -1);
 
 	uzfs_zinfo_drop_refcnt(zinfo);

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -340,6 +340,8 @@ uzfs_zvol_worker(void *arg)
 		goto drop_refcount;
 	}
 
+	atomic_inc_64(&zinfo->cur_io_cnt);
+
 	/*
 	 * If zvol hasn't passed rebuild phase or if read
 	 * is meant for rebuild or if target has asked for metadata
@@ -434,6 +436,9 @@ uzfs_zvol_worker(void *arg)
 	(void) pthread_mutex_unlock(&zinfo->zinfo_mutex);
 
 drop_refcount:
+	atomic_add_64(&zinfo->cur_io_cnt, -1);
+	atomic_add_64(&zinfo->dispatched_io_cnt, -1);
+
 	uzfs_zinfo_drop_refcnt(zinfo);
 }
 
@@ -794,6 +799,7 @@ next_step:
 		 */
 		uzfs_zinfo_take_refcnt(zinfo);
 		zio_cmd->zinfo = zinfo;
+		atomic_inc_64(&zinfo->dispatched_io_cnt);
 		uzfs_zvol_worker(zio_cmd);
 		if (zio_cmd->hdr.status != ZVOL_OP_STATUS_OK) {
 			LOG_ERR("rebuild IO failed.. for %s..", zinfo->name);
@@ -1291,6 +1297,7 @@ uzfs_zvol_rebuild_scanner_callback(off_t offset, size_t len,
 	uzfs_zinfo_take_refcnt(zinfo);
 	zio_cmd->zinfo = zinfo;
 	zinfo->rebuild_zv = zv;
+	atomic_inc_64(&zinfo->dispatched_io_cnt);
 
 	/*
 	 * Any error in uzfs_zvol_worker will send FAILURE status to degraded
@@ -1318,6 +1325,7 @@ uzfs_zvol_send_zio_cmd(zvol_info_t *zinfo, zvol_io_hdr_t *hdrp,
 	if (payload_size != 0)
 		bcopy(payload, zio_cmd->buf, payload_size);
 
+	atomic_inc_64(&zinfo->dispatched_io_cnt);
 	/* Take refcount for uzfs_zvol_worker to work on it */
 	uzfs_zinfo_take_refcnt(zinfo);
 	zio_cmd->zinfo = zinfo;
@@ -1741,6 +1749,7 @@ uzfs_zvol_io_ack_sender(void *arg)
 		zinfo->zio_cmd_in_ack = zio_cmd;
 		if (zio_cmd->hdr.flags & ZVOL_OP_FLAG_REBUILD)
 			zinfo->rebuild_cmd_acked_cnt++;
+
 		(void) pthread_mutex_unlock(&zinfo->zinfo_mutex);
 
 		LOG_DEBUG("ACK for op: %d, seq-id: %ld",
@@ -2116,6 +2125,8 @@ uzfs_zvol_io_receiver(void *arg)
 			zinfo->quiesce_requested = 0;
 			zinfo->quiesce_done = 1;
 		}
+
+		atomic_inc_64(&zinfo->dispatched_io_cnt);
 
 		taskq_dispatch(zinfo->uzfs_zvol_taskq, uzfs_zvol_worker,
 		    zio_cmd, TQ_SLEEP);

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -416,6 +416,10 @@ uzfs_ioc_stats(zfs_cmd_t *zc, nvlist_t *nvl)
 			    zv->sync_req_ack_cnt);
 			fnvlist_add_uint64(innvl, "syncLatency",
 			    zv->sync_latency);
+			fnvlist_add_uint64(innvl, "curIOCnt",
+			    zv->cur_io_cnt);
+			fnvlist_add_uint64(innvl, "dispatchedIOCnt",
+			    zv->dispatched_io_cnt);
 
 			nvlist_t *rnvl = fnvlist_alloc();
 

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -416,8 +416,8 @@ uzfs_ioc_stats(zfs_cmd_t *zc, nvlist_t *nvl)
 			    zv->sync_req_ack_cnt);
 			fnvlist_add_uint64(innvl, "syncLatency",
 			    zv->sync_latency);
-			fnvlist_add_uint64(innvl, "curIOCnt",
-			    zv->cur_io_cnt);
+			fnvlist_add_uint64(innvl, "inflightIOCnt",
+			    zv->inflight_io_cnt);
 			fnvlist_add_uint64(innvl, "dispatchedIOCnt",
 			    zv->dispatched_io_cnt);
 


### PR DESCRIPTION
root@cstor-disk-1-jgo9-754f596bb5-jdfbt:/# zfs stats | jq
{
  "stats": [
    {
      "name": "cstor-5ac49b1b-2ab4-11e9-a02a-42010a80014b/pvc-5fef263d-2ab4-11e9-a02a-42010a80014b",
      "status": "Offline",
      "rebuildStatus": "INIT",
      "isIOAckSenderCreated": 0,
      "isIOReceiverCreated": 0,
      "runningIONum": 0,
      "checkpointedIONum": 0,
      "degradedCheckpointedIONum": 0,
      "checkpointedTime": 0,
      "rebuildBytes": 0,
      "rebuildCnt": 0,
      "rebuildDoneCnt": 0,
      "rebuildFailedCnt": 0,
      "readCount": 0,
      "readLatency": 0,
      "readByte": 0,
      "writeCount": 0,
      "writeLatency": 0,
      "writeByte": 0,
      "syncCount": 0,
      "syncLatency": 0,
      "curIOCnt": 0,
      "dispatchedIOCnt": 0,
      "ruio": {},
      "wuio": {}
    },
    {
      "pool": {
        "cstor-5ac49b1b-2ab4-11e9-a02a-42010a80014b": {
          "rzio": {
            "32KB": "24576/3"
          },
          "wzio": {
            "32KB": "1249280/161",
            "64KB": "176128/4",
            "128KB": "917504/8",
            "160KB": "524288/4"
          }
        }
      }
    }
  ]
}
