### PR TITLE
removing `zfs-images` submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "scripts/zfs-images"]
-	path = scripts/zfs-images
-	url = https://github.com/zfsonlinux/zfs-images


### PR DESCRIPTION
Changes:
- Removed un-used submodule `zfs-images`

Signed-off-by: mayank <mayank.patel@cloudbyte.com>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
