### PR TITLE
Changes in error handling for `dmu_tx_assign` in uzfs_write_data.

### DIFF
--- a/lib/libzpool/uzfs_io.c
+++ b/lib/libzpool/uzfs_io.c
@@ -172,7 +172,7 @@ chunk_io:
 		error = dmu_tx_assign(tx, TXG_WAIT);
 		if (error) {
 			dmu_tx_abort(tx);
-			ret = UZFS_IO_TX_ASSIGN_FAIL;
+			ret = error;
 			goto exit_with_error;
 		}
 		dmu_write(os, ZVOL_OBJ, offset, bytes, buf + wrote, tx);


### PR DESCRIPTION
Changes:
Earlier if `dmu_tx_assign` fails then `uzfs_write_data` was returning
`UZFS_IO_TX_ASSIGN_FAIL` instead of error code from `dmu_tx_assign`.

Signed-off-by: mayank <mayank.patel@cloudbyte.com>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
