### PR TITLE
fix(stale_snaps): delete internal created snaps for helping in rebuil…

### DIFF
--- a/include/data_conn.h
+++ b/include/data_conn.h
@@ -79,8 +79,6 @@ int uzfs_zvol_create_internal_snapshot(zvol_state_t *zv, zvol_state_t **snap_zv,
 void signal_fds_related_to_zinfo(zvol_info_t *zinfo);
 void quiesce_wait(zvol_info_t *zinfo);
 
-int uzfs_zvol_create_internal_snapshot(zvol_state_t *zv, zvol_state_t **snap_zv,
-    uint64_t io_num);
 int uzfs_zvol_handle_rebuild_snap_done(zvol_io_hdr_t *, int, zvol_info_t *);
 
 #ifdef __cplusplus

--- a/include/uzfs_rebuilding.h
+++ b/include/uzfs_rebuilding.h
@@ -66,6 +66,8 @@ int uzfs_zvol_release_internal_clone(zvol_state_t *zv,
  */
 int uzfs_destroy_all_internal_snapshots(zvol_state_t *zv);
 boolean_t is_stale_clone(zvol_state_t *);
+int uzfs_destroy_all_iosnap_snapshots(zvol_state_t *zv);
+boolean_t is_stale_clone(zvol_state_t *);
 
 #ifdef __cplusplus
 }

--- a/lib/libzpool/uzfs_rebuilding.c
+++ b/lib/libzpool/uzfs_rebuilding.c
@@ -394,12 +394,36 @@ again:
 	return (ret);
 }
 
+typedef boolean_t (*uzfs_snapname_matching_func)(char *snapname);
+
 /*
- * To destroy all internal created snapshot
- * on a dataset
+ * Return true for snaps that are internal created
  */
-int
-uzfs_destroy_all_internal_snapshots(zvol_state_t *zv)
+boolean_t
+uzfs_match_internal_snapshots(char *snapname)
+{
+	if ((strcmp(snapname, REBUILD_SNAPSHOT_SNAPNAME) == 0) ||
+	    (strncmp(snapname, IO_DIFF_SNAPNAME,
+	    sizeof (IO_DIFF_SNAPNAME) - 1) == 0))
+		return (B_TRUE);
+	return (B_FALSE);
+}
+
+/*
+ * Return true for snaps that starts with .io_snap
+ */
+boolean_t
+uzfs_match_iosnap_snapshots(char *snapname)
+{
+	if (strncmp(snapname, IO_DIFF_SNAPNAME,
+	    sizeof (IO_DIFF_SNAPNAME) - 1) == 0)
+		return (B_TRUE);
+	return (B_FALSE);
+}
+
+static int
+uzfs_destroy_matching_snapshots(zvol_state_t *zv,
+    uzfs_snapname_matching_func matching_fn)
 {
 	int ret;
 	char snapname[MAXNAMELEN];
@@ -423,11 +447,9 @@ uzfs_destroy_all_internal_snapshots(zvol_state_t *zv)
 			break;
 		}
 
-		if (!(strcmp(snapname, REBUILD_SNAPSHOT_SNAPNAME) == 0) &&
-		    !(strncmp(snapname, IO_DIFF_SNAPNAME,
-		    sizeof (IO_DIFF_SNAPNAME) - 1) == 0)) {
+		/* skip destroying non-matching snaps */
+		if ((*matching_fn)(snapname) == B_FALSE)
 			continue;
-		}
 
 		ret = destroy_snapshot_zv(zv, snapname);
 		if (ret != 0) {
@@ -437,5 +459,27 @@ uzfs_destroy_all_internal_snapshots(zvol_state_t *zv)
 		}
 	}
 
+	return (ret);
+}
+
+/*
+ * To destroy all internal created snapshot
+ * on a dataset
+ */
+int
+uzfs_destroy_all_internal_snapshots(zvol_state_t *zv)
+{
+	int ret;
+	ret = uzfs_destroy_matching_snapshots(zv,
+	    uzfs_match_internal_snapshots);
+	return (ret);
+}
+
+int
+uzfs_destroy_all_iosnap_snapshots(zvol_state_t *zv)
+{
+	int ret;
+	ret = uzfs_destroy_matching_snapshots(zv,
+	    uzfs_match_iosnap_snapshots);
 	return (ret);
 }

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -1520,6 +1520,7 @@ uzfs_zvol_rebuild_scanner(void *arg)
 	uint64_t	payload_size = 0;
 	char		*snap_name;
 	zvol_rebuild_scanner_info_t	*warg = NULL;
+	char		*at_ptr = NULL;
 
 	if ((rc = setsockopt(fd, SOL_SOCKET, SO_LINGER, &lo, sizeof (lo)))
 	    != 0) {
@@ -1706,7 +1707,9 @@ read_socket:
 					    snap_zv->zv_name);
 					LOG_INFO("closing snap %s", snap_name);
 					uzfs_close_dataset(snap_zv);
-					VERIFY0(strncmp(snap_name,
+					at_ptr = strchr(snap_name, '@');
+					VERIFY3P(at_ptr, !=, NULL);
+					VERIFY0(strncmp(at_ptr + 1,
 					    IO_DIFF_SNAPNAME,
 					    sizeof (IO_DIFF_SNAPNAME) - 1));
 #if DEBUG
@@ -1744,7 +1747,9 @@ exit:
 			snap_name = kmem_asprintf("%s", snap_zv->zv_name);
 			LOG_INFO("closing snap on conn break %s", snap_name);
 			uzfs_close_dataset(snap_zv);
-			VERIFY0(strncmp(snap_name, IO_DIFF_SNAPNAME,
+			at_ptr = strchr(snap_name, '@');
+			VERIFY3P(at_ptr, !=, NULL);
+			VERIFY0(strncmp(at_ptr + 1, IO_DIFF_SNAPNAME,
 			    sizeof (IO_DIFF_SNAPNAME) - 1));
 #if DEBUG
 			if (inject_error.delay.helping_replica_rebuild_complete


### PR DESCRIPTION
…d during data connection

This PR is to delete the internally created snapshots with prefix '.io_snap' that are created to help in rebuilding volume on another node.
These stale snapshots exists if zrepl restarts when it is involved in rebuild process.

Added a testcase by creating snaps and verified that they are indeed deleted.

Signed-off-by: Vitta <vitta@mayadata.io>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
