### PR TITLE
[2502] feat(debug-tools): installing curl/tcpdump/nslookup/ping packages

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -8,9 +8,11 @@ FROM openebs/cstor-ubuntu:xenial-20181005
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \ 
     apt-get update && apt-get install -y \
+    curl tcpdump dnsutils iputils-ping \
     libaio1 libaio-dev \
     libkqueue-dev libssl1.0.0 rsyslog net-tools gdb apt-utils \
     sed libjemalloc-dev openssh-server
+RUN apt-get -y install apt-file && apt-file update
 
 COPY zfs/bin/* /usr/local/bin/
 COPY zfs/lib/* /usr/lib/


### PR DESCRIPTION
This PR fixes openebs/openebs#2502.
Installs curl/tcpdump/gdb/ping/nslookup as part of cstor-pool image

Signed-off-by: Vitta <vitta@mayadata.io>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
