### PR TITLE
support(travis) : TRAVIS_BRANCH in travis.yaml to determine remote branch for openebs/libcstor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,8 @@ install:
     # Build libcstor for uzfs feature
     - git clone https://github.com/openebs/libcstor.git
     - cd libcstor
-    - git checkout v1.0.x
+    - [ ! -z ${TRAVIS_TAG} ] && git checkout ${TRAVIS_TAG} || git checkout master
+    - git branch
     - sh autogen.sh;
     - ./configure --enable-debug --with-zfs-headers=$PWD/../cstor/include --with-spl-headers=$PWD/../cstor/lib/libspl/include
     - make -j4;

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ install:
     # Build libcstor for uzfs feature
     - git clone https://github.com/openebs/libcstor.git
     - cd libcstor
-    - [ ! -z ${TRAVIS_TAG} ] && git checkout ${TRAVIS_TAG} || git checkout master
+    - if [ ! -z ${TRAVIS_TAG} ]; then git checkout ${TRAVIS_TAG}; else git checkout master; fi
     - git branch
     - sh autogen.sh;
     - ./configure --enable-debug --with-zfs-headers=$PWD/../cstor/include --with-spl-headers=$PWD/../cstor/lib/libspl/include

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ install:
     # Build libcstor for uzfs feature
     - git clone https://github.com/openebs/libcstor.git
     - cd libcstor
-    - if [ ! -z ${TRAVIS_TAG} ]; then git checkout ${TRAVIS_TAG}; else git checkout master; fi
+    - if [ ! -z ${TRAVIS_BRANCH} ]; then git checkout ${TRAVIS_BRANCH}; else git checkout master; fi
     - git branch
     - sh autogen.sh;
     - ./configure --enable-debug --with-zfs-headers=$PWD/../cstor/include --with-spl-headers=$PWD/../cstor/lib/libspl/include

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ install:
     # Build libcstor for uzfs feature
     - git clone https://github.com/openebs/libcstor.git
     - cd libcstor
-    - if [ ! -z ${TRAVIS_BRANCH} ]; then git checkout ${TRAVIS_BRANCH}; else git checkout master; fi
+    - if [ ${TRAVIS_BRANCH} == "develop" ]; then git checkout master; else git checkout ${TRAVIS_BRANCH}; fi
     - git branch
     - sh autogen.sh;
     - ./configure --enable-debug --with-zfs-headers=$PWD/../cstor/include --with-spl-headers=$PWD/../cstor/lib/libspl/include


### PR DESCRIPTION
Changes:
- Use `master` branch of `openebs/libcstor` if current branch is `develop` else use branch from `${TRAVIS_BRANCH}`
Signed-off-by: mayank <mayank.patel@mayadata.io>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
