### PR TITLE
support(travis) : TRAVIS_BRANCH in travis.yaml to determine remote branch for openebs/libcstor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ install:
     # Build libcstor for uzfs feature
     - git clone https://github.com/openebs/libcstor.git
     - cd libcstor
+    - if [ ${TRAVIS_BRANCH} == "develop" ]; then git checkout master; else git checkout ${TRAVIS_BRANCH} || git checkout master; fi
     - sh autogen.sh;
     - ./configure --enable-debug --with-zfs-headers=$PWD/../cstor/include --with-spl-headers=$PWD/../cstor/lib/libspl/include
     - make -j4;


### PR DESCRIPTION
With this change:
- Travis build will use `${TRAVIS_BRANCH}` for `openebs/libcstor`. If `openebs/libcstor` doesn't have `${TRAVIS_BRANCH}` then default `master` branch will be used to build `openebs/libcstor`.

Signed-off-by: mayank <mayank.patel@mayadata.io>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
