### PR TITLE
feat(seamless_upgrades): make zfs compatible with version 3 and 4

### DIFF
--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -223,6 +223,7 @@ typedef struct zvol_rebuild_scanner_info_s {
 		uint32_t flags;
 	};
 	int		fd;
+	uint16_t	version;
 } zvol_rebuild_scanner_info_t;
 
 typedef struct thread_args_s {

--- a/include/zrepl_prot.h
+++ b/include/zrepl_prot.h
@@ -129,6 +129,15 @@ struct zvol_op_open_data {
 
 typedef struct zvol_op_open_data zvol_op_open_data_t;
 
+struct zvol_op_open_data_ver_3 {
+	uint32_t	tgt_block_size;	// used block size for rw in bytes
+	uint32_t	timeout;	// replica timeout in seconds
+	char		volname[MAX_NAME_LEN];
+} __attribute__((packed));
+
+typedef struct zvol_op_open_data_ver_3 zvol_op_open_data_ver_3_t;
+
+
 /*
  * Payload data send in response to handshake on control connection. It tells
  * IP, port where replica listens for data connection to zvol.

--- a/include/zrepl_prot.h
+++ b/include/zrepl_prot.h
@@ -45,6 +45,8 @@ extern "C" {
  * properly aligned (and packed).
  */
 
+#define	MIN_SUPPORTED_REPLICA_VERSION	3
+
 #define	REPLICA_VERSION	4
 #define	MAX_NAME_LEN	256
 #define	MAX_IP_LEN	64

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -2096,9 +2096,9 @@ get_open_opcode_data_len(zvol_io_hdr_t *hdr)
 {
 	switch (hdr->version) {
 		case 3:
-			return sizeof (zvol_op_open_data_ver_3_t);
+			return (sizeof (zvol_op_open_data_ver_3_t));
 		case 4:
-			return sizeof (zvol_op_open_data_t);
+			return (sizeof (zvol_op_open_data_t));
 		default:
 			return (-1);
 	}
@@ -2115,7 +2115,6 @@ fill_default_values_for_version_change(zvol_io_hdr_t *hdr,
 		default:
 			break;
 	}
-	return;
 }
 
 /*

--- a/lib/libzrepl/mgmt_conn.c
+++ b/lib/libzrepl/mgmt_conn.c
@@ -369,22 +369,23 @@ zinfo_destroy_cb(zvol_info_t *zinfo)
  */
 static int
 reply_nodata(uzfs_mgmt_conn_t *conn, zvol_op_status_t status,
-    int opcode, uint64_t io_seq)
+    zvol_io_hdr_t *in_hdr)
 {
 	zvol_io_hdr_t *hdrp;
 	struct epoll_event ev;
 
 	if (status != ZVOL_OP_STATUS_OK) {
 		LOGERRCONN(conn, "Error reply with status %d for OP %d",
-		    status, opcode);
+		    status, in_hdr->opcode);
 	} else {
-		DBGCONN(conn, "Reply without payload for OP %d", opcode);
+		DBGCONN(conn, "Reply without payload for OP %d",
+		    in_hdr->opcode);
 	}
 
 	hdrp = kmem_zalloc(sizeof (*hdrp), KM_SLEEP);
-	hdrp->version = conn->conn_hdr->version;
-	hdrp->opcode = opcode;
-	hdrp->io_seq = io_seq;
+	hdrp->version = in_hdr->version;
+	hdrp->opcode = in_hdr->opcode;
+	hdrp->io_seq = in_hdr->io_seq;
 	hdrp->status = status;
 	hdrp->len = 0;
 	ASSERT3P(conn->conn_buf, ==, NULL);
@@ -568,8 +569,7 @@ uzfs_zvol_mgmt_do_handshake(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 	zvol_io_hdr_t	hdr;
 	if (uzfs_zvol_mgmt_get_handshake_info(hdrp, name, zinfo, &hdr,
 	    &mgmt_ack) != 0)
-		return (reply_nodata(conn, ZVOL_OP_STATUS_FAILED, hdrp->opcode,
-		    hdrp->io_seq));
+		return (reply_nodata(conn, ZVOL_OP_STATUS_FAILED, hdrp));
 	return (reply_data(conn, &hdr, &mgmt_ack, sizeof (mgmt_ack)));
 }
 
@@ -839,8 +839,7 @@ finish_async_tasks(void)
 				    async_task->response_length);
 			} else
 				rc = reply_nodata(async_task->conn,
-				    async_task->status, async_task->hdr.opcode,
-				    async_task->hdr.io_seq);
+				    async_task->status, &async_task->hdr);
 		}
 		SLIST_REMOVE(&async_tasks, async_task, async_task, task_next);
 		free_async_task(async_task);
@@ -1191,10 +1190,8 @@ uzfs_zvol_rebuild_dw_replica_start(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 	int rc;
 	rc = uzfs_zinfo_rebuild_start_threads(mack, zinfo, rebuild_op_cnt);
 	if (rc != 0)
-		return (reply_nodata(conn, ZVOL_OP_STATUS_FAILED, hdrp->opcode,
-		    hdrp->io_seq));
-	return (reply_nodata(conn, ZVOL_OP_STATUS_OK, hdrp->opcode,
-	    hdrp->io_seq));
+		return (reply_nodata(conn, ZVOL_OP_STATUS_FAILED, hdrp));
+	return (reply_nodata(conn, ZVOL_OP_STATUS_OK, hdrp));
 }
 
 /*
@@ -1242,8 +1239,7 @@ handle_start_rebuild_req(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 	/* Invalid payload size */
 	if ((payload_size == 0) || (payload_size % sizeof (mgmt_ack_t)) != 0) {
 		LOG_ERR("rebuilding failed.. response is invalid");
-		rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED,
-		    hdrp->opcode, hdrp->io_seq);
+		rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED, hdrp);
 		goto end;
 	}
 
@@ -1258,8 +1254,7 @@ handle_start_rebuild_req(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 		}
 		else
 			LOG_ERR("rebuilding failed..");
-		rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED,
-		    hdrp->opcode, hdrp->io_seq);
+		rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED, hdrp);
 		goto end;
 	}
 
@@ -1271,8 +1266,7 @@ handle_start_rebuild_req(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 		LOG_ERR("rebuilding failed for %s due to improper zinfo "
 		    "status %d", zinfo->name, status);
 		uzfs_zinfo_drop_refcnt(zinfo);
-		rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED,
-		    hdrp->opcode, hdrp->io_seq);
+		rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED, hdrp);
 		goto end;
 	}
 
@@ -1283,8 +1277,7 @@ handle_start_rebuild_req(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 		LOG_ERR("rebuilding failed for %s due to improper rebuild "
 		    "status %d", zinfo->name, rstatus);
 		uzfs_zinfo_drop_refcnt(zinfo);
-		rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED,
-		    hdrp->opcode, hdrp->io_seq);
+		rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED, hdrp);
 		goto end;
 	}
 
@@ -1310,13 +1303,11 @@ handle_start_rebuild_req(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 		if (rc != 0) {
 			LOG_ERR("Rebuild from clone for vol %s "
 			    "failed", zinfo->name);
-			rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED,
-			    hdrp->opcode, hdrp->io_seq);
+			rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED, hdrp);
 		} else {
 			LOG_INFO("Rebuild started from clone for vol "
 			    "%s", zinfo->name);
-			rc = reply_nodata(conn, ZVOL_OP_STATUS_OK,
-			    hdrp->opcode, hdrp->io_seq);
+			rc = reply_nodata(conn, ZVOL_OP_STATUS_OK, hdrp);
 		}
 		uzfs_zinfo_drop_refcnt(zinfo);
 		goto end;
@@ -1339,8 +1330,7 @@ handle_start_rebuild_req(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 		    rebuild_op_cnt, zinfo->checkpointed_ionum,
 		    max_ioseq);
 		uzfs_zinfo_drop_refcnt(zinfo);
-		rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED,
-		    hdrp->opcode, hdrp->io_seq);
+		rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED, hdrp);
 		goto end;
 	}
 
@@ -1392,8 +1382,7 @@ process_message(uzfs_mgmt_conn_t *conn)
 	case ZVOL_OPCODE_REPLICA_STATUS:
 	case ZVOL_OPCODE_STATS:
 		if (payload_size == 0 || payload_size >= MAX_NAME_LEN) {
-			rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED,
-			    hdrp->opcode, hdrp->io_seq);
+			rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED, hdrp);
 			break;
 		}
 		strlcpy(zvol_name, payload, payload_size);
@@ -1401,8 +1390,7 @@ process_message(uzfs_mgmt_conn_t *conn)
 
 		if ((zinfo = uzfs_zinfo_lookup(zvol_name)) == NULL) {
 			LOGERRCONN(conn, "Unknown zvol: %s", zvol_name);
-			rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED,
-			    hdrp->opcode, hdrp->io_seq);
+			rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED, hdrp);
 			break;
 		}
 		/*
@@ -1414,8 +1402,7 @@ process_message(uzfs_mgmt_conn_t *conn)
 			uzfs_zinfo_drop_refcnt(zinfo);
 			LOGERRCONN(conn, "Target used invalid connection for "
 			    "zvol %s", zvol_name);
-			rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED,
-			    hdrp->opcode, hdrp->io_seq);
+			rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED, hdrp);
 			break;
 		}
 
@@ -1447,8 +1434,7 @@ process_message(uzfs_mgmt_conn_t *conn)
 	case ZVOL_OPCODE_SNAP_DESTROY:
 	case ZVOL_OPCODE_SNAP_LIST:
 		if (payload_size == 0 || payload_size >= MAX_NAME_LEN) {
-			rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED,
-			    hdrp->opcode, hdrp->io_seq);
+			rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED, hdrp);
 			break;
 		}
 		strlcpy(zvol_name, payload, payload_size);
@@ -1459,7 +1445,7 @@ process_message(uzfs_mgmt_conn_t *conn)
 				LOG_ERR("Invalid snapshot name: %s",
 				    zvol_name);
 				rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED,
-				    hdrp->opcode, hdrp->io_seq);
+				    hdrp);
 				break;
 			}
 			*snap++ = '\0';
@@ -1467,16 +1453,14 @@ process_message(uzfs_mgmt_conn_t *conn)
 		/* ref will be released when async command has finished */
 		if ((zinfo = uzfs_zinfo_lookup(zvol_name)) == NULL) {
 			LOGERRCONN(conn, "Unknown zvol: %s", zvol_name);
-			rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED,
-			    hdrp->opcode, hdrp->io_seq);
+			rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED, hdrp);
 			break;
 		}
 		if (zinfo->mgmt_conn != conn) {
 			uzfs_zinfo_drop_refcnt(zinfo);
 			LOGERRCONN(conn, "Target used invalid connection for "
 			    "zvol %s to take %s snapshot", zvol_name, snap);
-			rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED,
-			    hdrp->opcode, hdrp->io_seq);
+			rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED, hdrp);
 			break;
 		}
 		if (hdrp->opcode == ZVOL_OPCODE_SNAP_LIST) {
@@ -1500,8 +1484,7 @@ process_message(uzfs_mgmt_conn_t *conn)
 			uzfs_zinfo_drop_refcnt(zinfo);
 			LOG_ERR("zvol %s is not healthy to take %s snapshot",
 			    zvol_name, snap);
-			rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED,
-			    hdrp->opcode, hdrp->io_seq);
+			rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED, hdrp);
 			break;
 		}
 		if (hdrp->opcode == ZVOL_OPCODE_SNAP_CREATE) {
@@ -1517,8 +1500,7 @@ process_message(uzfs_mgmt_conn_t *conn)
 
 	case ZVOL_OPCODE_RESIZE:
 		if (payload_size != sizeof (*resize_data)) {
-			rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED,
-			    hdrp->opcode, hdrp->io_seq);
+			rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED, hdrp);
 			break;
 		}
 		resize_data = payload;
@@ -1527,16 +1509,14 @@ process_message(uzfs_mgmt_conn_t *conn)
 		if ((zinfo = uzfs_zinfo_lookup(resize_data->volname)) == NULL) {
 			LOGERRCONN(conn, "Unknown zvol: %s",
 			    resize_data->volname);
-			rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED,
-			    hdrp->opcode, hdrp->io_seq);
+			rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED, hdrp);
 			break;
 		}
 		if (zinfo->mgmt_conn != conn) {
 			uzfs_zinfo_drop_refcnt(zinfo);
 			LOGERRCONN(conn, "Target used invalid connection for "
 			    "zvol %s", resize_data->volname);
-			rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED,
-			    hdrp->opcode, hdrp->io_seq);
+			rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED, hdrp);
 			break;
 		}
 		LOGCONN(conn, "Resize zvol %s to %lu bytes", zinfo->name,
@@ -1554,8 +1534,7 @@ process_message(uzfs_mgmt_conn_t *conn)
 	default:
 		LOGERRCONN(conn, "Message with unknown OP code %d",
 		    hdrp->opcode);
-		rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED, hdrp->opcode,
-		    hdrp->io_seq);
+		rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED, hdrp);
 		break;
 	}
 	kmem_free(hdrp, sizeof (*hdrp));
@@ -1574,6 +1553,7 @@ move_to_next_state(uzfs_mgmt_conn_t *conn)
 {
 	struct epoll_event ev;
 	zvol_io_hdr_t *hdrp;
+	zvol_io_hdr_t hdr = { 0 };
 	uint16_t vers;
 	int rc = 0;
 
@@ -1607,8 +1587,9 @@ move_to_next_state(uzfs_mgmt_conn_t *conn)
 		    (vers < MIN_SUPPORTED_REPLICA_VERSION)) {
 			LOGERRCONN(conn, "Invalid replica protocol version %d",
 			    vers);
+			hdr.version = vers;
 			rc = reply_nodata(conn, ZVOL_OP_STATUS_VERSION_MISMATCH,
-			    0, 0);
+			    &hdr);
 			/* override the default next state from reply_nodata */
 			conn->conn_state = CS_CLOSE;
 		} else {

--- a/lib/libzrepl/mgmt_conn.c
+++ b/lib/libzrepl/mgmt_conn.c
@@ -1587,7 +1587,11 @@ move_to_next_state(uzfs_mgmt_conn_t *conn)
 		    (vers < MIN_SUPPORTED_REPLICA_VERSION)) {
 			LOGERRCONN(conn, "Invalid replica protocol version %d",
 			    vers);
-			hdr.version = vers;
+			/*
+			 * In case of version mismatch, max version that uzfs
+			 * supports will be sent
+			 */
+			hdr.version = REPLICA_VERSION;
 			rc = reply_nodata(conn, ZVOL_OP_STATUS_VERSION_MISMATCH,
 			    &hdr);
 			/* override the default next state from reply_nodata */

--- a/lib/libzrepl/mgmt_conn.c
+++ b/lib/libzrepl/mgmt_conn.c
@@ -723,7 +723,7 @@ uzfs_zvol_fetch_snapshot_list(zvol_info_t *zinfo, void **buf,
 	uint64_t total_len;
 	char err_msg[128];
 
-	snapname = kmem_alloc(ZFS_MAX_DATASET_NAME_LEN, KM_SLEEP);
+	snapname = kmem_zalloc(ZFS_MAX_DATASET_NAME_LEN, KM_SLEEP);
 	jarray = json_object_new_array();
 
 	while (error == 0) {

--- a/tests/cbtest/gtest/test_uzfs.cc
+++ b/tests/cbtest/gtest/test_uzfs.cc
@@ -1891,7 +1891,7 @@ exit:
  * This fn does data conn for a host:ip and volume, and fills data fd
  *
  * NOTE: Return value must be void otherwise we could not use asserts
- * (pecularity of gtest framework).
+ * (peculiarity of gtest framework).
  */
 static void do_data_connection(int &data_fd, std::string host, uint16_t port,
     std::string zvol_name, int bs=512, int timeout=120,

--- a/tests/cbtest/gtest/test_zrepl_prot.cc
+++ b/tests/cbtest/gtest/test_zrepl_prot.cc
@@ -569,7 +569,7 @@ TEST_F(ZreplHandshakeTest, HandshakeWrongVersion) {
 
 	rc = read(m_control_fd, &hdr_in, sizeof (hdr_in));
 	ASSERT_EQ(rc, sizeof (hdr_in));
-	EXPECT_EQ(hdr_in.version, REPLICA_VERSION);
+	EXPECT_EQ(hdr_in.version, hdr_out.version);
 	EXPECT_EQ(hdr_in.opcode, ZVOL_OPCODE_HANDSHAKE);
 	EXPECT_EQ(hdr_in.status, ZVOL_OP_STATUS_VERSION_MISMATCH);
 	EXPECT_EQ(hdr_in.io_seq, 0);


### PR DESCRIPTION
This PR lets cstor to work compatible with targets of version 3 and 4. This avoids getting volumes into RO during uprades.

Signed-off-by: Vitta <vitta@mayadata.io>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
