### PR TITLE
fix(rebuild_issue): scanner thread not exiting

### DIFF
--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -78,6 +78,7 @@ typedef struct inject_delay_s {
 	int io_receiver_exit;
 	int helping_replica_rebuild_complete;
 	int rebuild_complete;
+	int helping_replica_ack_sender;
 } inject_delay_t;
 
 typedef struct inject_rebuild_error_s {
@@ -202,7 +203,6 @@ typedef struct zvol_info_s {
 	uint64_t 	sync_latency;
 	uint64_t 	inflight_io_cnt; // ongoing IOs count
 	uint64_t	dispatched_io_cnt; // total received but incomplete IOs
-
 
 	// histogram of IOs
 	zfs_histogram_t uzfs_rio_histogram[ZFS_HISTOGRAM_IO_SIZE /

--- a/lib/libzpool/zrepl_mgmt.c
+++ b/lib/libzpool/zrepl_mgmt.c
@@ -398,6 +398,7 @@ uzfs_zinfo_init(zvol_state_t *zv, const char *ds_name, nvlist_t *create_props)
 
 	STAILQ_INIT(&zinfo->complete_queue);
 	STAILQ_INIT(&zinfo->fd_list);
+	STAILQ_INIT(&zinfo->rebuild_scanner_list);
 	uzfs_zinfo_init_mutex(zinfo);
 
 	strlcpy(zinfo->name, ds_name, MAXNAMELEN);

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -450,7 +450,7 @@ drop_refcount:
  */
 static void zvol_rebuild_scanner_inc_ack_cnt(zvol_info_t *zinfo, int fd)
 {
-	zvol_rebuild_scanner_info_t *sinfo = NULL;
+	zvol_rebuild_scanner_info_t *sinfo;
 
 	sinfo = STAILQ_FIRST(&zinfo->rebuild_scanner_list);
 	while (sinfo != NULL) {

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -466,7 +466,7 @@ static void zvol_rebuild_scanner_set_errored_fd(zvol_info_t *zinfo, int fd)
 	sinfo = STAILQ_FIRST(&zinfo->rebuild_scanner_list);
 	while (sinfo != NULL) {
 		if (sinfo->fd == fd) {
-			sinfo->is_fd_errored = B_TRUE;
+			sinfo->is_fd_errored = 1;
 			break;
 		}
 		sinfo = STAILQ_NEXT(sinfo, link);
@@ -1865,7 +1865,7 @@ uzfs_zvol_io_ack_sender(void *arg)
 		zinfo->zio_cmd_in_ack = zio_cmd;
 
 		if (zio_cmd->hdr.flags & ZVOL_OP_FLAG_REBUILD)
-			zvol_rebuild_scanner_inc_ack_cnt(zinfo, fd);
+			zvol_rebuild_scanner_inc_ack_cnt(zinfo, zio_cmd->conn);
 
 		(void) pthread_mutex_unlock(&zinfo->zinfo_mutex);
 

--- a/lib/libzrepl/mgmt_conn.c
+++ b/lib/libzrepl/mgmt_conn.c
@@ -599,8 +599,12 @@ uzfs_zvol_rebuild_status(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 	 */
 	if (uzfs_zvol_get_rebuild_status(zinfo->main_zv) ==
 	    ZVOL_REBUILDING_FAILED) {
+		uzfs_zvol_set_rebuild_status(zinfo->main_zv,
+		    ZVOL_REBUILDING_INIT);
 		memset(&zinfo->main_zv->rebuild_info, 0,
 		    sizeof (zvol_rebuild_info_t));
+
+		/* Initialize rebuild status to INIT */
 		uzfs_zvol_set_rebuild_status(zinfo->main_zv,
 		    ZVOL_REBUILDING_INIT);
 	}

--- a/lib/libzrepl/mgmt_conn.c
+++ b/lib/libzrepl/mgmt_conn.c
@@ -1126,8 +1126,6 @@ uzfs_zinfo_rebuild_start_threads(mgmt_ack_t *mack, zvol_info_t *zinfo,
 	rebuild_thread_arg_t	*thrd_arg;
 	kthread_t		*thrd_info;
 	for (; rebuild_op_cnt > 0; rebuild_op_cnt--, mack++) {
-		LOG_INFO("zvol %s at %s:%u helping in rebuild",
-		    mack->volname, mack->ip, mack->port);
 		if (uzfs_zvol_name_compare(zinfo, mack->dw_volname) != 0) {
 			LOG_ERR("zvol %s not matching with zinfo %s",
 			    mack->dw_volname, zinfo->name);
@@ -1164,6 +1162,8 @@ ret_error:
 			goto ret_error;
 		}
 
+		LOG_INFO("[%s:%d] at %s:%u helping in rebuild",
+		    mack->volname, io_sfd, mack->ip, mack->port);
 		uzfs_zinfo_take_refcnt(zinfo);
 
 		thrd_arg = kmem_alloc(sizeof (rebuild_thread_arg_t), KM_SLEEP);


### PR DESCRIPTION
Currently, when the rebuild connection is broken between 2 nodes, other dw_replica thread which is rebuilding from self clone exits. But, the scanner thread from clone still exists and stuck at scanner_callback() in usleep(). Reason being rebuild_cmd_queued_cnt < than rebuild_cmd_ack_cnt.
This happened as another rebuild is triggered from target and same set of variables (rebuild_cmd_queued_cnt and rebuild_cmd_ack_cnt) are used.

Fix is to have different counters per rebuild scanner rather than having these counters at per zvol. These counters kept at zvol on assumption that there won't be multiple rebuilds at a give time. But, there are scenarios where rebuild scanner can exist.

This PR also makes rebuild scanner thread to know if any error happens on socket write at ack_sender thread. Based on this, rebuild scanner exits at earliest.

Signed-off-by: Vitta <vitta@mayadata.io>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
