### PR TITLE
feat(upgrades): seamless during openebs upgrades

### DIFF
--- a/include/mgmt_conn.h
+++ b/include/mgmt_conn.h
@@ -68,7 +68,9 @@ typedef struct uzfs_mgmt_conn {
 	void		*conn_buf;	// buffer to hold network data
 	int		conn_bufsiz;    // bytes to read/write in total
 	int		conn_procn;	// bytes already read/written
-	zvol_io_hdr_t	*conn_hdr;	// header of currently processed cmd
+	void		*conn_hdr;	// header of currently processed cmd
+	int		conn_hdrsiz;    // conn_hdr alloted size
+	uint16_t	zvol_io_recv_vers;
 	time_t		conn_last_connect;  // time of last attempted connect()
 } uzfs_mgmt_conn_t;
 

--- a/include/mgmt_conn.h
+++ b/include/mgmt_conn.h
@@ -115,7 +115,7 @@ int uzfs_get_snap_zv_ionum(zvol_info_t *, uint64_t, zvol_state_t **);
 
 int uzfs_zvol_get_snap_dataset_with_io(zvol_info_t *zinfo,
     char *snapname, uint64_t *snapshot_io_num, zvol_state_t **snap_zv);
-
+int get_header_size(uint16_t vers);
 #ifdef __cplusplus
 }
 #endif

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -178,6 +178,7 @@ typedef struct zvol_info_s {
 	uint8_t		quiesce_requested;
 	uint8_t		quiesce_done;
 	int32_t		io_fd;
+	uint16_t	protocol_version; // version with which handshake done
 
 	/* Pointer to mgmt connection for this zinfo */
 	void		*mgmt_conn;

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -1925,6 +1925,12 @@ find_apt_zvol_status(zvol_info_t *zinfo, zvol_op_open_data_t *open_data)
 		return (ZVOL_STATUS_DEGRADED);
 	}
 
+	if (open_data->replication_factor != 1) {
+		LOG_INFO("Quorum is on, but, degraded mode with rep: %d",
+		    open_data->replication_factor);
+		return (ZVOL_STATUS_DEGRADED);
+	}
+
 	ret = get_snapshot_zv(zinfo->main_zv, REBUILD_SNAPSHOT_SNAPNAME,
 	    &l_snap_zv, B_TRUE, B_TRUE);
 	if (ret != ENOENT) {

--- a/lib/libzrepl/mgmt_conn.c
+++ b/lib/libzrepl/mgmt_conn.c
@@ -1658,6 +1658,7 @@ switch_zvol_mgmt_io_req(uzfs_mgmt_conn_t *conn)
 	}
 }
 
+#define	MIN_SUPPORTED_REPLICA_VERSION	3
 /*
  * Transition to the next state. This is called only if IO buffer was fully
  * read or written.
@@ -1699,7 +1700,8 @@ move_to_next_state(uzfs_mgmt_conn_t *conn)
 		conn->zvol_io_recv_vers = vers;
 		kmem_free(conn->conn_buf, sizeof (uint16_t));
 		conn->conn_buf = NULL;
-		if (vers > REPLICA_VERSION) {
+		if ((vers > REPLICA_VERSION) ||
+		    (vers < MIN_SUPPORTED_REPLICA_VERSION)) {
 			LOGERRCONN(conn, "Invalid replica protocol version %d",
 			    vers);
 			rc = reply_nodata(conn, ZVOL_OP_STATUS_VERSION_MISMATCH,

--- a/lib/libzrepl/mgmt_conn.c
+++ b/lib/libzrepl/mgmt_conn.c
@@ -1592,7 +1592,7 @@ process_message(uzfs_mgmt_conn_t *conn)
 /*
  * Returns -1 on invalid vers
  */
-static int
+int
 get_header_size(uint16_t vers)
 {
 	switch (vers) {
@@ -1623,11 +1623,14 @@ static int
 switch_zvol_mgmt_io_req_3_to_cur(uzfs_mgmt_conn_t *conn)
 {
 	zvol_io_hdr_t *hdrp = conn->conn_hdr;
-	zvol_op_open_data_t *buf;
 
+	hdrp->version = REPLICA_VERSION;
+#if 0
+	zvol_op_open_data_t *buf;
 	switch (hdrp->opcode) {
 		case ZVOL_OPCODE_OPEN:
-			buf = kmem_zalloc(sizeof (zvol_op_open_data_t), KM_SLEEP);
+			buf = kmem_zalloc(sizeof (zvol_op_open_data_t),
+			    KM_SLEEP);
 			memcpy(buf, conn->conn_buf, conn->conn_bufsiz);
 			buf->replication_factor = 0;
 			kmem_free(conn->conn_buf, conn->conn_bufsiz);
@@ -1637,6 +1640,8 @@ switch_zvol_mgmt_io_req_3_to_cur(uzfs_mgmt_conn_t *conn)
 			hdrp->version = REPLICA_VERSION;
 			return (0);
 	}
+#endif
+	return (0);
 }
 
 static int


### PR DESCRIPTION
During upgrades of openebs components, there are chances of volumes getting into read-only if there is change in protocol version between target and pools, and, if upgrades takes more than 120 seconds.

This PR is to make upgrades seamless even with change in protocol version between target and pools, by making zrepl to support older versions of targets connecting to it.

Signed-off-by: Vitta <vitta@mayadata.io>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->