### PR TITLE
adding a new op code to exchange size information while rebuilding

### DIFF
--- a/include/data_conn.h
+++ b/include/data_conn.h
@@ -80,6 +80,7 @@ void signal_fds_related_to_zinfo(zvol_info_t *zinfo);
 void quiesce_wait(zvol_info_t *zinfo);
 
 int uzfs_zvol_handle_rebuild_snap_done(zvol_io_hdr_t *, int, zvol_info_t *);
+int uzfs_zvol_handle_rebuild_snap_start(zvol_io_hdr_t *, int, zvol_info_t *);
 
 #ifdef __cplusplus
 }

--- a/include/zrepl_prot.h
+++ b/include/zrepl_prot.h
@@ -78,6 +78,7 @@ enum zvol_op_code {
 	ZVOL_OPCODE_SNAP_LIST,
 	ZVOL_OPCODE_RESIZE,
 	ZVOL_OPCODE_STATS,
+	ZVOL_OPCODE_REBUILD_SNAP_START,
 } __attribute__((packed));
 
 typedef enum zvol_op_code zvol_op_code_t;

--- a/lib/libzpool/uzfs_rebuilding.c
+++ b/lib/libzpool/uzfs_rebuilding.c
@@ -89,8 +89,16 @@ uzfs_get_io_diff(zvol_state_t *zv, blk_metadata_t *low, zvol_state_t *snap,
 	zvol_state_t *snap_zv;
 	metaobj_blk_offset_t snap_metablk;
 
-	if (!func || (lun_offset + lun_len) > zv->zv_volsize || snap == NULL)
+	if (!func || snap == NULL)
 		return (EINVAL);
+
+	// dont fail if rebuilding from lower size volume
+	// can we avoid rebuilding at all from smaller volume?
+	if (lun_offset >= zv->zv_volsize)
+		return (0);
+	if ((lun_offset + lun_len) > zv->zv_volsize) {
+		lun_len = zv->zv_volsize - lun_offset;
+	}
 
 	get_zv_metaobj_block_details(&snap_metablk, zv, lun_offset, lun_len);
 	offset = snap_metablk.m_offset;

--- a/lib/libzrepl/data_conn.c
+++ b/lib/libzrepl/data_conn.c
@@ -84,6 +84,7 @@ zio_cmd_alloc(zvol_io_hdr_t *hdr, int fd)
 		ASSERT((hdr->opcode == ZVOL_OPCODE_READ) ||
 		    (hdr->opcode == ZVOL_OPCODE_WRITE) ||
 		    (hdr->opcode == ZVOL_OPCODE_OPEN) ||
+		    (hdr->opcode == ZVOL_OPCODE_REBUILD_SNAP_START) ||
 		    (hdr->opcode == ZVOL_OPCODE_REBUILD_SNAP_DONE));
 	}
 	zio_cmd->conn = fd;
@@ -127,6 +128,7 @@ zio_cmd_free(zvol_io_cmd_t **cmd)
 		case ZVOL_OPCODE_SYNC:
 		case ZVOL_OPCODE_REBUILD_STEP_DONE:
 		case ZVOL_OPCODE_REBUILD_ALL_SNAP_DONE:
+		case ZVOL_OPCODE_REBUILD_SNAP_START:
 			/* Nothing to do */
 			break;
 
@@ -402,6 +404,7 @@ uzfs_zvol_worker(void *arg)
 			break;
 
 		case ZVOL_OPCODE_REBUILD_SNAP_DONE:
+		case ZVOL_OPCODE_REBUILD_SNAP_START:
 		case ZVOL_OPCODE_REBUILD_ALL_SNAP_DONE:
 		case ZVOL_OPCODE_REBUILD_STEP_DONE:
 			break;
@@ -636,6 +639,42 @@ uzfs_zvol_handle_rebuild_snap_done(zvol_io_hdr_t *hdrp,
 	return (rc);
 }
 
+int
+uzfs_zvol_handle_rebuild_snap_start(zvol_io_hdr_t *hdrp,
+    int sfd, zvol_info_t *zinfo)
+{
+	int rc = 0;
+	uint64_t dvolsize = ZVOL_VOLUME_SIZE(zinfo->main_zv);
+	uint64_t volsize;
+
+	if (hdrp->len != sizeof (volsize)) {
+		LOG_ERR("snap start Unexpected hdr.len:%ld on volume: %s",
+		    hdrp->len, zinfo->name);
+		return (rc = -1);
+	}
+
+	if ((rc = uzfs_zvol_socket_read(sfd, (char *)&volsize, hdrp->len)) != 0)
+		return (rc);
+
+	if (dvolsize < volsize) {
+		LOG_INFO("resize the volume %s old size = %lu, new size = %lu",
+		    zinfo->main_zv->zv_name, dvolsize, volsize);
+		rc = zvol_check_volsize(volsize,
+		    zinfo->main_zv->zv_volblocksize);
+		if (rc == 0) {
+			rc = zvol_update_volsize(volsize,
+			    zinfo->main_zv->zv_objset);
+			if (rc == 0)
+				zvol_size_changed(zinfo->main_zv, volsize);
+		}
+		if (rc != 0) {
+			LOG_ERR("Failed to resize zvol %s",
+			    zinfo->main_zv->zv_name);
+		}
+	}
+	return (rc);
+}
+
 void
 uzfs_zvol_rebuild_dw_replica(void *arg)
 {
@@ -829,6 +868,18 @@ next_step:
 
 		if (hdr.opcode == ZVOL_OPCODE_REBUILD_SNAP_DONE)
 			goto next_step;
+
+		if (hdr.opcode == ZVOL_OPCODE_REBUILD_SNAP_START) {
+			rc = uzfs_zvol_handle_rebuild_snap_start(&hdr,
+			    sfd, zinfo);
+			if (rc != 0) {
+				LOG_ERR("Rebuild snap start failed.."
+				    "for %s on fd(%d)",
+				    zinfo->name, sfd);
+				goto exit;
+			}
+			continue;
+		}
 
 		if (hdr.opcode == ZVOL_OPCODE_REBUILD_ALL_SNAP_DONE) {
 			LOG_DEBUG("Received ALL_SNAP_DONE on fd: %d", sfd);
@@ -1622,11 +1673,17 @@ read_socket:
 					    " %s, err(%d)", zinfo->name, rc);
 					goto exit;
 				}
-#if DEBUG
-				if (snap_zv != NULL)
+				if (snap_zv != NULL) {
+					uint64_t volsize =
+					    ZVOL_VOLUME_SIZE(snap_zv);
+					uzfs_zvol_send_zio_cmd(zinfo, &hdr,
+					    ZVOL_OPCODE_REBUILD_SNAP_START,
+					    fd, (char *)&volsize,
+					    sizeof (volsize), 0, warg);
+
 					LOG_INFO("Rebuilding from zv:%s\n",
 					    snap_zv->zv_name);
-#endif
+				}
 			}
 
 			zvol_state_t *zv = zinfo->main_zv;
@@ -1658,6 +1715,11 @@ read_socket:
 					    " err(%d)", zinfo->name, rc);
 					goto exit;
 				}
+				uint64_t volsize = ZVOL_VOLUME_SIZE(snap_zv);
+				uzfs_zvol_send_zio_cmd(zinfo, &hdr,
+				    ZVOL_OPCODE_REBUILD_SNAP_START,
+				    fd, (char *)&volsize,
+				    sizeof (volsize), 0, warg);
 			}
 
 			rc = uzfs_get_io_diff(zv, &metadata,
@@ -1951,7 +2013,8 @@ uzfs_zvol_io_ack_sender(void *arg)
 		if (rc == -1)
 			goto error_check;
 
-		if (zio_cmd->hdr.opcode == ZVOL_OPCODE_REBUILD_SNAP_DONE) {
+		if ((zio_cmd->hdr.opcode == ZVOL_OPCODE_REBUILD_SNAP_DONE) ||
+		    (zio_cmd->hdr.opcode == ZVOL_OPCODE_REBUILD_SNAP_START)) {
 			rc = uzfs_zvol_socket_write(zio_cmd->conn,
 			    zio_cmd->buf, zio_cmd->hdr.len);
 error_check:


### PR DESCRIPTION
adding a op code which exchanges the volume size while rebuilding as we need to resize the volume before starting the snapshot rebuild if resize has happened in the past.

Signed-off-by: Pawan <pawan@mayadata.io>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
