### PR TITLE
feat(tunings): zvol_workers as option for zfs create (#204)

### DIFF
--- a/include/sys/uzfs_zvol.h
+++ b/include/sys/uzfs_zvol.h
@@ -95,6 +95,7 @@ struct zvol_state {
 	zvol_status_t zv_status;		/* zvol status */
 	kmutex_t rebuild_mtx;
 	zvol_rebuild_info_t rebuild_info;
+	uint8_t zvol_workers;			/* zvol workers count */
 };
 
 #define	ZVOL_VOLUME_SIZE(zv)	(zv->zv_volsize)

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -40,6 +40,7 @@ extern "C" {
 #define	uZFS_ZVOL_WORKERS_MAX 128
 #define	uZFS_ZVOL_WORKERS_DEFAULT 6
 #define	ZFS_PROP_TARGET_IP	"io.openebs:targetip"
+#define	ZFS_PROP_ZVOL_WORKERS	"io.openebs:zvol_workers"
 
 #define	REBUILD_IO_SERVER_PORT	3233
 #define	IO_SERVER_PORT	3232
@@ -239,7 +240,7 @@ typedef struct zvol_rebuild_s {
 	int		fd;
 } zvol_rebuild_t;
 
-extern int uzfs_zinfo_init(void *zv, const char *ds_name,
+extern int uzfs_zinfo_init(zvol_state_t *zv, const char *ds_name,
     nvlist_t *create_props);
 extern zvol_info_t *uzfs_zinfo_lookup(const char *name);
 extern void uzfs_zinfo_replay_zil_all(void);

--- a/lib/libzpool/zrepl_mgmt.c
+++ b/lib/libzpool/zrepl_mgmt.c
@@ -370,7 +370,7 @@ end:
 }
 
 int
-uzfs_zinfo_init(void *zv, const char *ds_name, nvlist_t *create_props)
+uzfs_zinfo_init(zvol_state_t *zv, const char *ds_name, nvlist_t *create_props)
 {
 	zvol_info_t	*zinfo;
 
@@ -387,8 +387,11 @@ uzfs_zinfo_init(void *zv, const char *ds_name, nvlist_t *create_props)
 		LOG_INFO("env UZFS_WORKER = %d", nthread);
 	}
 
-	int nworker = MAX(boot_ncpus, nthread);
+	int nworker = zv->zvol_workers;
+	if (nworker == 0)
+		nworker = MAX(boot_ncpus, nthread);
 
+	zv->zvol_workers = nworker;
 	zinfo->uzfs_zvol_taskq = taskq_create("replica", nworker,
 	    defclsyspri, nworker, INT_MAX,
 	    TASKQ_PREPOPULATE | TASKQ_DYNAMIC);

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -390,6 +390,8 @@ uzfs_ioc_stats(zfs_cmd_t *zc, nvlist_t *nvl)
 			    zv->degraded_checkpointed_ionum);
 			fnvlist_add_uint64(innvl, "checkpointedTime",
 			    zv->checkpointed_time);
+			fnvlist_add_uint64(innvl, "zvol_workers",
+			    zv->main_zv->zvol_workers);
 
 			fnvlist_add_uint64(innvl, "rebuildBytes",
 			    zv->main_zv->rebuild_info.rebuild_bytes);

--- a/tests/cbtest/script/test_uzfs.sh
+++ b/tests/cbtest/script/test_uzfs.sh
@@ -206,7 +206,7 @@ run_zvol_tests()
 	log_must datasetexists $src_pool/$src_vol
 	log_must check_prop $src_pool/$src_vol type volume
 
-	log_must $ZFS create -V $VOLSIZE -o io.openebs:targetip=127.0.0.1:6060 $src_pool/$src_vol"_1"
+	log_must $ZFS create -V $VOLSIZE -o io.openebs:targetip=127.0.0.1:6060 -o io.openebs:zvol_workers=19 $src_pool/$src_vol"_1"
 
 	# test volume properties
 	log_must $ZFS get all $src_pool/$src_vol > /dev/null
@@ -231,6 +231,8 @@ run_zvol_tests()
 	log_must check_prop "$src_pool/$src_vol" sync always
 
 	log_must check_prop "$src_pool/$src_vol""_1" io.openebs:targetip 127.0.0.1:6060
+
+	log_must check_stats "$src_pool/$src_vol""_1" zvol_workers 19
 
 	# dump some data
 	#log_must dump_data
@@ -530,6 +532,13 @@ check_history()
 	    | grep -i "$match" > /dev/null 2>&1
 
 	return $?
+}
+
+check_stats()
+{
+	type=$($ZFS stats | jq .stats[0].$2)
+	test $type = "$3" && return 0
+	return 1
 }
 
 check_prop()


### PR DESCRIPTION
This PR adds io.openebs:zvol_workers option to zfs create command. This option lets user to determine the number of threads that executes client IOs.

Modified command looks like:
$ZFS create -s -V 1G pool1/vol1 -o io.openebs:targetip=127.0.0.1:6060 -o io.openebs:zvol_workers=20

Signed-off-by: Vitta <vitta@mayadata.io>

cherry-pick #204 