### PR TITLE
fix(zfs): show pool stats if pool name provided

### DIFF
--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -463,11 +463,14 @@ uzfs_ioc_stats(zfs_cmd_t *zc, nvlist_t *nvl)
 	}
 	(void) mutex_exit(&zvol_list_mutex);
 
-	if (zc->zc_name[0] == '\0') {
+	if (zc->zc_name[0] != '\0') {
 		spa_t *spa = NULL;
 		nvlist_t *tnvl = fnvlist_alloc();
 		mutex_enter(&spa_namespace_lock);
 		while ((spa = spa_next(spa)) != NULL) {
+			if (strcmp(spa->spa_name, zc->zc_name) != 0) {
+				continue;
+			}
 			nvlist_t *pnvl = fnvlist_alloc();
 
 			nvlist_t *innvl = fnvlist_alloc();


### PR DESCRIPTION
Stats command will display pool stats if pool name is provided
e.g. `zfs stats <poolname>`
```
{"stats":[{"pool":{"pool3":{"rzio":{"32KB":"49152\/6","128KB":"917504\/8"},"wzio":{"32KB":"240640\/97","128KB":"1835008\/16","160KB":"1048576\/8"}}}}]}
```

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
