### PR TITLE
[TC57] Unit test to verify deletion of rebuild_snap once rebuild finished

### DIFF
--- a/include/sys/uzfs_zvol.h
+++ b/include/sys/uzfs_zvol.h
@@ -62,10 +62,9 @@ typedef struct zvol_rebuild_info {
 
 	/*
 	 * does stale clone exist?
-	 * If stale_clone_exist set to 2 then timer thread will delete
+	 * If stale_clone_exist set to non-zero then timer thread will delete
 	 * the clone and related_snapshot.
-	 * scanner thread and rebuilding thread will increment
-	 * stale_clone_exis by 1.
+	 * rebuilding thread will set stale_clone_exist to 1.
 	 */
 	uint8_t	stale_clone_exist;
 } zvol_rebuild_info_t;
@@ -123,7 +122,7 @@ typedef struct zvol_state zvol_state_t;
 	(zv->rebuild_info.zv_rebuild_status == ZVOL_REBUILDING_FAILED)
 
 #define	ZVOL_HAS_STALE_CLONE(zv)	\
-	(zv->rebuild_info.stale_clone_exist == 2)
+	(zv->rebuild_info.stale_clone_exist)
 
 extern int zvol_get_data(void *arg, lr_write_t *lr, char *buf, zio_t *zio);
 const char *rebuild_status_to_str(zvol_rebuild_status_t status);

--- a/include/sys/uzfs_zvol.h
+++ b/include/sys/uzfs_zvol.h
@@ -59,6 +59,15 @@ typedef struct zvol_rebuild_info {
 
 	/* peer replica cnt whose rebuild is done and failure */
 	uint16_t rebuild_failed_cnt;
+
+	/*
+	 * does stale clone exist?
+	 * If stale_clone_exist set to 2 then timer thread will delete
+	 * the clone and related_snapshot.
+	 * scanner thread and rebuilding thread will increment
+	 * stale_clone_exis by 1.
+	 */
+	uint8_t	stale_clone_exist;
 } zvol_rebuild_info_t;
 
 /*
@@ -112,6 +121,9 @@ typedef struct zvol_state zvol_state_t;
 	(zv->rebuild_info.zv_rebuild_status == ZVOL_REBUILDING_ERRORED)
 #define	ZVOL_IS_REBUILDING_FAILED(zv)	\
 	(zv->rebuild_info.zv_rebuild_status == ZVOL_REBUILDING_FAILED)
+
+#define	ZVOL_HAS_STALE_CLONE(zv)	\
+	(zv->rebuild_info.stale_clone_exist == 2)
 
 extern int zvol_get_data(void *arg, lr_write_t *lr, char *buf, zio_t *zio);
 const char *rebuild_status_to_str(zvol_rebuild_status_t status);

--- a/include/uzfs_rebuilding.h
+++ b/include/uzfs_rebuilding.h
@@ -64,7 +64,7 @@ int uzfs_zvol_release_internal_clone(zvol_state_t *zv,
 /*
  * To remove all internal snapshots of a dataset
  */
-int uzfs_destroy_internal_all_snap(zvol_state_t *zv);
+int uzfs_destroy_all_internal_snapshots(zvol_state_t *zv);
 boolean_t is_stale_clone(zvol_state_t *);
 
 #ifdef __cplusplus

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -76,6 +76,7 @@ typedef struct inject_delay_s {
 	int downgraded_replica_rebuild_size_set;
 	int io_receiver_exit;
 	int helping_replica_rebuild_complete;
+	int rebuild_complete;
 } inject_delay_t;
 
 typedef struct inject_rebuild_error_s {
@@ -283,6 +284,11 @@ uzfs_zinfo_take_refcnt(zvol_info_t *zinfo)
 {
 	atomic_inc_64(&zinfo->refcnt);
 }
+
+/*
+ * To remove the internal stale clone
+ */
+int uzfs_zinfo_destroy_stale_clone(zvol_info_t *zinfo);
 
 /*
  * ZAP key for io sequence number

--- a/lib/libzpool/uzfs_rebuilding.c
+++ b/lib/libzpool/uzfs_rebuilding.c
@@ -399,7 +399,7 @@ again:
  * on a dataset
  */
 int
-uzfs_destroy_internal_all_snap(zvol_state_t *zv)
+uzfs_destroy_all_internal_snapshots(zvol_state_t *zv)
 {
 	int ret;
 	char snapname[MAXNAMELEN];

--- a/lib/libzpool/zrepl_mgmt.c
+++ b/lib/libzpool/zrepl_mgmt.c
@@ -658,6 +658,9 @@ uzfs_zinfo_destroy_stale_clone(zvol_info_t *zinfo)
 			uzfs_close_dataset(l_snap_zv);
 			return (ret);
 		}
+	} else {
+		uzfs_close_dataset(l_snap_zv);
+		return (ret);
 	}
 
 	if (!uzfs_zvol_destroy_snapshot_clone(zv, l_snap_zv, l_clone_zv))

--- a/lib/libzpool/zrepl_mgmt.c
+++ b/lib/libzpool/zrepl_mgmt.c
@@ -545,10 +545,10 @@ uzfs_zvol_destroy_snapshot_clone(zvol_state_t *zv, zvol_state_t *snap_zv,
 	    clone_zv->zv_name, clonename, zv->zv_name);
 
 	/* Destroy clone's snapshot */
-	ret = uzfs_destroy_internal_all_snap(clone_zv);
+	ret = uzfs_destroy_all_internal_snapshots(clone_zv);
 	if (ret != 0) {
 		LOG_ERR("Rebuild_clone snap destroy failed on:%s"
-		    " with err:%d", clone_zv->zv_name, ret);
+		    " with err:%d", zv->zv_name, ret);
 	}
 
 	uzfs_zvol_release_internal_clone(zv, snap_zv, clone_zv);
@@ -605,5 +605,51 @@ uzfs_zinfo_destroy_internal_clone(zvol_info_t *zinfo)
 
 	ret = uzfs_zvol_destroy_snapshot_clone(zinfo->main_zv, snap_zv,
 	    clone_zv);
+	return (ret);
+}
+
+/*
+ * This API is used to delete stale
+ * cloned volume and backing snapshot.
+ */
+int
+uzfs_zinfo_destroy_stale_clone(zvol_info_t *zinfo)
+{
+	int ret = 0;
+	char *clone_subname = NULL;
+	zvol_state_t *l_snap_zv = NULL, *l_clone_zv = NULL;
+	zvol_state_t *zv;
+
+	if (!zinfo->main_zv)
+		return (0);
+
+	zv = zinfo->main_zv;
+
+	ret = get_snapshot_zv(zv, REBUILD_SNAPSHOT_SNAPNAME,
+	    &l_snap_zv, B_FALSE, B_TRUE);
+	if (ret != 0) {
+		LOG_ERR("Failed to get info about %s@%s",
+		    zv->zv_name, REBUILD_SNAPSHOT_SNAPNAME);
+		return (ret);
+	}
+
+	clone_subname = kmem_asprintf("%s_%s", strchr(zv->zv_name, '/') + 1,
+	    REBUILD_SNAPSHOT_CLONENAME);
+
+	ret = uzfs_open_dataset(zv->zv_spa, clone_subname, &l_clone_zv);
+	if (ret == 0) {
+		ret = uzfs_hold_dataset(l_clone_zv);
+		if (ret != 0) {
+			LOG_ERR("Failed to hold clone: %d", ret);
+			uzfs_close_dataset(l_clone_zv);
+			l_clone_zv = NULL;
+		}
+	}
+
+	if (!uzfs_zvol_destroy_snapshot_clone(zv, l_snap_zv, l_clone_zv))
+		zv->rebuild_info.stale_clone_exist = 0;
+
+	strfree(clone_subname);
+
 	return (ret);
 }

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -904,6 +904,8 @@ exit:
 			mutex_enter(&zinfo->main_zv->rebuild_mtx);
 			zinfo->main_zv->rebuild_info.stale_clone_exist++;
 			mutex_exit(&zinfo->main_zv->rebuild_mtx);
+		} else {
+			zinfo->main_zv->rebuild_info.stale_clone_exist = 0;
 		}
 	}
 

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -1410,7 +1410,6 @@ uzfs_zvol_rebuild_scanner(void *arg)
 	uint64_t	checkpointed_io_seq = 0;
 	uint64_t	payload_size = 0;
 	char		*snap_name;
-	boolean_t	afs_rebuild;
 
 	if ((rc = setsockopt(fd, SOL_SOCKET, SO_LINGER, &lo, sizeof (lo)))
 	    != 0) {
@@ -1474,9 +1473,6 @@ read_socket:
 
 			LOG_INFO("Rebuild scanner started on zvol %s from "
 			    "sock(%d)", name, fd);
-
-			if (ZVOL_IS_REBUILDING_AFS(zinfo->main_zv))
-				afs_rebuild = B_TRUE;
 
 			uzfs_zvol_append_to_fd_list(zinfo, fd);
 			zinfo->rebuild_cmd_queued_cnt =
@@ -1647,15 +1643,6 @@ exit:
 		uzfs_zvol_remove_from_fd_list(zinfo, fd);
 
 		uzfs_zinfo_drop_refcnt(zinfo);
-
-		/*
-		 * Increment stale_clone_exist with 1
-		 */
-		if (afs_rebuild) {
-			mutex_enter(&zinfo->main_zv->rebuild_mtx);
-			zinfo->main_zv->rebuild_info.stale_clone_exist++;
-			mutex_exit(&zinfo->main_zv->rebuild_mtx);
-		}
 	} else {
 		LOG_INFO("Closing rebuild connection on sock(%d)", fd);
 	}

--- a/tests/cbtest/gtest/test_uzfs.cc
+++ b/tests/cbtest/gtest/test_uzfs.cc
@@ -2118,7 +2118,9 @@ TEST(uZFSRebuild, TestRebuildSnapDeletion) {
 
 	rebuild_scanner = &uzfs_zvol_rebuild_scanner;
         zinfo->main_zv->zv_status = ZVOL_STATUS_DEGRADED;
+#ifdef	DEBUG
 	inject_error.delay.rebuild_complete = 1;
+#endif
 	do_data_connection(data_conn_fd1, "127.0.0.1", IO_SERVER_PORT, "vol1");
         execute_rebuild_test_case("complete rebuild with data conn", 15,
             ZVOL_REBUILDING_SNAP, ZVOL_REBUILDING_DONE, 4, "vol3");

--- a/tests/cbtest/gtest/test_uzfs.cc
+++ b/tests/cbtest/gtest/test_uzfs.cc
@@ -2126,7 +2126,9 @@ TEST(uZFSRebuild, TestRebuildSnapDeletion) {
             ZVOL_REBUILDING_SNAP, ZVOL_REBUILDING_DONE, 4, "vol3");
 
 	sleep(12);
+#ifdef	DEBUG
 	inject_error.delay.rebuild_complete = 0;
+#endif
 
 	EXPECT_EQ(0, dsl_prop_get_integer(zinfo->main_zv->zv_name,
 	    zfs_prop_to_name(ZFS_PROP_QUORUM), &quorum, NULL));

--- a/tests/cbtest/gtest/test_uzfs.cc
+++ b/tests/cbtest/gtest/test_uzfs.cc
@@ -2059,6 +2059,83 @@ void verify_ios_from_two_replica(void *arg)
 	zk_thread_exit();
 }
 
+static int
+check_if_snap_exist(zvol_state_t *zv, char *snap)
+{
+	int ret;
+	char snapname[MAXNAMELEN];
+	objset_t *os;
+	uint64_t obj = 0, cookie = 0;
+
+	if (!zv || !zv->zv_objset)
+		return (-1);
+
+	os = zv->zv_objset;
+	while (1) {
+		dsl_pool_config_enter(spa_get_dsl(zv->zv_spa), FTAG);
+		ret = dmu_snapshot_list_next(os, sizeof (snapname) - 1,
+		    snapname, &obj, &cookie, NULL);
+		dsl_pool_config_exit(spa_get_dsl(zv->zv_spa), FTAG);
+
+		if (ret) {
+			if (ret == ENOENT)
+				ret = 0;
+			break;
+		}
+		if (strcmp(snapname, snap) == 0) {
+			ret = 1;
+			break;
+		}
+	}
+
+	return (ret);
+}
+
+TEST(uZFSRebuild, TestRebuildSnapDeletion) {
+	int data_conn_fd1, data_conn_fd3;
+	rebuild_scanner = &uzfs_mock_rebuild_scanner_abrupt_conn_close;
+	dw_replica_fn = &uzfs_zvol_rebuild_dw_replica;
+	io_receiver = &uzfs_zvol_io_receiver;
+
+	zinfo->main_zv->zv_status = ZVOL_STATUS_DEGRADED;
+	zvol_rebuild_step_size = (1024ULL * 1024ULL * 1024ULL) / 2 + 1000;
+	do_data_connection(data_conn_fd1, "127.0.0.1", IO_SERVER_PORT, "vol1");
+	do_data_connection(data_conn_fd3, "127.0.0.1", IO_SERVER_PORT, "vol3");
+
+	uint64_t quorum = -1;
+	EXPECT_EQ(0, dsl_prop_get_integer(zinfo->main_zv->zv_name,
+	    zfs_prop_to_name(ZFS_PROP_QUORUM), &quorum, NULL));
+	EXPECT_EQ(quorum, 0);
+
+	/* thread that helps rebuilding exits abruptly just after connects */
+	execute_rebuild_test_case("rebuild abrupt", 1, ZVOL_REBUILDING_SNAP,
+	    ZVOL_REBUILDING_FAILED, 4, "vol3");
+        close(data_conn_fd1);
+
+	EXPECT_EQ(NULL, !zinfo->clone_zv);
+	EXPECT_EQ(0, dmu_objset_snapshot_one(zinfo->clone_zv->zv_name, ".io_snap100.2"));
+	EXPECT_EQ(0, dmu_objset_snapshot_one(zinfo->clone_zv->zv_name, ".io_snap100.1"));
+
+	rebuild_scanner = &uzfs_zvol_rebuild_scanner;
+        zinfo->main_zv->zv_status = ZVOL_STATUS_DEGRADED;
+	inject_error.delay.rebuild_complete = 1;
+	do_data_connection(data_conn_fd1, "127.0.0.1", IO_SERVER_PORT, "vol1");
+        execute_rebuild_test_case("complete rebuild with data conn", 15,
+            ZVOL_REBUILDING_SNAP, ZVOL_REBUILDING_DONE, 4, "vol3");
+
+	sleep(12);
+	inject_error.delay.rebuild_complete = 0;
+
+	EXPECT_EQ(0, dsl_prop_get_integer(zinfo->main_zv->zv_name,
+	    zfs_prop_to_name(ZFS_PROP_QUORUM), &quorum, NULL));
+	EXPECT_EQ(quorum, 1);
+
+	EXPECT_EQ(0, check_if_snap_exist(zinfo->main_zv, (char *)REBUILD_SNAPSHOT_SNAPNAME));
+	close(data_conn_fd1);
+	close(data_conn_fd3);
+	sleep(10);
+}
+
 TEST(uZFSRebuild, TestErroredRebuild) {
 	replica_writes_io_t wargs = { 0 };
 	kthread_t *writer_thread, *reader_thread;
@@ -2087,11 +2164,6 @@ TEST(uZFSRebuild, TestErroredRebuild) {
 #ifdef DEBUG
 	inject_error.inject_rebuild_error.dw_replica_rebuild_error_io = (total_ios) / 4;
 #endif
-	uint64_t quorum = -1;
-	EXPECT_EQ(0, dsl_prop_get_integer(zinfo->main_zv->zv_name,
-	    zfs_prop_to_name(ZFS_PROP_QUORUM), &quorum, NULL));
-	EXPECT_EQ(quorum, 0);
-
 	execute_rebuild_test_case("errored rebuild with data conn", 15,
 	    ZVOL_REBUILDING_SNAP, ZVOL_REBUILDING_FAILED, 4, "vol3");
 	close(wargs.r1_fd);
@@ -2130,6 +2202,7 @@ TEST(uZFSRebuild, TestErroredRebuild) {
 	    0, 0);
 	zk_thread_join(writer_thread->t_tid);
 
+	uint64_t quorum = 0;
 	EXPECT_EQ(0, dsl_prop_get_integer(zinfo->main_zv->zv_name,
 	    zfs_prop_to_name(ZFS_PROP_QUORUM), &quorum, NULL));
 	EXPECT_EQ(quorum, 1);


### PR DESCRIPTION
Changes:
1. Unit-test to verify deletion of rebuild_snap once dataset becomes healthy.

2. Handling of rebuild_snap deletion in `timer_thread`.
    - To track the stale clone during runtime, I have introduced a new variable `stale_clone_exist` in `zvol_rebuild_info_t`. `stale_clone_exist` is protected by `rebuild_mtx` of `zvol_state_t`.

    - Once `uzfs_zvol_rebuild_scanner` completes the rebuilding process fully, it will try to delete the stale clone. If this deletion fails then it will set `stale_clone_exist` to 1.

   - `timer_thread` will periodically check for the stale clone (if `zv->rebuild_info.stale_clone_exists` != 0). If stale clone found on any dataset then `timer_thread` will try to delete the `rebuild_clone` and `rebuild_snap`. Upon successful removal of `rebuild_clone` and `rebuild_snap`, `timer_thread` will update  `stale_clone_exist` variable with value 0.

Signed-off-by: mayank <mayank.patel@cloudbyte.com>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
