### PR TITLE
fix(image): remove openssh from baseimage

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -11,7 +11,7 @@ RUN apt-get clean && \
     curl tcpdump dnsutils iputils-ping \
     libaio1 libaio-dev \
     libkqueue-dev libssl1.0.0 rsyslog net-tools gdb apt-utils \
-    sed libjemalloc-dev openssh-server
+    sed libjemalloc-dev
 RUN apt-get -y install apt-file && apt-file update
 
 COPY zfs/bin/* /usr/local/bin/

--- a/docker/entrypoint-poolimage.sh
+++ b/docker/entrypoint-poolimage.sh
@@ -10,7 +10,6 @@ echo  "exit code:" $?
 echo "reference: "  $0 
 }
 
-service ssh start
 
 if [ -z "$LOGLEVEL" ]; then
 	LOGLEVEL=info


### PR DESCRIPTION
This commit removes the openssh modules and the commands
from cstor-base image, since it's not required.

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
