### PR TITLE
feat(zfs): split name into poolname and volname

### DIFF
--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -368,7 +368,8 @@ uzfs_ioc_stats(zfs_cmd_t *zc, nvlist_t *nvl)
 		if (zc->zc_name[0] == '\0' ||
 		    (uzfs_zvol_name_compare(zv, zc->zc_name) == 0)) {
 			nvlist_t *innvl = fnvlist_alloc();
-			/* split the string of the format poolname/volname
+			/*
+			 * split the string of the format poolname/volname
 			 * into two separate strings.
 			 */
 			char str[256];

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -368,8 +368,17 @@ uzfs_ioc_stats(zfs_cmd_t *zc, nvlist_t *nvl)
 		if (zc->zc_name[0] == '\0' ||
 		    (uzfs_zvol_name_compare(zv, zc->zc_name) == 0)) {
 			nvlist_t *innvl = fnvlist_alloc();
+			/* split the string of the format poolname/volname
+			 * into two separate strings.
+			 */
+			char str[256];
+			strcpy(str, zv->name);
+			char *newstr = str;
+			char *poolname = strtok_r(newstr, "/", &newstr);
 
 			fnvlist_add_string(innvl, "name", zv->name);
+			fnvlist_add_string(innvl, "poolName", poolname);
+			fnvlist_add_string(innvl, "volName", newstr);
 
 			fnvlist_add_string(innvl, "status",
 			    status_to_str(zv));


### PR DESCRIPTION
In the earlier JSON output poolname and volname were
part of the "name" field which needs to parsed when
consumed apart from json unmarshalling. This change
is backward compatiable.

Output:
```
 "name": "pool1/vol1",
 "poolName": "pool1",
 "volName": "vol1",
```

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
