### PR TITLE
fix(chore):remove dependency on hardcoded repo name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ jobs:
             sudo make -j4
             sudo cp *.a /usr/lib
             popd
+            pushd .
             cd ..
             git clone https://github.com/axboe/fio
             cd fio
@@ -46,7 +47,7 @@ jobs:
             sh autogen.sh
             ./configure
             make -j4;
-            cd ../zfs
+            popd
             sh autogen.sh
             ./configure --with-config=user --enable-code-coverage=yes --enable-debug --enable-uzfs=yes --with-jemalloc --with-fio=$PWD/../fio
             make -j4;
@@ -74,6 +75,7 @@ jobs:
             sudo apt-get install gdb
             sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-6 /usr/bin/gcc
             sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-6 /usr/bin/g++
+            pushd .
             cd ..
             git clone https://github.com/openebs/spl
             cd spl
@@ -82,7 +84,7 @@ jobs:
             ./configure
             make --no-print-directory -s pkg-utils pkg-kmod;
             sudo dpkg -i *.deb;
-            cd ../zfs
+            popd
             sh autogen.sh
             ./configure --enable-code-coverage=yes --enable-debug
             make --no-print-directory -s pkg-utils pkg-kmod

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,6 +32,8 @@ before_script:
   - sudo make -j4
   - sudo cp *.a /usr/lib
   - popd
+  - pushd .
+  - pushd .
   - cd ..
   # we need fio repo to build zfs replica fio engine
   - git clone https://github.com/axboe/fio
@@ -50,7 +52,7 @@ build-zfs-0:
    stage: build
    script: 
     - make -j4
-    - cd ../zfs
+    - popd
     - sh autogen.sh
     - echo $PWD
     - ./configure --with-config=user --enable-code-coverage=yes --enable-debug --enable-uzfs=yes --with-jemalloc --with-fio=$PWD/../fio
@@ -67,7 +69,7 @@ build-zfs-1:
    script: 
     - make --no-print-directory -s pkg-utils pkg-kmod
     - sudo dpkg -i *.deb
-    - cd ../zfs
+    - popd
     - echo $FIO_SRCDIR
     - sh autogen.sh
     - ./configure --enable-code-coverage=yes --enable-debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ install:
     - sudo make -j4
     - sudo cp *.a /usr/lib
     - popd
+    # save the current location to get back
+    - pushd .
     - cd ..
     # we need fio repo to build zfs replica fio engine
     - git clone https://github.com/axboe/fio
@@ -55,7 +57,8 @@ install:
         make --no-print-directory -s pkg-utils pkg-kmod;
         sudo dpkg -i *.deb;
       fi
-    - cd ../zfs
+    # return to cstor code 
+    - popd
     - sh autogen.sh
     - if [ $ZFS_BUILD_TAGS = 0 ]; then
         ./configure --with-config=user --enable-code-coverage=yes --enable-debug --enable-uzfs=yes --with-jemalloc --with-fio=$PWD/../fio || travis_terminate 1;


### PR DESCRIPTION
Renamed the repo from openebs/zfs to openebs/cstor.

Travis build failed with the following error:
$ cd ../zfs
/home/travis/.travis/functions: line 104: cd: ../zfs: No such file or directory
The command "cd ../zfs" failed and exited with 1 during .

In this PR removed the hard coded dependency in the build script
on the repo name.

Signed-off-by: kmova <kiran.mova@openebs.io>
(cherry picked from commit 8c89f34f54ed8dcdcaa8f83cb1c9974c13267c06)

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
