### PR TITLE
cherrypick(v0.8.x): Deletion of stale clone dataset 

### DIFF
--- a/include/sys/uzfs_zvol.h
+++ b/include/sys/uzfs_zvol.h
@@ -59,6 +59,14 @@ typedef struct zvol_rebuild_info {
 
 	/* peer replica cnt whose rebuild is done and failure */
 	uint16_t rebuild_failed_cnt;
+
+	/*
+	 * does stale clone exist?
+	 * If stale_clone_exist set to non-zero then timer thread will delete
+	 * the clone and related_snapshot.
+	 * rebuilding thread will set stale_clone_exist to 1.
+	 */
+	uint8_t	stale_clone_exist;
 } zvol_rebuild_info_t;
 
 /*
@@ -112,6 +120,9 @@ typedef struct zvol_state zvol_state_t;
 	(zv->rebuild_info.zv_rebuild_status == ZVOL_REBUILDING_ERRORED)
 #define	ZVOL_IS_REBUILDING_FAILED(zv)	\
 	(zv->rebuild_info.zv_rebuild_status == ZVOL_REBUILDING_FAILED)
+
+#define	ZVOL_HAS_STALE_CLONE(zv)	\
+	(zv->rebuild_info.stale_clone_exist)
 
 extern int zvol_get_data(void *arg, lr_write_t *lr, char *buf, zio_t *zio);
 const char *rebuild_status_to_str(zvol_rebuild_status_t status);

--- a/include/uzfs_rebuilding.h
+++ b/include/uzfs_rebuilding.h
@@ -64,7 +64,7 @@ int uzfs_zvol_release_internal_clone(zvol_state_t *zv,
 /*
  * To remove all internal snapshots of a dataset
  */
-int uzfs_destroy_internal_all_snap(zvol_state_t *zv);
+int uzfs_destroy_all_internal_snapshots(zvol_state_t *zv);
 boolean_t is_stale_clone(zvol_state_t *);
 
 #ifdef __cplusplus

--- a/include/uzfs_rebuilding.h
+++ b/include/uzfs_rebuilding.h
@@ -61,6 +61,10 @@ int uzfs_zvol_get_or_create_internal_clone(zvol_state_t *zv,
 int uzfs_zvol_release_internal_clone(zvol_state_t *zv,
     zvol_state_t *snap_zv, zvol_state_t *clone_zv);
 
+/*
+ * To remove all internal snapshots of a dataset
+ */
+int uzfs_destroy_internal_all_snap(zvol_state_t *zv);
 boolean_t is_stale_clone(zvol_state_t *);
 
 #ifdef __cplusplus

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -75,6 +75,7 @@ typedef struct inject_delay_s {
 	int downgraded_replica_rebuild_size_set;
 	int io_receiver_exit;
 	int helping_replica_rebuild_complete;
+	int rebuild_complete;
 } inject_delay_t;
 
 typedef struct inject_rebuild_error_s {
@@ -275,6 +276,11 @@ uzfs_zinfo_take_refcnt(zvol_info_t *zinfo)
 {
 	atomic_inc_64(&zinfo->refcnt);
 }
+
+/*
+ * To remove the internal stale clone
+ */
+int uzfs_zinfo_destroy_stale_clone(zvol_info_t *zinfo);
 
 /*
  * ZAP key for io sequence number

--- a/lib/libzpool/uzfs_rebuilding.c
+++ b/lib/libzpool/uzfs_rebuilding.c
@@ -399,7 +399,7 @@ again:
  * on a dataset
  */
 int
-uzfs_destroy_internal_all_snap(zvol_state_t *zv)
+uzfs_destroy_all_internal_snapshots(zvol_state_t *zv)
 {
 	int ret;
 	char snapname[MAXNAMELEN];

--- a/lib/libzpool/zrepl_mgmt.c
+++ b/lib/libzpool/zrepl_mgmt.c
@@ -654,12 +654,14 @@ uzfs_zinfo_destroy_stale_clone(zvol_info_t *zinfo)
 		ret = uzfs_hold_dataset(l_clone_zv);
 		if (ret != 0) {
 			LOG_ERR("Failed to hold clone: %d", ret);
+			strfree(clone_subname);
 			uzfs_close_dataset(l_clone_zv);
 			uzfs_close_dataset(l_snap_zv);
 			return (ret);
 		}
 	} else {
 		uzfs_close_dataset(l_snap_zv);
+		strfree(clone_subname);
 		return (ret);
 	}
 

--- a/lib/libzpool/zrepl_mgmt.c
+++ b/lib/libzpool/zrepl_mgmt.c
@@ -544,6 +544,13 @@ uzfs_zvol_destroy_snapshot_clone(zvol_state_t *zv, zvol_state_t *snap_zv,
 	LOG_INFO("Destroying %s and %s(%s) on:%s", snap_zv->zv_name,
 	    clone_zv->zv_name, clonename, zv->zv_name);
 
+	/* Destroy clone's snapshot */
+	ret = uzfs_destroy_internal_all_snap(clone_zv);
+	if (ret != 0) {
+		LOG_ERR("Rebuild_clone snap destroy failed on:%s"
+		    " with err:%d", clone_zv->zv_name, ret);
+	}
+
 	uzfs_zvol_release_internal_clone(zv, snap_zv, clone_zv);
 
 // try_clone_delete_again:

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -893,12 +893,23 @@ exit:
 		close(sfd);
 	}
 
-	if (wquiesce)
-		uzfs_zinfo_destroy_internal_clone(zinfo);
+#ifdef	DEBUG
+	if (inject_error.delay.rebuild_complete == 1)
+		sleep(10);
+#endif
+
+	if (wquiesce) {
+		if (uzfs_zinfo_destroy_internal_clone(zinfo)) {
+			mutex_enter(&zinfo->main_zv->rebuild_mtx);
+			zinfo->main_zv->rebuild_info.stale_clone_exist++;
+			mutex_exit(&zinfo->main_zv->rebuild_mtx);
+		} else {
+			zinfo->main_zv->rebuild_info.stale_clone_exist = 0;
+		}
+	}
 
 	/* Parent thread have taken refcount, drop it now */
 	uzfs_zinfo_drop_refcnt(zinfo);
-
 	zk_thread_exit();
 }
 
@@ -962,6 +973,10 @@ uzfs_zvol_timer_thread(void)
 					next_check = now +
 					    zinfo->update_ionum_interval;
 				}
+
+				if (ZVOL_HAS_STALE_CLONE(zinfo->main_zv)) {
+					uzfs_zinfo_destroy_stale_clone(zinfo);
+				}
 			} else if (uzfs_zvol_get_status(zinfo->main_zv) ==
 			    ZVOL_STATUS_DEGRADED &&
 			    zinfo->main_zv->zv_objset) {
@@ -1013,6 +1028,7 @@ uzfs_zvol_timer_thread(void)
 		    node_next);
 		kmem_free(n_zinfo, sizeof (*n_zinfo));
 	}
+	zk_thread_exit();
 }
 
 /*
@@ -1514,7 +1530,6 @@ read_socket:
 				}
 				if (ZINFO_IS_DEGRADED(zinfo))
 					zv = zinfo->clone_zv;
-
 				rc = uzfs_zvol_create_internal_snapshot(zv,
 				    &snap_zv, metadata.io_num);
 				if (rc != 0) {
@@ -1651,6 +1666,7 @@ reinitialize_zv_state(zvol_state_t *zv)
 
 	uzfs_zvol_set_status(zv, ZVOL_STATUS_DEGRADED);
 	uzfs_zvol_set_rebuild_status(zv, ZVOL_REBUILDING_INIT);
+	zv->rebuild_info.stale_clone_exist = 0;
 }
 
 /*

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -372,9 +372,9 @@ uzfs_ioc_stats(zfs_cmd_t *zc, nvlist_t *nvl)
 			    zv->main_zv->rebuild_info.zv_rebuild_status));
 
 			fnvlist_add_uint64(innvl, "isIOAckSenderCreated",
-			    zv->is_io_ack_sender_created);
+			    (zv->is_io_ack_sender_created) ? 1 : 0);
 			fnvlist_add_uint64(innvl, "isIOReceiverCreated",
-			    zv->is_io_receiver_created);
+			    (zv->is_io_receiver_created) ? 1 : 0);
 			fnvlist_add_uint64(innvl, "runningIONum",
 			    zv->running_ionum);
 			fnvlist_add_uint64(innvl, "checkpointedIONum",


### PR DESCRIPTION
Cherry-picking following commits from `zfs-0.7-release` branch:
1. commit 20bb7e32a2c4a0c32bf03eba1f401d4934293c02
Author: Mayank <33252549+mynktl@users.noreply.github.com>
Date:   Tue Feb 19 13:48:30 2019 +0530

    fix(memleak): freeing string in error case in uzfs_zinfo_destroy_stale_clone (#201)
    
    Signed-off-by: mayank <mayank.patel@cloudbyte.com>

2. commit 10610ef4bab4205e94efd9ddfc6e01548b272625
Author: Mayank <33252549+mynktl@users.noreply.github.com>
Date:   Tue Feb 19 11:11:57 2019 +0530

    [TC57] fix(stale clone): delete stale volume in timer fn and its test cases (#200)
    
    Signed-off-by: mayank <mayank.patel@cloudbyte.com>

3. commit c5ee05b13d24c4d6d88c99dc1a5a6a08f7352bb4
Author: Mayank <33252549+mynktl@users.noreply.github.com>
Date:   Thu Feb 14 13:54:27 2019 +0530

    [DE249]fix(zrepl): destroying all internal snapshots of rebuild clone dataset once rebuild completes (#199)
        
    Signed-off-by: mayank <mayank.patel@cloudbyte.com>
