### PR TITLE
[DE249] Destroying all snapshot of rebuild clone dataset once rebuild completes

### DIFF
--- a/include/uzfs_rebuilding.h
+++ b/include/uzfs_rebuilding.h
@@ -61,6 +61,10 @@ int uzfs_zvol_get_or_create_internal_clone(zvol_state_t *zv,
 int uzfs_zvol_release_internal_clone(zvol_state_t *zv,
     zvol_state_t *snap_zv, zvol_state_t *clone_zv);
 
+/*
+ * To remove all internal snapshots of a dataset
+ */
+int uzfs_destroy_internal_all_snap(zvol_state_t *zv);
 boolean_t is_stale_clone(zvol_state_t *);
 
 #ifdef __cplusplus

--- a/lib/libzpool/uzfs_rebuilding.c
+++ b/lib/libzpool/uzfs_rebuilding.c
@@ -403,8 +403,13 @@ uzfs_destroy_internal_all_snap(zvol_state_t *zv)
 {
 	int ret;
 	char snapname[MAXNAMELEN];
-	objset_t *os = zv->zv_objset;
+	objset_t *os;
 	uint64_t obj = 0, cookie = 0;
+
+	if (!zv || !zv->zv_objset)
+		return (-1);
+
+	os = zv->zv_objset;
 
 	while (1) {
 		dsl_pool_config_enter(spa_get_dsl(zv->zv_spa), FTAG);

--- a/lib/libzpool/uzfs_rebuilding.c
+++ b/lib/libzpool/uzfs_rebuilding.c
@@ -393,3 +393,44 @@ again:
 	strfree(snapname);
 	return (ret);
 }
+
+/*
+ * To destroy all internal created snapshot
+ * on a dataset
+ */
+int
+uzfs_destroy_internal_all_snap(zvol_state_t *zv)
+{
+	int ret;
+	char snapname[MAXNAMELEN];
+	objset_t *os = zv->zv_objset;
+	uint64_t obj = 0, cookie = 0;
+
+	while (1) {
+		dsl_pool_config_enter(spa_get_dsl(zv->zv_spa), FTAG);
+		ret = dmu_snapshot_list_next(os, sizeof (snapname) - 1,
+		    snapname, &obj, &cookie, NULL);
+		dsl_pool_config_exit(spa_get_dsl(zv->zv_spa), FTAG);
+
+		if (ret) {
+			if (ret == ENOENT)
+				ret = 0;
+			break;
+		}
+
+		if (!(strcmp(snapname, REBUILD_SNAPSHOT_SNAPNAME) == 0) &&
+		    !(strncmp(snapname, IO_DIFF_SNAPNAME,
+		    sizeof (IO_DIFF_SNAPNAME) - 1) == 0)) {
+			continue;
+		}
+
+		ret = destroy_snapshot_zv(zv, snapname);
+		if (ret != 0) {
+			LOG_ERR("Failed to destroy internal snap(%s) on:%s "
+			    "with err:%d", snapname, zv->zv_name, ret);
+			break;
+		}
+	}
+
+	return (ret);
+}

--- a/lib/libzpool/zrepl_mgmt.c
+++ b/lib/libzpool/zrepl_mgmt.c
@@ -544,6 +544,13 @@ uzfs_zvol_destroy_snapshot_clone(zvol_state_t *zv, zvol_state_t *snap_zv,
 	LOG_INFO("Destroying %s and %s(%s) on:%s", snap_zv->zv_name,
 	    clone_zv->zv_name, clonename, zv->zv_name);
 
+	/* Destroy clone's snapshot */
+	ret = uzfs_destroy_internal_all_snap(clone_zv);
+	if (ret != 0) {
+		LOG_ERR("Rebuild_clone snap destroy failed on:%s"
+		    " with err:%d", clone_zv->zv_name, ret);
+	}
+
 	uzfs_zvol_release_internal_clone(zv, snap_zv, clone_zv);
 
 // try_clone_delete_again:

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -379,9 +379,9 @@ uzfs_ioc_stats(zfs_cmd_t *zc, nvlist_t *nvl)
 			    zv->main_zv->rebuild_info.zv_rebuild_status));
 
 			fnvlist_add_uint64(innvl, "isIOAckSenderCreated",
-			    zv->is_io_ack_sender_created);
+			    (zv->is_io_ack_sender_created) ? 1 : 0);
 			fnvlist_add_uint64(innvl, "isIOReceiverCreated",
-			    zv->is_io_receiver_created);
+			    (zv->is_io_receiver_created) ? 1 : 0);
 			fnvlist_add_uint64(innvl, "runningIONum",
 			    zv->running_ionum);
 			fnvlist_add_uint64(innvl, "checkpointedIONum",


### PR DESCRIPTION
Changes:
1. [DE249] Destroying all snapshot of rebuild clone dataset once rebuild completes

2. Changes in `zfs stats` output.
     ######                   ...
     ######                   isIOAckSenderCreated: 1
     ######                   isIOReceiverCreated: 1
     ######                   ...
     #####             Earlier it was :
     ######                   ...
     ######                   isIOAckSenderCreated: -1
     ######                   isIOReceiverCreated: -1
     ######                   ...

Signed-off-by: mayank <mayank.patel@cloudbyte.com>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
