### PR TITLE
fix(zfs): create zinfo after setting the volume properties

### DIFF
--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -3401,9 +3401,6 @@ zfs_ioc_create(const char *fsname, nvlist_t *innvl, nvlist_t *outnvl)
 	    is_insensitive ? DS_FLAG_CI_DATASET : 0, cbfunc, &zct);
 	nvlist_free(zct.zct_zplprops);
 
-#if !defined(_KERNEL)
-	(void) uzfs_zvol_create_cb((char *)fsname, nvprops);
-#endif
 	/*
 	 * It would be nice to do this atomically.
 	 */
@@ -3430,6 +3427,9 @@ zfs_ioc_create(const char *fsname, nvlist_t *innvl, nvlist_t *outnvl)
 			}
 		}
 	}
+#if !defined(_KERNEL)
+	(void) uzfs_zvol_create_cb((char *)fsname, nvprops);
+#endif
 	return (error);
 }
 


### PR DESCRIPTION
For every volume creation command 'zfs create', zinfo will be created, and, it triggers management connection with target. During handshake in management connection, zrepl sends quorum property.
Quorum property is set after creating zinfo.
If there is race between handshake command and setting quorum property, zrepl may send default quorum property which is 'false' and can cause issues.
This PR is to avoid the race by creating zinfo after setting quorum property.

**Test:** 
        Tested by provisioning n(~300) volumes at a time all the volumes are in healthy state.

**Bug fix:** https://github.com/openebs/openebs/issues/2434

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
