### PR TITLE
feat(image): Using non-debug build of libcstor for cstor images

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -2,6 +2,18 @@
 set -e
 
 pwd
+
+# Build libcstor
+cd ../libcstor
+make clean
+sh autogen.sh
+./configure --with-zfs-headers=$PWD/../cstor/include --with-spl-headers=$PWD/../cstor/lib/libspl/include
+make -j4
+sudo make install
+sudo ldconfig
+
+# Build cstor
+cd ../cstor
 make clean
 sh autogen.sh
 ./configure --enable-uzfs=yes --with-config=user --with-jemalloc --with-libcstor=$PWD/../libcstor/include


### PR DESCRIPTION
Changes:
- Adding libcstor non-debug build in `build_image.sh`. With this change, `cstor-base` image will have `libcstor.so` having debug mode disabled.

Signed-off-by: mayank <mayank.patel@mayadata.io>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
