### PR TITLE
zrepl(perf) adding tunable zrepl worker via env

### DIFF
--- a/lib/libzpool/zrepl_mgmt.c
+++ b/lib/libzpool/zrepl_mgmt.c
@@ -380,7 +380,16 @@ uzfs_zinfo_init(void *zv, const char *ds_name, nvlist_t *create_props)
 	ASSERT(zinfo->clone_zv == NULL);
 	ASSERT(zinfo->snapshot_zv == NULL);
 
-	zinfo->uzfs_zvol_taskq = taskq_create("replica", boot_ncpus,
+	char *env = getenv("UZFS_WORKER");
+	int nthread = 1;
+	if (env != NULL) {
+		nthread = atoi(env);
+		LOG_INFO("env UZFS_WORKER = %d", nthread);
+	}
+
+	int nworker = MAX(boot_ncpus, nthread);
+
+	zinfo->uzfs_zvol_taskq = taskq_create("replica", nworker,
 	    defclsyspri, boot_ncpus, INT_MAX,
 	    TASKQ_PREPOPULATE | TASKQ_DYNAMIC);
 

--- a/lib/libzpool/zrepl_mgmt.c
+++ b/lib/libzpool/zrepl_mgmt.c
@@ -390,7 +390,7 @@ uzfs_zinfo_init(void *zv, const char *ds_name, nvlist_t *create_props)
 	int nworker = MAX(boot_ncpus, nthread);
 
 	zinfo->uzfs_zvol_taskq = taskq_create("replica", nworker,
-	    defclsyspri, boot_ncpus, INT_MAX,
+	    defclsyspri, nworker, INT_MAX,
 	    TASKQ_PREPOPULATE | TASKQ_DYNAMIC);
 
 	STAILQ_INIT(&zinfo->complete_queue);


### PR DESCRIPTION
```
pawan@pawan-openebs:~/gke-yaml$ kubectl describe pod cstor-disk-1-w7xf-65fb7d7855-w5mvn -n openebs
Name:               cstor-disk-1-w7xf-65fb7d7855-w5mvn
Namespace:          openebs
Priority:           0
PriorityClassName:  <none>
Node:               gke-pawan-perf-pool-1-74a172fd-73v9/10.128.15.224
Start Time:         Thu, 07 Feb 2019 16:04:23 +0530
Labels:             app=cstor-pool
                    openebs.io/storage-pool-claim=cstor-disk-1
                    pod-template-hash=2196383411
Annotations:        <none>
Status:             Running
IP:                 10.12.2.11
Controlled By:      ReplicaSet/cstor-disk-1-w7xf-65fb7d7855
Containers:
  cstor-pool:
    Container ID:   docker://cbc89db5f4f872396457672c615fdf4cb08d16c25da4886f94de2431ac399c0e
    Image:          pawanpraka1/cstor-pool:env1
    Image ID:       docker-pullable://pawanpraka1/cstor-pool@sha256:e2cea07de77ca245b039847ff89f66915aa7bd327a3a356e4b9f45527a7c8ab0
    Ports:          12000/TCP, 3233/TCP, 3232/TCP
    Host Ports:     0/TCP, 0/TCP, 0/TCP
    State:          Running
      Started:      Thu, 07 Feb 2019 16:04:24 +0530
    Ready:          True
    Restart Count:  0
    Environment:
      UZFS_WORKER:  10
    Mounts:
      /dev from device (rw)
      /run/udev from udev (rw)
      /tmp from tmp (rw)
      /var/openebs/sparse from sparse (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from openebs-maya-operator-token-r2xjn (ro)
  cstor-pool-mgmt:
    Container ID:   docker://242010aafeb3e261912c0b88dd97963fae0d396ea361b03d68a0485010152a0a
    Image:          quay.io/openebs/cstor-pool-mgmt:0.8.0
    Image ID:       docker-pullable://quay.io/openebs/cstor-pool-mgmt@sha256:19423d5fbeaf4cda4b9cd62993245116b68a46a508a08d78eb165c2ed7f9366c
    Port:           9500/TCP
    Host Port:      0/TCP
    State:          Running
      Started:      Thu, 07 Feb 2019 16:04:27 +0530
    Ready:          True
    Restart Count:  0
    Environment:
      OPENEBS_IO_CSTOR_ID:  b29cd78c-2abe-11e9-a965-42010a8000f7
      UZFS_WORKER:          10
      POD_NAME:             cstor-disk-1-w7xf-65fb7d7855-w5mvn (v1:metadata.name)
      NAMESPACE:            openebs (v1:metadata.namespace)
      RESYNC_INTERVAL:      30
    Mounts:
      /dev from device (rw)
      /run/udev from udev (rw)
      /tmp from tmp (rw)
      /var/openebs/sparse from sparse (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from openebs-maya-operator-token-r2xjn (ro)
Conditions:
  Type              Status
  Initialized       True 
  Ready             True 
  ContainersReady   True 
  PodScheduled      True 
Volumes:
  device:
    Type:          HostPath (bare host directory volume)
    Path:          /dev
    HostPathType:  Directory
  tmp:
    Type:          HostPath (bare host directory volume)
    Path:          /var/openebs/shared-cstor-disk-1
    HostPathType:  DirectoryOrCreate
  sparse:
    Type:          HostPath (bare host directory volume)
    Path:          /var/openebs/sparse
    HostPathType:  DirectoryOrCreate
  udev:
    Type:          HostPath (bare host directory volume)
    Path:          /run/udev
    HostPathType:  Directory
  openebs-maya-operator-token-r2xjn:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  openebs-maya-operator-token-r2xjn
    Optional:    false
QoS Class:       BestEffort
Node-Selectors:  kubernetes.io/hostname=gke-pawan-perf-pool-1-74a172fd-73v9
Tolerations:     node.kubernetes.io/not-ready:NoExecute for 300s
                 node.kubernetes.io/unreachable:NoExecute for 300s
Events:
  Type    Reason     Age   From                                          Message
  ----    ------     ----  ----                                          -------
  Normal  Scheduled  20s   default-scheduler                             Successfully assigned openebs/cstor-disk-1-w7xf-65fb7d7855-w5mvn to gke-pawan-perf-pool-1-74a172fd-73v9
  Normal  Pulling    19s   kubelet, gke-pawan-perf-pool-1-74a172fd-73v9  pulling image "pawanpraka1/cstor-pool:env1"
  Normal  Pulled     19s   kubelet, gke-pawan-perf-pool-1-74a172fd-73v9  Successfully pulled image "pawanpraka1/cstor-pool:env1"
  Normal  Created    19s   kubelet, gke-pawan-perf-pool-1-74a172fd-73v9  Created container
  Normal  Started    19s   kubelet, gke-pawan-perf-pool-1-74a172fd-73v9  Started container
  Normal  Pulled     17s   kubelet, gke-pawan-perf-pool-1-74a172fd-73v9  Container image "quay.io/openebs/cstor-pool-mgmt:0.8.0" already present on machine
  Normal  Created    17s   kubelet, gke-pawan-perf-pool-1-74a172fd-73v9  Created container
  Normal  Started    16s   kubelet, gke-pawan-perf-pool-1-74a172fd-73v9  Started container
```

```
pawan@pawan-openebs:~/gke-yaml$ kubectl logs -f cstor-disk-1-w7xf-65fb7d7855-w5mvn -n openebs -c cstor-pool
 * Starting OpenBSD Secure Shell server sshd
   ...done.
sleeping for 2 sec
2019-02-07/10:34:26.916 disabled auto import (reading of zpool.cache)
physmem = 7718891 pages (29.45 GB)
2019-02-07/10:34:27.449 zvol cstor-b29cd78c-2abe-11e9-a965-42010a8000f7/pvc-a7498b0d-2abf-11e9-a965-42010a8000f7 status change: DEGRADED -> DEGRADED
2019-02-07/10:34:27.449 zvol cstor-b29cd78c-2abe-11e9-a965-42010a8000f7/pvc-a7498b0d-2abf-11e9-a965-42010a8000f7 rebuild status change: INIT -> INIT
2019-02-07/10:34:27.449 env UZFS_WORKER = 10
2019-02-07/10:34:27.450 Instantiating zvol cstor-b29cd78c-2abe-11e9-a965-42010a8000f7/pvc-a7498b0d-2abf-11e9-a965-42010a8000f7
2019-02-07/10:34:27.450 [tgt 10.15.245.75:6060:17]: Connected
2019-02-07/10:34:27.451 [tgt 10.15.245.75:6060:17]: Handshake command for zvol pvc-a7498b0d-2abf-11e9-a965-42010a8000f7
2019-02-07/10:34:27.489 Volume:cstor-b29cd78c-2abe-11e9-a965-42010a8000f7/pvc-a7498b0d-2abf-11e9-a965-42010a8000f7 has zvol_guid:11894468975980190260
2019-02-07/10:34:27.489 IO sequence number:0 Degraded IO sequence number:0
2019-02-07/10:34:27.489 New data connection on fd 8
2019-02-07/10:34:27.506 zvol cstor-b29cd78c-2abe-11e9-a965-42010a8000f7/pvc-a7498b0d-2abf-11e9-a965-42010a8000f7@rebuild_snap status change: DEGRADED -> DEGRADED
2019-02-07/10:34:27.506 zvol cstor-b29cd78c-2abe-11e9-a965-42010a8000f7/pvc-a7498b0d-2abf-11e9-a965-42010a8000f7@rebuild_snap rebuild status change: INIT -> INIT
2019-02-07/10:34:27.562 zvol cstor-b29cd78c-2abe-11e9-a965-42010a8000f7/pvc-a7498b0d-2abf-11e9-a965-42010a8000f7_rebuild_clone status change: DEGRADED -> DEGRADED
2019-02-07/10:34:27.562 zvol cstor-b29cd78c-2abe-11e9-a965-42010a8000f7/pvc-a7498b0d-2abf-11e9-a965-42010a8000f7_rebuild_clone rebuild status change: INIT -> INIT
2019-02-07/10:34:27.563 Started ack sender for zvol cstor-b29cd78c-2abe-11e9-a965-42010a8000f7/pvc-a7498b0d-2abf-11e9-a965-42010a8000f7 fd: 8
2019-02-07/10:34:27.563 Data connection associated with zvol cstor-b29cd78c-2abe-11e9-a965-42010a8000f7/pvc-a7498b0d-2abf-11e9-a965-42010a8000f7 fd: 8
2019-02-07/10:34:38.571 [tgt 10.15.245.75:6060:17]: Replica status command for zvol pvc-a7498b0d-2abf-11e9-a965-42010a8000f7
2019-02-07/10:34:38.571 zvol cstor-b29cd78c-2abe-11e9-a965-42010a8000f7/pvc-a7498b0d-2abf-11e9-a965-42010a8000f7 rebuild status change: INIT -> ACTIVE DATASET REBUILD INPROGRESS
2019-02-07/10:34:38.571 Volume:cstor-b29cd78c-2abe-11e9-a965-42010a8000f7/pvc-a7498b0d-2abf-11e9-a965-42010a8000f7 has zvol_guid:11894468975980190260
2019-02-07/10:34:38.571 IO sequence number:0 Degraded IO sequence number:0
2019-02-07/10:34:38.572 zvol cstor-b29cd78c-2abe-11e9-a965-42010a8000f7/pvc-a7498b0d-2abf-11e9-a965-42010a8000f7 at 10.12.2.11:3233 helping in rebuild
2019-02-07/10:34:38.572 Rebuild started from clone for vol cstor-b29cd78c-2abe-11e9-a965-42010a8000f7/pvc-a7498b0d-2abf-11e9-a965-42010a8000f7
2019-02-07/10:34:38.572 New rebuild connection
2019-02-07/10:34:38.572 Rebuild scanner started on zvol cstor-b29cd78c-2abe-11e9-a965-42010a8000f7/pvc-a7498b0d-2abf-11e9-a965-42010a8000f7
2019-02-07/10:34:38.572 Checkpointed IO_seq: 0, Rebuild Req offset: 0, Rebuild Req length: 5368709120
2019-02-07/10:34:38.591 zvol cstor-b29cd78c-2abe-11e9-a965-42010a8000f7/pvc-a7498b0d-2abf-11e9-a965-42010a8000f7_rebuild_clone@.io_snap0.1549535678 status change: DEGRADED -> DEGRADED
2019-02-07/10:34:38.591 zvol cstor-b29cd78c-2abe-11e9-a965-42010a8000f7/pvc-a7498b0d-2abf-11e9-a965-42010a8000f7_rebuild_clone@.io_snap0.1549535678 rebuild status change: INIT -> INIT
2019-02-07/10:34:38.635 Rebuilding zvol cstor-b29cd78c-2abe-11e9-a965-42010a8000f7/pvc-a7498b0d-2abf-11e9-a965-42010a8000f7 completed
2019-02-07/10:34:38.635 closing snap cstor-b29cd78c-2abe-11e9-a965-42010a8000f7/pvc-a7498b0d-2abf-11e9-a965-42010a8000f7_rebuild_clone@.io_snap0.1549535678
2019-02-07/10:34:38.636 zvol cstor-b29cd78c-2abe-11e9-a965-42010a8000f7/pvc-a7498b0d-2abf-11e9-a965-42010a8000f7 rebuild status change: ACTIVE DATASET REBUILD INPROGRESS -> DONE
2019-02-07/10:34:38.636 zvol cstor-b29cd78c-2abe-11e9-a965-42010a8000f7/pvc-a7498b0d-2abf-11e9-a965-42010a8000f7 status change: DEGRADED -> HEALTHY
2019-02-07/10:34:38.654 Rebuild process is over on zvol cstor-b29cd78c-2abe-11e9-a965-42010a8000f7/pvc-a7498b0d-2abf-11e9-a965-42010a8000f7
2019-02-07/10:34:38.654 Closing rebuild connection for zvol cstor-b29cd78c-2abe-11e9-a965-42010a8000f7/pvc-a7498b0d-2abf-11e9-a965-42010a8000f7
2019-02-07/10:34:38.655 Destroying cstor-b29cd78c-2abe-11e9-a965-42010a8000f7/pvc-a7498b0d-2abf-11e9-a965-42010a8000f7@rebuild_snap and cstor-b29cd78c-2abe-11e9-a965-42010a8000f7/pvc-a7498b0d-2abf-11e9-a965-42010a8000f7_rebuild_clone(cstor-b29cd78c-2abe-11e9-a965-42010a8000f7/pvc-a7498b0d-2abf-11e9-a965-42010a8000f7_rebuild_clone) on:cstor-b29cd78c-2abe-11e9-a965-42010a8000f7/pvc-a7498b0d-2abf-11e9-a965-42010a8000f7
2019-02-07/10:34:38.655 Closing cstor-b29cd78c-2abe-11e9-a965-42010a8000f7/pvc-a7498b0d-2abf-11e9-a965-42010a8000f7@rebuild_snap and cstor-b29cd78c-2abe-11e9-a965-42010a8000f7/pvc-a7498b0d-2abf-11e9-a965-42010a8000f7_rebuild_clone dataset on:cstor-b29cd78c-2abe-11e9-a965-42010a8000f7/pvc-a7498b0d-2abf-11e9-a965-42010a8000f7
2019-02-07/10:34:38.655 Destroy for pool: null vol: cstor-b29cd78c-2abe-11e9-a965-42010a8000f7/pvc-a7498b0d-2abf-11e9-a965-42010a8000f7_rebuild_clone, destroyed: 0
2019-02-07/10:34:48.582 [tgt 10.15.245.75:6060:17]: Replica status command for zvol pvc-a7498b0d-2abf-11e9-a965-42010a8000f7

```