### PR TITLE
opt(replica_status): to Healthy for single replica with quorum on

### DIFF
--- a/include/zrepl_prot.h
+++ b/include/zrepl_prot.h
@@ -123,7 +123,6 @@ struct zvol_op_open_data {
 	uint32_t	timeout;	// replica timeout in seconds
 	char		volname[MAX_NAME_LEN];
 	uint8_t		replication_factor; // replicas config at target
-	uint8_t		is_IOs_not_happened; // true for vol with no IOs on it
 } __attribute__((packed));
 
 typedef struct zvol_op_open_data zvol_op_open_data_t;

--- a/include/zrepl_prot.h
+++ b/include/zrepl_prot.h
@@ -122,8 +122,8 @@ struct zvol_op_open_data {
 	uint32_t	tgt_block_size;	// used block size for rw in bytes
 	uint32_t	timeout;	// replica timeout in seconds
 	char		volname[MAX_NAME_LEN];
-	uint8_t		replication_factor;
-	uint64_t	io_seq;
+	uint8_t		replication_factor; // replicas config at target
+	uint8_t		is_IOs_not_happened; // true for vol with no IOs on it
 } __attribute__((packed));
 
 typedef struct zvol_op_open_data zvol_op_open_data_t;

--- a/include/zrepl_prot.h
+++ b/include/zrepl_prot.h
@@ -123,7 +123,6 @@ struct zvol_op_open_data {
 	uint32_t	timeout;	// replica timeout in seconds
 	char		volname[MAX_NAME_LEN];
 	uint8_t		replication_factor;
-	uint8_t 	padding[3];
 	uint64_t	io_seq;
 } __attribute__((packed));
 

--- a/include/zrepl_prot.h
+++ b/include/zrepl_prot.h
@@ -122,6 +122,10 @@ struct zvol_op_open_data {
 	uint32_t	tgt_block_size;	// used block size for rw in bytes
 	uint32_t	timeout;	// replica timeout in seconds
 	char		volname[MAX_NAME_LEN];
+	uint8_t		replication_factor;
+	uint8_t		consistency_factor;
+	uint8_t 	padding[2];
+	uint64_t	io_seq;
 } __attribute__((packed));
 
 typedef struct zvol_op_open_data zvol_op_open_data_t;

--- a/include/zrepl_prot.h
+++ b/include/zrepl_prot.h
@@ -45,7 +45,7 @@ extern "C" {
  * properly aligned (and packed).
  */
 
-#define	REPLICA_VERSION	3
+#define	REPLICA_VERSION	4
 #define	MAX_NAME_LEN	256
 #define	MAX_IP_LEN	64
 #define	TARGET_PORT	6060
@@ -123,8 +123,7 @@ struct zvol_op_open_data {
 	uint32_t	timeout;	// replica timeout in seconds
 	char		volname[MAX_NAME_LEN];
 	uint8_t		replication_factor;
-	uint8_t		consistency_factor;
-	uint8_t 	padding[2];
+	uint8_t 	padding[3];
 	uint64_t	io_seq;
 } __attribute__((packed));
 

--- a/lib/libzpool/uzfs_rebuilding.c
+++ b/lib/libzpool/uzfs_rebuilding.c
@@ -281,6 +281,30 @@ is_stale_clone(zvol_state_t *zv)
 }
 
 /*
+ */
+int
+uzfs_zvol_get_internal_clone(zvol_state_t *zv, zvol_state_t **snap_zv,
+    zvol_state_t **clone_zv, int *error)
+{
+	int ret = 0;
+	char *snapname = NULL;
+	char *clonename = NULL;
+	char *clone_subname = NULL;
+	zvol_state_t *l_snap_zv = NULL, *l_clone_zv = NULL;
+
+again:
+	ret = get_snapshot_zv(zv, REBUILD_SNAPSHOT_SNAPNAME, &l_snap_zv,
+	    B_FALSE, B_TRUE);
+	if (ret == ENOENT) {
+		LOG_ERR("internal snapshot for %s doesn't exists",
+		    zv->zv_name);
+		*snap_zv = *clone_zv = NULL;
+		return (0);
+	}
+
+}
+
+/*
  * This API is used to create internal clone for rebuild.
  * It will load the clone dataset if clone already exist.
  * Cloned volume created through this API can not be exposed

--- a/lib/libzpool/uzfs_rebuilding.c
+++ b/lib/libzpool/uzfs_rebuilding.c
@@ -281,30 +281,6 @@ is_stale_clone(zvol_state_t *zv)
 }
 
 /*
- */
-int
-uzfs_zvol_get_internal_clone(zvol_state_t *zv, zvol_state_t **snap_zv,
-    zvol_state_t **clone_zv, int *error)
-{
-	int ret = 0;
-	char *snapname = NULL;
-	char *clonename = NULL;
-	char *clone_subname = NULL;
-	zvol_state_t *l_snap_zv = NULL, *l_clone_zv = NULL;
-
-again:
-	ret = get_snapshot_zv(zv, REBUILD_SNAPSHOT_SNAPNAME, &l_snap_zv,
-	    B_FALSE, B_TRUE);
-	if (ret == ENOENT) {
-		LOG_ERR("internal snapshot for %s doesn't exists",
-		    zv->zv_name);
-		*snap_zv = *clone_zv = NULL;
-		return (0);
-	}
-
-}
-
-/*
  * This API is used to create internal clone for rebuild.
  * It will load the clone dataset if clone already exist.
  * Cloned volume created through this API can not be exposed

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -1912,7 +1912,7 @@ exit:
  * else if replication_factor is 1, returns HEALTHY
  * else returns DEGRADED
  */
-static int
+static zvol_status_t
 find_apt_zvol_status(zvol_info_t *zinfo, zvol_op_open_data_t *open_data)
 {
 	uint8_t quorum = uzfs_zinfo_get_quorum(zinfo);

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -2051,8 +2051,9 @@ open_zvol(int fd, zvol_info_t **zinfopp)
 		if (zinfo->snapshot_zv == NULL) {
 			ASSERT3P(zinfo->clone_zv, ==, NULL);
 			/* Create clone for rebuild */
-			if (uzfs_zvol_get_or_create_internal_clone(zinfo->main_zv,
-			    &zinfo->snapshot_zv, &zinfo->clone_zv, NULL) != 0) {
+			if (uzfs_zvol_get_or_create_internal_clone(
+			    zinfo->main_zv, &zinfo->snapshot_zv,
+			    &zinfo->clone_zv, NULL) != 0) {
 				LOG_ERR("Failed to create clone for rebuild");
 				goto error_ret;
 			}

--- a/tests/cbtest/gtest/test_zrepl_prot.cc
+++ b/tests/cbtest/gtest/test_zrepl_prot.cc
@@ -291,7 +291,7 @@ static void get_zvol_status(std::string zvol_name, uint64_t &ioseq, int control_
 }
 
 static void transition_zvol_to_online(uint64_t &ioseq, int control_fd,
-    std::string zvol_name)
+    std::string zvol_name, int res = ZVOL_OP_STATUS_OK)
 {
 	zvol_io_hdr_t hdr_in, hdr_out = {0};
 	struct mgmt_ack mgmt_ack = {0};
@@ -318,7 +318,7 @@ static void transition_zvol_to_online(uint64_t &ioseq, int control_fd,
 	ASSERT_EQ(rc, sizeof (hdr_in));
 	EXPECT_EQ(hdr_in.opcode, ZVOL_OPCODE_START_REBUILD);
 	EXPECT_EQ(hdr_in.io_seq, ioseq);
-	EXPECT_EQ(hdr_in.status, ZVOL_OP_STATUS_OK);
+	EXPECT_EQ(hdr_in.status, res);
 	EXPECT_EQ(hdr_in.len, 0);
 }
 
@@ -1041,6 +1041,9 @@ TEST(ReplicaState, SingleReplicaQuorumOff) {
 
 	get_zvol_status(zvol_name1, ioseq1, control_fd1, ZVOL_STATUS_HEALTHY, ZVOL_REBUILDING_DONE);
 	get_zvol_status(zvol_name2, ioseq1, control_fd2, ZVOL_STATUS_DEGRADED, ZVOL_REBUILDING_INIT);
+
+	/* transition the zvol to online state */
+	transition_zvol_to_online(ioseq1, control_fd1, zvol_name1, ZVOL_OP_STATUS_FAILED);
 
 	zrepl.kill();
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
Fixes https://www.github.com/openebs/openebs/issues/2437

uzfs marks zinfo related to zvol as Degraded when the zvol is created or imported, and then, does the rebuilding of data from zvols (which might be in Healthy or Degraded state) available in other nodes.

This PR is to mark the state as Healthy for single replica case zvols.

Signed-off-by: Vitta vitta@mayadata.io