### PR TITLE
New error logging format for automatic alert generation

### DIFF
--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -111,54 +111,55 @@ zfs_validate_name(libzfs_handle_t *hdl, const char *path, int type,
 			switch (why) {
 			case NAME_ERR_TOOLONG:
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "name is too long"));
+				    "reason=name is too long"));
 				break;
 
 			case NAME_ERR_LEADING_SLASH:
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "leading slash in name"));
+				    "reason=leading slash in name"));
 				break;
 
 			case NAME_ERR_EMPTY_COMPONENT:
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "empty component in name"));
+				    "reason=empty component in name"));
 				break;
 
 			case NAME_ERR_TRAILING_SLASH:
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "trailing slash in name"));
+				    "reason=trailing slash in name"));
 				break;
 
 			case NAME_ERR_INVALCHAR:
 				zfs_error_aux(hdl,
-				    dgettext(TEXT_DOMAIN, "invalid character "
+				    dgettext(TEXT_DOMAIN,
+				    "reason=invalid character "
 				    "'%c' in name"), what);
 				break;
 
 			case NAME_ERR_MULTIPLE_DELIMITERS:
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "multiple '@' and/or '#' delimiters in "
-				    "name"));
+				    "reason=multiple '@' and/or '#' delimiters "
+				    "in name"));
 				break;
 
 			case NAME_ERR_NOLETTER:
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "pool doesn't begin with a letter"));
+				    "reason=pool doesn't begin with a letter"));
 				break;
 
 			case NAME_ERR_RESERVED:
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "name is reserved"));
+				    "reason=name is reserved"));
 				break;
 
 			case NAME_ERR_DISKLIKE:
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "reserved disk name"));
+				    "reason=reserved disk name"));
 				break;
 
 			default:
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "(%d) not defined"), why);
+				    "reason=(%d) not defined"), why);
 				break;
 			}
 		}
@@ -169,35 +170,37 @@ zfs_validate_name(libzfs_handle_t *hdl, const char *path, int type,
 	if (!(type & ZFS_TYPE_SNAPSHOT) && strchr(path, '@') != NULL) {
 		if (hdl != NULL)
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "snapshot delimiter '@' is not expected here"));
+			    "reason=snapshot delimiter '@' is not "
+			    "expected here"));
 		return (0);
 	}
 
 	if (type == ZFS_TYPE_SNAPSHOT && strchr(path, '@') == NULL) {
 		if (hdl != NULL)
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "missing '@' delimiter in snapshot name"));
+			    "reason=missing '@' delimiter in snapshot name"));
 		return (0);
 	}
 
 	if (!(type & ZFS_TYPE_BOOKMARK) && strchr(path, '#') != NULL) {
 		if (hdl != NULL)
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "bookmark delimiter '#' is not expected here"));
+			    "reason=bookmark delimiter '#' is not "
+			    "expected here"));
 		return (0);
 	}
 
 	if (type == ZFS_TYPE_BOOKMARK && strchr(path, '#') == NULL) {
 		if (hdl != NULL)
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "missing '#' delimiter in bookmark name"));
+			    "reason=missing '#' delimiter in bookmark name"));
 		return (0);
 	}
 
 	if (modifying && strchr(path, '%') != NULL) {
 		if (hdl != NULL)
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "invalid character %c in name"), '%');
+			    "reason=invalid character %c in name"), '%');
 		return (0);
 	}
 
@@ -676,7 +679,8 @@ zfs_open(libzfs_handle_t *hdl, const char *path, int types)
 	char *bookp;
 
 	(void) snprintf(errbuf, sizeof (errbuf),
-	    dgettext(TEXT_DOMAIN, "cannot open '%s'"), path);
+	    dgettext(TEXT_DOMAIN,
+	    "ecode=cstor.cannot.open.dataset msg=cannot open '%s'"), path);
 
 	/*
 	 * Validate the name before we even try to open it.
@@ -998,14 +1002,14 @@ zfs_valid_proplist(libzfs_handle_t *hdl, zfs_type_t type, nvlist_t *nvl,
 			 */
 			if (nvpair_type(elem) != DATA_TYPE_STRING) {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "'%s' must be a string"), propname);
+				    "reason='%s' must be a string"), propname);
 				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 				goto error;
 			}
 
 			if (strlen(nvpair_name(elem)) >= ZAP_MAXNAMELEN) {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "property name '%s' is too long"),
+				    "reason=property name '%s' is too long"),
 				    propname);
 				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 				goto error;
@@ -1025,7 +1029,8 @@ zfs_valid_proplist(libzfs_handle_t *hdl, zfs_type_t type, nvlist_t *nvl,
 		 */
 		if (type == ZFS_TYPE_SNAPSHOT) {
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "this property can not be modified for snapshots"));
+			    "reason=this property can not be modified "
+			    "for snapshots"));
 			(void) zfs_error(hdl, EZFS_PROPTYPE, errbuf);
 			goto error;
 		}
@@ -1042,8 +1047,8 @@ zfs_valid_proplist(libzfs_handle_t *hdl, zfs_type_t type, nvlist_t *nvl,
 			    &uqtype, domain, sizeof (domain), &rid) != 0) {
 				zfs_error_aux(hdl,
 				    dgettext(TEXT_DOMAIN,
-				    "'%s' has an invalid user/group name"),
-				    propname);
+				    "reason='%s' has an invalid "
+				    "user/group name"), propname);
 				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 				goto error;
 			}
@@ -1053,7 +1058,8 @@ zfs_valid_proplist(libzfs_handle_t *hdl, zfs_type_t type, nvlist_t *nvl,
 			    uqtype != ZFS_PROP_USEROBJQUOTA &&
 			    uqtype != ZFS_PROP_GROUPOBJQUOTA) {
 				zfs_error_aux(hdl,
-				    dgettext(TEXT_DOMAIN, "'%s' is readonly"),
+				    dgettext(TEXT_DOMAIN,
+				    "reason='%s' is readonly"),
 				    propname);
 				(void) zfs_error(hdl, EZFS_PROPREADONLY,
 				    errbuf);
@@ -1075,13 +1081,13 @@ zfs_valid_proplist(libzfs_handle_t *hdl, zfs_type_t type, nvlist_t *nvl,
 				(void) nvpair_value_uint64(elem, &intval);
 				if (intval == 0) {
 					zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-					    "use 'none' to disable "
+					    "reason=use 'none' to disable "
 					    "userquota/groupquota"));
 					goto error;
 				}
 			} else {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "'%s' must be a number"), propname);
+				    "reason='%s' must be a number"), propname);
 				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 				goto error;
 			}
@@ -1112,7 +1118,7 @@ zfs_valid_proplist(libzfs_handle_t *hdl, zfs_type_t type, nvlist_t *nvl,
 			continue;
 		} else if (prop == ZPROP_INVAL && zfs_prop_written(propname)) {
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "'%s' is readonly"),
+			    "reason='%s' is readonly"),
 			    propname);
 			(void) zfs_error(hdl, EZFS_PROPREADONLY, errbuf);
 			goto error;
@@ -1120,14 +1126,14 @@ zfs_valid_proplist(libzfs_handle_t *hdl, zfs_type_t type, nvlist_t *nvl,
 
 		if (prop == ZPROP_INVAL) {
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "invalid property '%s'"), propname);
+			    "reason=invalid property '%s'"), propname);
 			(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 			goto error;
 		}
 
 		if (!zfs_prop_valid_for_type(prop, type, B_FALSE)) {
 			zfs_error_aux(hdl,
-			    dgettext(TEXT_DOMAIN, "'%s' does not "
+			    dgettext(TEXT_DOMAIN, "reason='%s' does not "
 			    "apply to datasets of this type"), propname);
 			(void) zfs_error(hdl, EZFS_PROPTYPE, errbuf);
 			goto error;
@@ -1136,7 +1142,7 @@ zfs_valid_proplist(libzfs_handle_t *hdl, zfs_type_t type, nvlist_t *nvl,
 		if (zfs_prop_readonly(prop) &&
 		    (!zfs_prop_setonce(prop) || zhp != NULL)) {
 			zfs_error_aux(hdl,
-			    dgettext(TEXT_DOMAIN, "'%s' is readonly"),
+			    dgettext(TEXT_DOMAIN, "reason='%s' is readonly"),
 			    propname);
 			(void) zfs_error(hdl, EZFS_PROPREADONLY, errbuf);
 			goto error;
@@ -1159,8 +1165,8 @@ zfs_valid_proplist(libzfs_handle_t *hdl, zfs_type_t type, nvlist_t *nvl,
 			version = zfs_prop_get_int(zhp, ZFS_PROP_VERSION);
 			if (intval < version) {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "Can not downgrade; already at version %u"),
-				    version);
+				    "reason=Can not downgrade; already at "
+				    "version %u"), version);
 				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 				goto error;
 			}
@@ -1185,7 +1191,7 @@ zfs_valid_proplist(libzfs_handle_t *hdl, zfs_type_t type, nvlist_t *nvl,
 			    intval > maxbs || !ISP2(intval)) {
 				zfs_nicebytes(maxbs, buf, sizeof (buf));
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "'%s' must be power of 2 from 512B "
+				    "reason='%s' must be power of 2 from 512B "
 				    "to %s"), propname, buf);
 				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 				goto error;
@@ -1246,7 +1252,7 @@ badlabel:
 			goto error;
 #else
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "mlslabels are unsupported"));
+			    "reason=mlslabels are unsupported"));
 			(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 			goto error;
 #endif /* HAVE_MLSLABEL */
@@ -1265,20 +1271,22 @@ badlabel:
 				case NAME_ERR_LEADING_SLASH:
 					zfs_error_aux(hdl,
 					    dgettext(TEXT_DOMAIN,
-					    "'%s' must be an absolute path, "
-					    "'none', or 'legacy'"), propname);
+					    "reason='%s' must be an"
+					    "absolute path, 'none', "
+					    "or 'legacy'"),
+					    propname);
 					break;
 				case NAME_ERR_TOOLONG:
 					zfs_error_aux(hdl,
 					    dgettext(TEXT_DOMAIN,
-					    "component of '%s' is too long"),
-					    propname);
+					    "reason=component of '%s' is "
+					    "too long"), propname);
 					break;
 
 				default:
 					zfs_error_aux(hdl,
 					    dgettext(TEXT_DOMAIN,
-					    "(%d) not defined"),
+					    "reason=(%d) not defined"),
 					    why);
 					break;
 				}
@@ -1310,7 +1318,7 @@ badlabel:
 			if (zoned) {
 				if (getzoneid() == GLOBAL_ZONEID) {
 					zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-					    "'%s' cannot be set on "
+					    "reason='%s' cannot be set on "
 					    "dataset in a non-global zone"),
 					    propname);
 					(void) zfs_error(hdl, EZFS_ZONED,
@@ -1319,7 +1327,7 @@ badlabel:
 				} else if (prop == ZFS_PROP_SHARENFS ||
 				    prop == ZFS_PROP_SHARESMB) {
 					zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-					    "'%s' cannot be set in "
+					    "reason='%s' cannot be set in "
 					    "a non-global zone"), propname);
 					(void) zfs_error(hdl, EZFS_ZONED,
 					    errbuf);
@@ -1331,7 +1339,7 @@ badlabel:
 				 * a global zone. If not, something is wrong.
 				 */
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "'%s' cannot be set while dataset "
+				    "reason='%s' cannot be set while dataset "
 				    "'zoned' property is set"), propname);
 				(void) zfs_error(hdl, EZFS_ZONED, errbuf);
 				goto error;
@@ -1371,8 +1379,8 @@ badlabel:
 					 * anything
 					 */
 					zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-					    "'%s' cannot be set: problem "
-					    "in share initialization"),
+					    "reason='%s' cannot be set: "
+					    "problem in share initialization"),
 					    propname);
 					(void) zfs_error(hdl, EZFS_BADPROP,
 					    errbuf);
@@ -1388,8 +1396,8 @@ badlabel:
 					 * interface.
 					 */
 					zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-					    "'%s' cannot be set to invalid "
-					    "options"), propname);
+					    "reason='%s' cannot be set to "
+					    "invalid options"), propname);
 					(void) zfs_error(hdl, EZFS_BADPROP,
 					    errbuf);
 					zfs_uninit_libshare(hdl);
@@ -1428,8 +1436,8 @@ badlabel:
 			case ZFS_PROP_REFRESERVATION:
 				if (intval > volsize) {
 					zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-					    "'%s' is greater than current "
-					    "volume size"), propname);
+					    "reason='%s' is greater than "
+					    "current volume size"), propname);
 					(void) zfs_error(hdl, EZFS_BADPROP,
 					    errbuf);
 					goto error;
@@ -1441,7 +1449,7 @@ badlabel:
 					zfs_nicebytes(blocksize, buf,
 					    sizeof (buf));
 					zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-					    "'%s' must be a multiple of "
+					    "reason='%s' must be a multiple of "
 					    "volume block size (%s)"),
 					    propname, buf);
 					(void) zfs_error(hdl, EZFS_BADPROP,
@@ -1451,7 +1459,7 @@ badlabel:
 
 				if (intval == 0) {
 					zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-					    "'%s' cannot be zero"),
+					    "reason='%s' cannot be zero"),
 					    propname);
 					(void) zfs_error(hdl, EZFS_BADPROP,
 					    errbuf);
@@ -1480,7 +1488,7 @@ badlabel:
 		}
 	} else if (chosen_normal > 0 && chosen_utf == 0) {
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-		    "'%s' must be set 'on' if normalization chosen"),
+		    "reason='%s' must be set 'on' if normalization chosen"),
 		    zfs_prop_to_name(ZFS_PROP_UTF8ONLY));
 		(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 		goto error;
@@ -1553,7 +1561,7 @@ zfs_setprop_error(libzfs_handle_t *hdl, zfs_prop_t prop, int err,
 		case ZFS_PROP_QUOTA:
 		case ZFS_PROP_REFQUOTA:
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "size is less than current used or "
+			    "reason=size is less than current used or "
 			    "reserved space"));
 			(void) zfs_error(hdl, EZFS_PROPSPACE, errbuf);
 			break;
@@ -1561,7 +1569,7 @@ zfs_setprop_error(libzfs_handle_t *hdl, zfs_prop_t prop, int err,
 		case ZFS_PROP_RESERVATION:
 		case ZFS_PROP_REFRESERVATION:
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "size is greater than available space"));
+			    "reason=size is greater than available space"));
 			(void) zfs_error(hdl, EZFS_PROPSPACE, errbuf);
 			break;
 
@@ -1581,13 +1589,13 @@ zfs_setprop_error(libzfs_handle_t *hdl, zfs_prop_t prop, int err,
 
 	case E2BIG:
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-		    "property value too long"));
+		    "reason=property value too long"));
 		(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 		break;
 
 	case ENOTSUP:
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-		    "pool and or dataset must be upgraded to set this "
+		    "reason=pool and or dataset must be upgraded to set this "
 		    "property or value"));
 		(void) zfs_error(hdl, EZFS_BADVERSION, errbuf);
 		break;
@@ -1597,13 +1605,13 @@ zfs_setprop_error(libzfs_handle_t *hdl, zfs_prop_t prop, int err,
 		    prop == ZFS_PROP_DNODESIZE ||
 		    prop == ZFS_PROP_RECORDSIZE) {
 			(void) zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "property setting is not allowed on "
+			    "reason=property setting is not allowed on "
 			    "bootable datasets"));
 			(void) zfs_error(hdl, EZFS_NOTSUP, errbuf);
 		} else if (prop == ZFS_PROP_CHECKSUM ||
 		    prop == ZFS_PROP_DEDUP) {
 			(void) zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "property setting is not allowed on "
+			    "reason=property setting is not allowed on "
 			    "root pools"));
 			(void) zfs_error(hdl, EZFS_NOTSUP, errbuf);
 		} else {
@@ -1667,8 +1675,9 @@ zfs_prop_set(zfs_handle_t *zhp, const char *propname, const char *propval)
 	nvlist_t *nvl = NULL;
 
 	(void) snprintf(errbuf, sizeof (errbuf),
-	    dgettext(TEXT_DOMAIN, "cannot set property for '%s'"),
-	    zhp->zfs_name);
+	    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.set.property "
+	    "rname=%s msg=cannot set property for '%s'"),
+	    zhp->zfs_name, zhp->zfs_name);
 
 	if (nvlist_alloc(&nvl, NV_UNIQUE_NAME, 0) != 0 ||
 	    nvlist_add_string(nvl, propname, propval) != 0) {
@@ -1705,8 +1714,9 @@ zfs_prop_set_list(zfs_handle_t *zhp, nvlist_t *props)
 	nvpair_t *elem;
 
 	(void) snprintf(errbuf, sizeof (errbuf),
-	    dgettext(TEXT_DOMAIN, "cannot set property for '%s'"),
-	    zhp->zfs_name);
+	    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.set.property "
+	    "rname=%s, msg=cannot set property for '%s'"),
+	    zhp->zfs_name, zhp->zfs_name);
 
 	if ((nvl = zfs_valid_proplist(hdl, zhp->zfs_type, props,
 	    zfs_prop_get_int(zhp, ZFS_PROP_ZONED), zhp, zhp->zpool_hdl,
@@ -1760,8 +1770,8 @@ zfs_prop_set_list(zfs_handle_t *zhp, nvlist_t *props)
 		if (prop == ZFS_PROP_MOUNTPOINT &&
 		    changelist_haszonedchild(cls[cl_idx])) {
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "child dataset with inherited mountpoint is used "
-			    "in a non-global zone"));
+			    "reason=child dataset with inherited "
+			    "mountpoint is used in a non-global zone"));
 			ret = zfs_error(hdl, EZFS_ZONED, errbuf);
 			goto error;
 		}
@@ -1871,7 +1881,9 @@ zfs_prop_inherit(zfs_handle_t *zhp, const char *propname, boolean_t received)
 	zfs_prop_t prop;
 
 	(void) snprintf(errbuf, sizeof (errbuf), dgettext(TEXT_DOMAIN,
-	    "cannot inherit %s for '%s'"), propname, zhp->zfs_name);
+	    "ecode=cstor.cannot.inherit.property rname=%s, "
+	    "msg=cannot inherit %s for '%s'"),
+	    zhp->zfs_name, propname, zhp->zfs_name);
 
 	zc.zc_cookie = received;
 	if ((prop = zfs_name_to_prop(propname)) == ZPROP_INVAL) {
@@ -1881,7 +1893,7 @@ zfs_prop_inherit(zfs_handle_t *zhp, const char *propname, boolean_t received)
 		 */
 		if (!zfs_prop_user(propname)) {
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "invalid property"));
+			    "reason=invalid property"));
 			return (zfs_error(hdl, EZFS_BADPROP, errbuf));
 		}
 
@@ -1919,7 +1931,7 @@ zfs_prop_inherit(zfs_handle_t *zhp, const char *propname, boolean_t received)
 	if (prop == ZFS_PROP_MOUNTPOINT && getzoneid() == GLOBAL_ZONEID &&
 	    zfs_prop_get_int(zhp, ZFS_PROP_ZONED)) {
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-		    "dataset is used in a non-global zone"));
+		    "reason=dataset is used in a non-global zone"));
 		return (zfs_error(hdl, EZFS_ZONED, errbuf));
 	}
 
@@ -1931,7 +1943,7 @@ zfs_prop_inherit(zfs_handle_t *zhp, const char *propname, boolean_t received)
 
 	if (prop == ZFS_PROP_MOUNTPOINT && changelist_haszonedchild(cl)) {
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-		    "child dataset with inherited mountpoint is used "
+		    "reason=child dataset with inherited mountpoint is used "
 		    "in a non-global zone"));
 		ret = zfs_error(hdl, EZFS_ZONED, errbuf);
 		goto error;
@@ -2238,9 +2250,9 @@ get_numeric_property(zfs_handle_t *zhp, zfs_prop_t prop, zprop_source_t *src,
 		case PROP_TYPE_STRING:
 		default:
 			zfs_error_aux(zhp->zfs_hdl, dgettext(TEXT_DOMAIN,
-			    "cannot get non-numeric property"));
+			    "reason=cannot get non-numeric property"));
 			return (zfs_error(zhp->zfs_hdl, EZFS_BADPROP,
-			    dgettext(TEXT_DOMAIN, "internal error")));
+			    dgettext(TEXT_DOMAIN, "reason=internal error")));
 		}
 	}
 
@@ -3182,12 +3194,13 @@ check_parents(libzfs_handle_t *hdl, const char *path, uint64_t *zoned,
 	uint64_t is_zoned;
 
 	(void) snprintf(errbuf, sizeof (errbuf),
-	    dgettext(TEXT_DOMAIN, "cannot create '%s'"), path);
+	    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.create.dataset "
+	    "rname=%s msg=cannot create '%s'"), path, path);
 
 	/* get parent, and check to see if this is just a pool */
 	if (parent_name(path, parent, sizeof (parent)) != 0) {
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-		    "missing dataset name"));
+		    "reason=missing dataset name"));
 		return (zfs_error(hdl, EZFS_INVALIDNAME, errbuf));
 	}
 
@@ -3199,7 +3212,7 @@ check_parents(libzfs_handle_t *hdl, const char *path, uint64_t *zoned,
 	if (uzfs_ioctl(hdl->libzfs_fd, ZFS_IOC_OBJSET_STATS, &zc) != 0 &&
 	    errno == ENOENT) {
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-		    "no such pool '%s'"), zc.zc_name);
+		    "reason=no such pool '%s'"), zc.zc_name);
 		return (zfs_error(hdl, EZFS_NOENT, errbuf));
 	}
 
@@ -3211,12 +3224,12 @@ check_parents(libzfs_handle_t *hdl, const char *path, uint64_t *zoned,
 			 */
 			if (parent_name(parent, parent, sizeof (parent)) != 0) {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "no such pool '%s'"), zc.zc_name);
+				    "reason=no such pool '%s'"), zc.zc_name);
 				return (zfs_error(hdl, EZFS_NOENT, errbuf));
 			}
 		} else if (errno == ENOENT) {
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "parent does not exist"));
+			    "reason=parent does not exist"));
 			return (zfs_error(hdl, EZFS_NOENT, errbuf));
 		} else
 			return (zfs_standard_error(hdl, errno, errbuf));
@@ -3236,7 +3249,7 @@ check_parents(libzfs_handle_t *hdl, const char *path, uint64_t *zoned,
 	/* make sure parent is a filesystem */
 	if (zfs_get_type(zhp) != ZFS_TYPE_FILESYSTEM) {
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-		    "parent is not a filesystem"));
+		    "reason=parent is not a filesystem"));
 		(void) zfs_error(hdl, EZFS_BADTYPE, errbuf);
 		zfs_close(zhp);
 		return (-1);
@@ -3343,7 +3356,7 @@ create_parents(libzfs_handle_t *hdl, char *target, int prefixlen)
 
 ancestorerr:
 	zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-	    "failed to %s ancestor '%s'"), opname, target);
+	    "reason=failed to %s ancestor '%s'"), opname, target);
 	return (-1);
 }
 
@@ -3386,7 +3399,8 @@ zfs_create(libzfs_handle_t *hdl, const char *path, zfs_type_t type,
 	zpool_handle_t *zpool_handle;
 
 	(void) snprintf(errbuf, sizeof (errbuf), dgettext(TEXT_DOMAIN,
-	    "cannot create '%s'"), path);
+	    "ecode=cstor.cannot.create.dataset rname=%s "
+	    "msg=cannot create '%s'"), path, path);
 
 	/* validate the path, taking care to note the extended error message */
 	if (!zfs_validate_name(hdl, path, type, B_TRUE))
@@ -3405,7 +3419,7 @@ zfs_create(libzfs_handle_t *hdl, const char *path, zfs_type_t type,
 	 */
 	if (zfs_dataset_exists(hdl, path, ZFS_TYPE_DATASET)) {
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-		    "dataset already exists"));
+		    "reason=dataset already exists"));
 		return (zfs_error(hdl, EZFS_EXISTS, errbuf));
 	}
 
@@ -3445,7 +3459,7 @@ zfs_create(libzfs_handle_t *hdl, const char *path, zfs_type_t type,
 		    zfs_prop_to_name(ZFS_PROP_VOLSIZE), &size) != 0) {
 			nvlist_free(props);
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "missing volume size"));
+			    "reason=missing volume size"));
 			return (zfs_error(hdl, EZFS_BADPROP, errbuf));
 		}
 
@@ -3458,7 +3472,7 @@ zfs_create(libzfs_handle_t *hdl, const char *path, zfs_type_t type,
 			} else {
 				nvlist_free(props);
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "missing volume block size"));
+				    "reason=missing volume block size"));
 				return (zfs_error(hdl, EZFS_BADPROP, errbuf));
 			}
 		}
@@ -3466,15 +3480,15 @@ zfs_create(libzfs_handle_t *hdl, const char *path, zfs_type_t type,
 		if (size == 0) {
 			nvlist_free(props);
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "volume size cannot be zero"));
+			    "reason=volume size cannot be zero"));
 			return (zfs_error(hdl, EZFS_BADPROP, errbuf));
 		}
 
 		if (size % blocksize != 0) {
 			nvlist_free(props);
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "volume size must be a multiple of volume block "
-			    "size"));
+			    "reason=volume size must be a multiple of "
+			    "volume block size"));
 			return (zfs_error(hdl, EZFS_BADPROP, errbuf));
 		}
 	}
@@ -3491,17 +3505,17 @@ zfs_create(libzfs_handle_t *hdl, const char *path, zfs_type_t type,
 		switch (errno) {
 		case ENOENT:
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "no such parent '%s'"), parent);
+			    "reason=no such parent '%s'"), parent);
 			return (zfs_error(hdl, EZFS_NOENT, errbuf));
 
 		case EINVAL:
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "parent '%s' is not a filesystem"), parent);
+			    "reason=parent '%s' is not a filesystem"), parent);
 			return (zfs_error(hdl, EZFS_BADTYPE, errbuf));
 
 		case ENOTSUP:
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "pool must be upgraded to set this "
+			    "reason=pool must be upgraded to set this "
 			    "property or value"));
 			return (zfs_error(hdl, EZFS_BADVERSION, errbuf));
 #ifdef _ILP32
@@ -3539,8 +3553,10 @@ zfs_destroy(zfs_handle_t *zhp, boolean_t defer)
 		fnvlist_free(nv);
 		if (error != 0) {
 			return (zfs_standard_error_fmt(zhp->zfs_hdl, errno,
-			    dgettext(TEXT_DOMAIN, "cannot destroy '%s'"),
-			    zhp->zfs_name));
+			    dgettext(TEXT_DOMAIN,
+			    "ecode=cstor.cannot.destroy.dataset "
+			    "rname=%s msg=cannot destroy '%s'"),
+			    zhp->zfs_name, zhp->zfs_name));
 		}
 		return (0);
 	}
@@ -3557,8 +3573,9 @@ zfs_destroy(zfs_handle_t *zhp, boolean_t defer)
 	if (zfs_ioctl(zhp->zfs_hdl, ZFS_IOC_DESTROY, &zc) != 0 &&
 	    errno != ENOENT) {
 		return (zfs_standard_error_fmt(zhp->zfs_hdl, errno,
-		    dgettext(TEXT_DOMAIN, "cannot destroy '%s'"),
-		    zhp->zfs_name));
+		    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.destroy.dataset "
+		    "rname=%s msg=cannot destroy '%s'"),
+		    zhp->zfs_name, zhp->zfs_name));
 	}
 
 	remove_mountpoint(zhp);
@@ -3605,8 +3622,9 @@ zfs_destroy_snaps(zfs_handle_t *zhp, char *snapname, boolean_t defer)
 
 	if (nvlist_empty(dd.nvl)) {
 		ret = zfs_standard_error_fmt(zhp->zfs_hdl, ENOENT,
-		    dgettext(TEXT_DOMAIN, "cannot destroy '%s@%s'"),
-		    zhp->zfs_name, snapname);
+		    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.destroy.snapshot "
+		    "rname=%s@%s msg=cannot destroy '%s@%s'"),
+		    zhp->zfs_name, snapname, zhp->zfs_name, snapname);
 	} else {
 		ret = zfs_destroy_snaps_nvl(zhp->zfs_hdl, dd.nvl, defer);
 	}
@@ -3634,7 +3652,9 @@ zfs_destroy_snaps_nvl(libzfs_handle_t *hdl, nvlist_t *snaps, boolean_t defer)
 	if (nvlist_empty(errlist)) {
 		char errbuf[1024];
 		(void) snprintf(errbuf, sizeof (errbuf),
-		    dgettext(TEXT_DOMAIN, "cannot destroy snapshots"));
+		    dgettext(TEXT_DOMAIN,
+		    "ecode=cstor.cannot.destroy.snapshots "
+		    "msg=cannot destroy snapshots"));
 
 		ret = zfs_standard_error(hdl, ret, errbuf);
 	}
@@ -3642,13 +3662,14 @@ zfs_destroy_snaps_nvl(libzfs_handle_t *hdl, nvlist_t *snaps, boolean_t defer)
 	    pair != NULL; pair = nvlist_next_nvpair(errlist, pair)) {
 		char errbuf[1024];
 		(void) snprintf(errbuf, sizeof (errbuf),
-		    dgettext(TEXT_DOMAIN, "cannot destroy snapshot %s"),
-		    nvpair_name(pair));
+		    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.destroy.snapshot "
+		    "rname=%s msg=cannot destroy snapshot %s"),
+		    nvpair_name(pair), nvpair_name(pair));
 
 		switch (fnvpair_value_int32(pair)) {
 		case EEXIST:
 			zfs_error_aux(hdl,
-			    dgettext(TEXT_DOMAIN, "snapshot is cloned"));
+			    dgettext(TEXT_DOMAIN, "reason=snapshot is cloned"));
 			ret = zfs_error(hdl, EZFS_EXISTS, errbuf);
 			break;
 		default:
@@ -3676,7 +3697,8 @@ zfs_clone(zfs_handle_t *zhp, const char *target, nvlist_t *props)
 	assert(zhp->zfs_type == ZFS_TYPE_SNAPSHOT);
 
 	(void) snprintf(errbuf, sizeof (errbuf), dgettext(TEXT_DOMAIN,
-	    "cannot create '%s'"), target);
+	    "ecode=cstor.cannot.create.clone rname=%s msg=cannot create '%s'"),
+	    target, target);
 
 	/* validate the target/clone name */
 	if (!zfs_validate_name(hdl, target, ZFS_TYPE_FILESYSTEM, B_TRUE))
@@ -3719,12 +3741,12 @@ zfs_clone(zfs_handle_t *zhp, const char *target, nvlist_t *props)
 			 * dataset doesn't exist.
 			 */
 			zfs_error_aux(zhp->zfs_hdl, dgettext(TEXT_DOMAIN,
-			    "no such parent '%s'"), parent);
+			    "reason=no such parent '%s'"), parent);
 			return (zfs_error(zhp->zfs_hdl, EZFS_NOENT, errbuf));
 
 		case EXDEV:
 			zfs_error_aux(zhp->zfs_hdl, dgettext(TEXT_DOMAIN,
-			    "source and target pools differ"));
+			    "reason=source and target pools differ"));
 			return (zfs_error(zhp->zfs_hdl, EZFS_CROSSTARGET,
 			    errbuf));
 
@@ -3749,17 +3771,18 @@ zfs_promote(zfs_handle_t *zhp)
 	char errbuf[1024];
 
 	(void) snprintf(errbuf, sizeof (errbuf), dgettext(TEXT_DOMAIN,
-	    "cannot promote '%s'"), zhp->zfs_name);
+	    "ecode=cstor.cannot.promote.clone rname=%s "
+	    "msg=cannot promote '%s'"), zhp->zfs_name, zhp->zfs_name);
 
 	if (zhp->zfs_type == ZFS_TYPE_SNAPSHOT) {
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-		    "snapshots can not be promoted"));
+		    "reason=snapshots can not be promoted"));
 		return (zfs_error(hdl, EZFS_BADTYPE, errbuf));
 	}
 
 	if (zhp->zfs_dmustats.dds_origin[0] == '\0') {
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-		    "not a cloned filesystem"));
+		    "reason=not a cloned filesystem"));
 		return (zfs_error(hdl, EZFS_BADTYPE, errbuf));
 	}
 
@@ -3770,7 +3793,8 @@ zfs_promote(zfs_handle_t *zhp)
 		case EEXIST:
 			/* There is a conflicting snapshot name. */
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "conflicting snapshot '%s' from parent '%s'"),
+			    "reason=conflicting snapshot '%s' from "
+			    "parent '%s'"),
 			    snapname, zhp->zfs_dmustats.dds_origin);
 			return (zfs_error(hdl, EZFS_EXISTS, errbuf));
 
@@ -3822,7 +3846,8 @@ zfs_snapshot_nvl(libzfs_handle_t *hdl, nvlist_t *snaps, nvlist_t *props)
 	char pool[ZFS_MAX_DATASET_NAME_LEN];
 
 	(void) snprintf(errbuf, sizeof (errbuf), dgettext(TEXT_DOMAIN,
-	    "cannot create snapshots "));
+	    "ecode=cstor.cannot.create.snapshots "
+	    "msg=cannot create snapshots "));
 
 	elem = NULL;
 	while ((elem = nvlist_next_nvpair(snaps, elem)) != NULL) {
@@ -3833,7 +3858,9 @@ zfs_snapshot_nvl(libzfs_handle_t *hdl, nvlist_t *snaps, nvlist_t *props)
 		    B_TRUE)) {
 			(void) snprintf(errbuf, sizeof (errbuf),
 			    dgettext(TEXT_DOMAIN,
-			    "cannot create snapshot '%s'"), snapname);
+			    "ecode=cstor.cannot.create.snapshot "
+			    "rname=%s msg=cannot create snapshot '%s'"),
+			    snapname, snapname);
 			return (zfs_error(hdl, EZFS_INVALIDNAME, errbuf));
 		}
 	}
@@ -3866,7 +3893,9 @@ zfs_snapshot_nvl(libzfs_handle_t *hdl, nvlist_t *snaps, nvlist_t *props)
 		    elem = nvlist_next_nvpair(errors, elem)) {
 			(void) snprintf(errbuf, sizeof (errbuf),
 			    dgettext(TEXT_DOMAIN,
-			    "cannot create snapshot '%s'"), nvpair_name(elem));
+			    "ecode=cstor.cannot.create.snapshot "
+			    "rname=%s msg=cannot create snapshot '%s'"),
+			    nvpair_name(elem), nvpair_name(elem));
 			(void) zfs_standard_error(hdl,
 			    fnvpair_value_int32(elem), errbuf);
 			printed = B_TRUE;
@@ -3875,7 +3904,7 @@ zfs_snapshot_nvl(libzfs_handle_t *hdl, nvlist_t *snaps, nvlist_t *props)
 			switch (ret) {
 			case EXDEV:
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "multiple snapshots of same "
+				    "reason=multiple snapshots of same "
 				    "fs not allowed"));
 				(void) zfs_error(hdl, EZFS_EXISTS, errbuf);
 
@@ -3903,7 +3932,8 @@ zfs_snapshot(libzfs_handle_t *hdl, const char *path, boolean_t recursive,
 	char errbuf[1024];
 
 	(void) snprintf(errbuf, sizeof (errbuf), dgettext(TEXT_DOMAIN,
-	    "cannot snapshot %s"), path);
+	    "ecode=cstor.cannot.create.snapshot rname=%s "
+	    "msg=cannot snapshot %s"), path, path);
 
 	if (!zfs_validate_name(hdl, path, ZFS_TYPE_SNAPSHOT, B_TRUE))
 		return (zfs_error(hdl, EZFS_INVALIDNAME, errbuf));
@@ -4037,15 +4067,19 @@ zfs_rollback(zfs_handle_t *zhp, zfs_handle_t *snap, boolean_t force)
 	err = lzc_rollback_to(zhp->zfs_name, snap->zfs_name);
 	if (err == EXDEV) {
 		zfs_error_aux(zhp->zfs_hdl, dgettext(TEXT_DOMAIN,
-		    "'%s' is not the latest snapshot"), snap->zfs_name);
+		    "reason='%s' is not the latest snapshot"), snap->zfs_name);
 		(void) zfs_error_fmt(zhp->zfs_hdl, EZFS_BUSY,
-		    dgettext(TEXT_DOMAIN, "cannot rollback '%s'"),
-		    zhp->zfs_name);
+		    dgettext(TEXT_DOMAIN,
+		    "ecode=cstor.cannot.rollback.snapshot "
+		    "rname=%s msg=cannot rollback '%s'"),
+		    zhp->zfs_name, zhp->zfs_name);
 		return (err);
 	} else if (err != 0) {
 		(void) zfs_standard_error_fmt(zhp->zfs_hdl, errno,
-		    dgettext(TEXT_DOMAIN, "cannot rollback '%s'"),
-		    zhp->zfs_name);
+		    dgettext(TEXT_DOMAIN,
+		    "ecode=cstor.cannot.rollback.snapshot "
+		    "rname=%s msg=cannot rollback '%s'"),
+		    zhp->zfs_name, zhp->zfs_name);
 		return (err);
 	}
 
@@ -4090,7 +4124,8 @@ zfs_rename(zfs_handle_t *zhp, const char *target, boolean_t recursive,
 		return (0);
 
 	(void) snprintf(errbuf, sizeof (errbuf), dgettext(TEXT_DOMAIN,
-	    "cannot rename to '%s'"), target);
+	    "ecode=cstor.cannot.rename.dataset rname=%s "
+	    "msg=cannot rename to '%s'"), target, target);
 
 	/*
 	 * Make sure the target name is valid
@@ -4119,7 +4154,7 @@ zfs_rename(zfs_handle_t *zhp, const char *target, boolean_t recursive,
 			if (strncmp(zhp->zfs_name, target, delim - target)
 			    != 0 || zhp->zfs_name[delim - target] != '@') {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "snapshots must be part of same "
+				    "reason=snapshots must be part of same "
 				    "dataset"));
 				return (zfs_error(hdl, EZFS_CROSSTARGET,
 				    errbuf));
@@ -4130,7 +4165,7 @@ zfs_rename(zfs_handle_t *zhp, const char *target, boolean_t recursive,
 	} else {
 		if (recursive) {
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "recursive rename must be a snapshot"));
+			    "reason=recursive rename must be a snapshot"));
 			return (zfs_error(hdl, EZFS_BADTYPE, errbuf));
 		}
 
@@ -4146,26 +4181,27 @@ zfs_rename(zfs_handle_t *zhp, const char *target, boolean_t recursive,
 		if (strncmp(zhp->zfs_name, target, delim - target) != 0 ||
 		    zhp->zfs_name[delim - target] != '/') {
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "datasets must be within same pool"));
+			    "reason=datasets must be within same pool"));
 			return (zfs_error(hdl, EZFS_CROSSTARGET, errbuf));
 		}
 
 		/* new name cannot be a child of the current dataset name */
 		if (is_descendant(zhp->zfs_name, target)) {
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "New dataset name cannot be a descendant of "
+			    "reason=New dataset name cannot be a descendant of "
 			    "current dataset name"));
 			return (zfs_error(hdl, EZFS_INVALIDNAME, errbuf));
 		}
 	}
 
 	(void) snprintf(errbuf, sizeof (errbuf),
-	    dgettext(TEXT_DOMAIN, "cannot rename '%s'"), zhp->zfs_name);
+	    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.rename.dataset "
+	    "rname=%s msg=cannot rename '%s'"), zhp->zfs_name, zhp->zfs_name);
 
 	if (getzoneid() == GLOBAL_ZONEID &&
 	    zfs_prop_get_int(zhp, ZFS_PROP_ZONED)) {
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-		    "dataset is used in a non-global zone"));
+		    "reason=dataset is used in a non-global zone"));
 		return (zfs_error(hdl, EZFS_ZONED, errbuf));
 	}
 
@@ -4189,8 +4225,8 @@ zfs_rename(zfs_handle_t *zhp, const char *target, boolean_t recursive,
 
 		if (changelist_haszonedchild(cl)) {
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "child dataset with inherited mountpoint is used "
-			    "in a non-global zone"));
+			    "reason=child dataset with inherited "
+			    "mountpoint is used in a non-global zone"));
 			(void) zfs_error(hdl, EZFS_ZONED, errbuf);
 			ret = -1;
 			goto error;
@@ -4216,11 +4252,13 @@ zfs_rename(zfs_handle_t *zhp, const char *target, boolean_t recursive,
 		 * be in zc.zc_name
 		 */
 		(void) snprintf(errbuf, sizeof (errbuf), dgettext(TEXT_DOMAIN,
-		    "cannot rename '%s'"), zc.zc_name);
+		    "ecode=cstor.cannot.rename.dataset "
+		    "rname=%s msg=cannot rename '%s'"),
+		    zc.zc_name, zc.zc_name);
 
 		if (recursive && errno == EEXIST) {
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "a child dataset already has a snapshot "
+			    "reason=a child dataset already has a snapshot "
 			    "with the new name"));
 			(void) zfs_error(hdl, EZFS_EXISTS, errbuf);
 		} else {
@@ -4512,7 +4550,9 @@ zfs_userspace(zfs_handle_t *zhp, zfs_userquota_prop_t type,
 
 			(void) snprintf(errbuf, sizeof (errbuf),
 			    dgettext(TEXT_DOMAIN,
-			    "cannot get used/quota for %s"), zc.zc_name);
+			    "ecode=cstor.cannot.get.usedspace.of.dataset "
+			    "rname=%s msg=cannot get used/quota for %s"),
+			    zc.zc_name, zc.zc_name);
 			return (zfs_standard_error_fmt(hdl, errno, errbuf));
 		}
 		if (zc.zc_nvlist_dst_size == 0)
@@ -4578,8 +4618,9 @@ zfs_hold(zfs_handle_t *zhp, const char *snapname, const char *tag,
 		ret = ENOENT;
 		(void) snprintf(errbuf, sizeof (errbuf),
 		    dgettext(TEXT_DOMAIN,
-		    "cannot hold snapshot '%s@%s'"),
-		    zhp->zfs_name, snapname);
+		    "ecode=cstor.cannot.hold.snapshot "
+		    "rname=%s@%s msg=cannot hold snapshot '%s@%s'"),
+		    zhp->zfs_name, snapname, zhp->zfs_name, snapname);
 		(void) zfs_standard_error(zhp->zfs_hdl, ret, errbuf);
 		return (ret);
 	}
@@ -4611,11 +4652,12 @@ zfs_hold_nvl(zfs_handle_t *zhp, int cleanup_fd, nvlist_t *holds)
 	if (nvlist_empty(errors)) {
 		/* no hold-specific errors */
 		(void) snprintf(errbuf, sizeof (errbuf),
-		    dgettext(TEXT_DOMAIN, "cannot hold"));
+		    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.hold "
+		    "msg=cannot hold"));
 		switch (ret) {
 		case ENOTSUP:
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "pool must be upgraded"));
+			    "reason=pool must be upgraded"));
 			(void) zfs_error(hdl, EZFS_BADVERSION, errbuf);
 			break;
 		case EINVAL:
@@ -4631,7 +4673,9 @@ zfs_hold_nvl(zfs_handle_t *zhp, int cleanup_fd, nvlist_t *holds)
 	    elem = nvlist_next_nvpair(errors, elem)) {
 		(void) snprintf(errbuf, sizeof (errbuf),
 		    dgettext(TEXT_DOMAIN,
-		    "cannot hold snapshot '%s'"), nvpair_name(elem));
+		    "ecode=cstor.cannot.hold.snapshot "
+		    "rname=%s msg=cannot hold snapshot '%s'"),
+		    nvpair_name(elem), nvpair_name(elem));
 		switch (fnvpair_value_int32(elem)) {
 		case E2BIG:
 			/*
@@ -4712,8 +4756,10 @@ zfs_release(zfs_handle_t *zhp, const char *snapname, const char *tag,
 		ret = ha.error;
 		(void) snprintf(errbuf, sizeof (errbuf),
 		    dgettext(TEXT_DOMAIN,
-		    "cannot release hold from snapshot '%s@%s'"),
-		    zhp->zfs_name, snapname);
+		    "ecode=cstor.cannot.release.snapshot "
+		    "rname=%s@%s msg=cannot release hold from "
+		    "snapshot '%s@%s'"),
+		    zhp->zfs_name, snapname, zhp->zfs_name, snapname);
 		if (ret == ESRCH) {
 			(void) zfs_error(hdl, EZFS_REFTAG_RELE, errbuf);
 		} else {
@@ -4734,11 +4780,11 @@ zfs_release(zfs_handle_t *zhp, const char *snapname, const char *tag,
 	if (nvlist_empty(errors)) {
 		/* no hold-specific errors */
 		(void) snprintf(errbuf, sizeof (errbuf), dgettext(TEXT_DOMAIN,
-		    "cannot release"));
+		    "ecode=cstor.cannot.release msg=cannot release"));
 		switch (errno) {
 		case ENOTSUP:
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "pool must be upgraded"));
+			    "reason=pool must be upgraded"));
 			(void) zfs_error(hdl, EZFS_BADVERSION, errbuf);
 			break;
 		default:
@@ -4751,8 +4797,9 @@ zfs_release(zfs_handle_t *zhp, const char *snapname, const char *tag,
 	    elem = nvlist_next_nvpair(errors, elem)) {
 		(void) snprintf(errbuf, sizeof (errbuf),
 		    dgettext(TEXT_DOMAIN,
-		    "cannot release hold from snapshot '%s'"),
-		    nvpair_name(elem));
+		    "ecode=cstor.cannot.release.snapshot "
+		    "rname=%s msg=cannot release hold from "
+		    "snapshot '%s'"), nvpair_name(elem), nvpair_name(elem));
 		switch (fnvpair_value_int32(elem)) {
 		case ESRCH:
 			(void) zfs_error(hdl, EZFS_REFTAG_RELE, errbuf);
@@ -4798,8 +4845,9 @@ tryagain:
 
 	if (uzfs_ioctl(hdl->libzfs_fd, ZFS_IOC_GET_FSACL, &zc) != 0) {
 		(void) snprintf(errbuf, sizeof (errbuf),
-		    dgettext(TEXT_DOMAIN, "cannot get permissions on '%s'"),
-		    zc.zc_name);
+		    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.get.permissions "
+		    "rname=%s msg=cannot get permissions on '%s'"),
+		    zc.zc_name, zc.zc_name);
 		switch (errno) {
 		case ENOMEM:
 			free(nvbuf);
@@ -4808,7 +4856,7 @@ tryagain:
 
 		case ENOTSUP:
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "pool must be upgraded"));
+			    "reason=pool must be upgraded"));
 			err = zfs_error(hdl, EZFS_BADVERSION, errbuf);
 			break;
 		case EINVAL:
@@ -4826,8 +4874,9 @@ tryagain:
 		int rc = nvlist_unpack(nvbuf, zc.zc_nvlist_dst_size, nvl, 0);
 		if (rc) {
 			(void) snprintf(errbuf, sizeof (errbuf), dgettext(
-			    TEXT_DOMAIN, "cannot get permissions on '%s'"),
-			    zc.zc_name);
+			    TEXT_DOMAIN, "ecode=cstor.cannot.get.permissions "
+			    "rname=%s msg=cannot get permissions on '%s'"),
+			    zc.zc_name, zc.zc_name);
 			err = zfs_standard_error_fmt(hdl, rc, errbuf);
 		}
 	}
@@ -4866,12 +4915,13 @@ zfs_set_fsacl(zfs_handle_t *zhp, boolean_t un, nvlist_t *nvl)
 
 	if (zfs_ioctl(hdl, ZFS_IOC_SET_FSACL, &zc) != 0) {
 		(void) snprintf(errbuf, sizeof (errbuf),
-		    dgettext(TEXT_DOMAIN, "cannot set permissions on '%s'"),
-		    zc.zc_name);
+		    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.set.permissions "
+		    "rname=%s msg=cannot set permissions on '%s'"),
+		    zc.zc_name, zc.zc_name);
 		switch (errno) {
 		case ENOTSUP:
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "pool must be upgraded"));
+			    "reason=pool must be upgraded"));
 			err = zfs_error(hdl, EZFS_BADVERSION, errbuf);
 			break;
 		case EINVAL:
@@ -4903,12 +4953,13 @@ zfs_get_holds(zfs_handle_t *zhp, nvlist_t **nvl)
 		libzfs_handle_t *hdl = zhp->zfs_hdl;
 
 		(void) snprintf(errbuf, sizeof (errbuf),
-		    dgettext(TEXT_DOMAIN, "cannot get holds for '%s'"),
-		    zhp->zfs_name);
+		    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.get.holds "
+		    "rname=%s msg=cannot get holds for '%s'"),
+		    zhp->zfs_name, zhp->zfs_name);
 		switch (err) {
 		case ENOTSUP:
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "pool must be upgraded"));
+			    "reason=pool must be upgraded"));
 			err = zfs_error(hdl, EZFS_BADVERSION, errbuf);
 			break;
 		case EINVAL:

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -466,14 +466,14 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 			if (err != 0) {
 				ASSERT3U(err, ==, ENOENT);
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "invalid feature '%s'"), fname);
+				    "reason=invalid feature '%s'"), fname);
 				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 				goto error;
 			}
 
 			if (nvpair_type(elem) != DATA_TYPE_STRING) {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "'%s' must be a string"), propname);
+				    "reason='%s' must be a string"), propname);
 				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 				goto error;
 			}
@@ -482,7 +482,7 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 			if (strcmp(strval, ZFS_FEATURE_ENABLED) != 0 &&
 			    strcmp(strval, ZFS_FEATURE_DISABLED) != 0) {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "property '%s' can only be set to "
+				    "reason=property '%s' can only be set to "
 				    "'enabled' or 'disabled'"), propname);
 				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 				goto error;
@@ -500,13 +500,13 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 		 */
 		if (prop == ZPROP_INVAL) {
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "invalid property '%s'"), propname);
+			    "reason=invalid property '%s'"), propname);
 			(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 			goto error;
 		}
 
 		if (zpool_prop_readonly(prop)) {
-			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "'%s' "
+			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "reason='%s' "
 			    "is readonly"), propname);
 			(void) zfs_error(hdl, EZFS_PROPREADONLY, errbuf);
 			goto error;
@@ -524,8 +524,8 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 			if (intval < version ||
 			    !SPA_VERSION_IS_SUPPORTED(intval)) {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "property '%s' number %d is invalid."),
-				    propname, intval);
+				    "reason=property '%s' number %d "
+				    "is invalid."), propname, intval);
 				(void) zfs_error(hdl, EZFS_BADVERSION, errbuf);
 				goto error;
 			}
@@ -535,9 +535,9 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 			if (intval != 0 &&
 			    (intval < ASHIFT_MIN || intval > ASHIFT_MAX)) {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "invalid '%s=%d' property: only values "
-				    "between %" PRId32 " and %" PRId32 " "
-				    "are allowed.\n"),
+				    "reason=invalid '%s=%d' property: only "
+				    "values between %" PRId32
+				    " and %" PRId32 " are allowed.\n"),
 				    propname, intval, ASHIFT_MIN, ASHIFT_MAX);
 				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 				goto error;
@@ -547,15 +547,16 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 		case ZPOOL_PROP_BOOTFS:
 			if (flags.create || flags.import) {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "property '%s' cannot be set at creation "
-				    "or import time"), propname);
+				    "reason=property '%s' cannot be set at "
+				    "creation or import time"),
+				    propname);
 				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 				goto error;
 			}
 
 			if (version < SPA_VERSION_BOOTFS) {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "pool must be upgraded to support "
+				    "reason=pool must be upgraded to support "
 				    "'%s' property"), propname);
 				(void) zfs_error(hdl, EZFS_BADVERSION, errbuf);
 				goto error;
@@ -567,15 +568,17 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 			 */
 			if (strval[0] != '\0' && !bootfs_name_valid(poolname,
 			    strval)) {
-				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "'%s' "
-				    "is an invalid name"), strval);
+				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
+				    "reason='%s' is an invalid name"),
+				    strval);
 				(void) zfs_error(hdl, EZFS_INVALIDNAME, errbuf);
 				goto error;
 			}
 
 			if ((zhp = zpool_open_canfail(hdl, poolname)) == NULL) {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "could not open pool '%s'"), poolname);
+				    "reason=could not open pool '%s'"),
+				    poolname);
 				(void) zfs_error(hdl, EZFS_OPENFAILED, errbuf);
 				goto error;
 			}
@@ -585,15 +588,16 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 		case ZPOOL_PROP_ALTROOT:
 			if (!flags.create && !flags.import) {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "property '%s' can only be set during pool "
-				    "creation or import"), propname);
+				    "reason=property '%s' can only be set "
+				    "during pool creation or import"),
+				    propname);
 				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 				goto error;
 			}
 
 			if (strval[0] != '/') {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "bad alternate root '%s'"), strval);
+				    "reason=bad alternate root '%s'"), strval);
 				(void) zfs_error(hdl, EZFS_BADPATH, errbuf);
 				goto error;
 			}
@@ -608,7 +612,7 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 
 			if (strval[0] != '/') {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "property '%s' must be empty, an "
+				    "reason=property '%s' must be empty, an "
 				    "absolute path, or 'none'"), propname);
 				(void) zfs_error(hdl, EZFS_BADPATH, errbuf);
 				goto error;
@@ -619,7 +623,7 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 			if (slash[1] == '\0' || strcmp(slash, "/.") == 0 ||
 			    strcmp(slash, "/..") == 0) {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "'%s' is not a valid file"), strval);
+				    "reason='%s' is not a valid file"), strval);
 				(void) zfs_error(hdl, EZFS_BADPATH, errbuf);
 				goto error;
 			}
@@ -630,7 +634,7 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 			    (stat64(strval, &statbuf) != 0 ||
 			    !S_ISDIR(statbuf.st_mode))) {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "'%s' is not a valid directory"),
+				    "reason='%s' is not a valid directory"),
 				    strval);
 				(void) zfs_error(hdl, EZFS_BADPATH, errbuf);
 				goto error;
@@ -644,8 +648,8 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 				if (!isprint(*check)) {
 					zfs_error_aux(hdl,
 					    dgettext(TEXT_DOMAIN,
-					    "comment may only have printable "
-					    "characters"));
+					    "reason=comment may only have "
+					    "printable characters"));
 					(void) zfs_error(hdl, EZFS_BADPROP,
 					    errbuf);
 					goto error;
@@ -653,7 +657,8 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 			}
 			if (strlen(strval) > ZPROP_MAX_COMMENT) {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "comment must not exceed %d characters"),
+				    "reason=comment must not exceed %d "
+				    "characters"),
 				    ZPROP_MAX_COMMENT);
 				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 				goto error;
@@ -662,7 +667,7 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 		case ZPOOL_PROP_READONLY:
 			if (!flags.import) {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "property '%s' can only be set at "
+				    "reason=property '%s' can only be set at "
 				    "import time"), propname);
 				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 				goto error;
@@ -671,7 +676,7 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 		case ZPOOL_PROP_TNAME:
 			if (!flags.create) {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "property '%s' can only be set at "
+				    "reason=property '%s' can only be set at "
 				    "creation time"), propname);
 				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 				goto error;
@@ -680,14 +685,16 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 		case ZPOOL_PROP_MULTIHOST:
 			if (get_system_hostid() == 0) {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "requires a non-zero system hostid"));
+				    "reason=requires a non-zero system "
+				    "hostid"));
 				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 				goto error;
 			}
 			break;
 		default:
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "property '%s'(%d) not defined"), propname, prop);
+			    "reason=property '%s'(%d) not defined"),
+			    propname, prop);
 			break;
 		}
 	}
@@ -713,8 +720,9 @@ zpool_set_prop(zpool_handle_t *zhp, const char *propname, const char *propval)
 	prop_flags_t flags = { 0 };
 
 	(void) snprintf(errbuf, sizeof (errbuf),
-	    dgettext(TEXT_DOMAIN, "cannot set property for '%s'"),
-	    zhp->zpool_name);
+	    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.set.property "
+	    "rname=%s msg=cannot set property for '%s'"),
+	    zhp->zpool_name, zhp->zpool_name);
 
 	if (nvlist_alloc(&nvl, NV_UNIQUE_NAME, 0) != 0)
 		return (no_memory(zhp->zpool_hdl));
@@ -960,12 +968,14 @@ zpool_name_valid(libzfs_handle_t *hdl, boolean_t isopen, const char *pool)
 			switch (why) {
 			case NAME_ERR_TOOLONG:
 				zfs_error_aux(hdl,
-				    dgettext(TEXT_DOMAIN, "reason=name is too long"));
+				    dgettext(TEXT_DOMAIN,
+				    "reason=name is too long"));
 				break;
 
 			case NAME_ERR_INVALCHAR:
 				zfs_error_aux(hdl,
-				    dgettext(TEXT_DOMAIN, "reason=invalid character "
+				    dgettext(TEXT_DOMAIN,
+				    "reason=invalid character "
 				    "'%c' in pool name"), what);
 				break;
 
@@ -1001,8 +1011,8 @@ zpool_name_valid(libzfs_handle_t *hdl, boolean_t isopen, const char *pool)
 
 			case NAME_ERR_MULTIPLE_DELIMITERS:
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "reason=multiple '@' and/or '#' delimiters in "
-				    "name"));
+				    "reason=multiple '@' and/or '#' delimiters "
+				    "in name"));
 				break;
 
 			case NAME_ERR_NO_AT:
@@ -1037,8 +1047,9 @@ zpool_open_canfail(libzfs_handle_t *hdl, const char *pool)
 	 */
 	if (!zpool_name_valid(hdl, B_TRUE, pool)) {
 		(void) zfs_error_fmt(hdl, EZFS_INVALIDNAME,
-		    dgettext(TEXT_DOMAIN, "cannot open '%s'"),
-		    pool);
+		    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.open.pool "
+		    "rname=%s msg=cannot open '%s'"),
+		    pool, pool);
 		return (NULL);
 	}
 
@@ -1054,9 +1065,12 @@ zpool_open_canfail(libzfs_handle_t *hdl, const char *pool)
 	}
 
 	if (missing) {
-		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "no such pool"));
+		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
+		    "reason=no such pool"));
 		(void) zfs_error_fmt(hdl, EZFS_NOENT,
-		    dgettext(TEXT_DOMAIN, "cannot open '%s'"), pool);
+		    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.open.pool "
+		    "rname=%s msg=cannot open '%s'"),
+		    pool, pool);
 		zpool_close(zhp);
 		return (NULL);
 	}
@@ -1109,7 +1123,9 @@ zpool_open(libzfs_handle_t *hdl, const char *pool)
 
 	if (zhp->zpool_state == POOL_STATE_UNAVAIL) {
 		(void) zfs_error_fmt(hdl, EZFS_POOLUNAVAIL,
-		    dgettext(TEXT_DOMAIN, "cannot open '%s'"), zhp->zpool_name);
+		    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.open.pool "
+		    "rname=%s msg=cannot open '%s'"),
+		    zhp->zpool_name, zhp->zpool_name);
 		zpool_close(zhp);
 		return (NULL);
 	}
@@ -1164,7 +1180,8 @@ zpool_create(libzfs_handle_t *hdl, const char *pool, nvlist_t *nvroot,
 	int ret = -1;
 
 	(void) snprintf(msg, sizeof (msg), dgettext(TEXT_DOMAIN,
-	    "ecode=cstor.cannot.create.pool rname=%s msg=cannot create '%s'"), pool, pool);
+	    "ecode=cstor.cannot.create.pool rname=%s "
+	    "msg=cannot create '%s'"), pool, pool);
 
 	if (!zpool_name_valid(hdl, B_FALSE, pool))
 		return (zfs_error(hdl, EZFS_INVALIDNAME, msg));
@@ -1224,8 +1241,8 @@ zpool_create(libzfs_handle_t *hdl, const char *pool, nvlist_t *nvroot,
 			 * part of an active md or lvm device.
 			 */
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "reason=one or more vdevs refer to the same device, or "
-			    "one of the devices is part of an active md or "
+			    "reason=one or more vdevs refer to the same device,"
+			    " or one of the devices is part of an active md or "
 			    "lvm device"));
 			return (zfs_error(hdl, EZFS_BADDEV, msg));
 
@@ -1258,8 +1275,8 @@ zpool_create(libzfs_handle_t *hdl, const char *pool, nvlist_t *nvroot,
 				    sizeof (buf));
 
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "reason=one or more devices is less than the "
-				    "minimum size (%s)"), buf);
+				    "reason=one or more devices is less than"
+				    " the minimum size (%s)"), buf);
 			}
 			return (zfs_error(hdl, EZFS_BADDEV, msg));
 
@@ -1270,7 +1287,8 @@ zpool_create(libzfs_handle_t *hdl, const char *pool, nvlist_t *nvroot,
 
 		case ENOTBLK:
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "reason=cache device must be a disk or disk slice"));
+			    "reason=cache device must be a disk "
+			    "or disk slice"));
 			return (zfs_error(hdl, EZFS_BADDEV, msg));
 
 		default:
@@ -1306,7 +1324,9 @@ zpool_destroy(zpool_handle_t *zhp, const char *log_str)
 
 	if (zfs_ioctl(hdl, ZFS_IOC_POOL_DESTROY, &zc) != 0) {
 		(void) snprintf(msg, sizeof (msg), dgettext(TEXT_DOMAIN,
-		    "ecode=cstor.cannot.destroy.pool rname=%s msg=cannot destroy '%s'"), zhp->zpool_name, zhp->zpool_name);
+		    "ecode=cstor.cannot.destroy.pool rname=%s "
+		    "msg=cannot destroy '%s'"), zhp->zpool_name,
+		    zhp->zpool_name);
 
 		if (errno == EROFS) {
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
@@ -1344,7 +1364,8 @@ zpool_add(zpool_handle_t *zhp, nvlist_t *nvroot)
 	uint_t nspares, nl2cache;
 
 	(void) snprintf(msg, sizeof (msg), dgettext(TEXT_DOMAIN,
-	    "ecode=cstor.cannot.add.to.pool rname=%s msg=cannot add to '%s'"), zhp->zpool_name, zhp->zpool_name);
+	    "ecode=cstor.cannot.add.to.pool rname=%s "
+	    "msg=cannot add to '%s'"), zhp->zpool_name, zhp->zpool_name);
 
 	if (zpool_get_prop_int(zhp, ZPOOL_PROP_VERSION, NULL) <
 	    SPA_VERSION_SPARES &&
@@ -1378,7 +1399,8 @@ zpool_add(zpool_handle_t *zhp, nvlist_t *nvroot)
 			 * label.
 			 */
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "reason=one or more vdevs refer to the same device"));
+			    "reason=one or more vdevs refer to "
+			    "the same device"));
 			(void) zfs_error(hdl, EZFS_BADDEV, msg);
 			break;
 
@@ -1410,7 +1432,8 @@ zpool_add(zpool_handle_t *zhp, nvlist_t *nvroot)
 
 		case ENOTBLK:
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "reason=cache device must be a disk or disk slice"));
+			    "reason=cache device must be a disk"
+			    " or disk slice"));
 			(void) zfs_error(hdl, EZFS_BADDEV, msg);
 			break;
 
@@ -1440,7 +1463,8 @@ zpool_export_common(zpool_handle_t *zhp, boolean_t force, boolean_t hardforce,
 	char msg[1024];
 
 	(void) snprintf(msg, sizeof (msg), dgettext(TEXT_DOMAIN,
-	    "cannot export '%s'"), zhp->zpool_name);
+	    "ecode=cstor.cannot.export.pool rname=%s msg=cannot export '%s'"),
+	    zhp->zpool_name, zhp->zpool_name);
 
 	(void) strlcpy(zc.zc_name, zhp->zpool_name, sizeof (zc.zc_name));
 	zc.zc_cookie = force;
@@ -1451,7 +1475,7 @@ zpool_export_common(zpool_handle_t *zhp, boolean_t force, boolean_t hardforce,
 		switch (errno) {
 		case EXDEV:
 			zfs_error_aux(zhp->zpool_hdl, dgettext(TEXT_DOMAIN,
-			    "use '-f' to override the following errors:\n"
+			    "reason=use '-f' to override the following errors: "
 			    "'%s' has an active shared spare which could be"
 			    " used by other pools once '%s' is exported."),
 			    zhp->zpool_name, zhp->zpool_name);
@@ -1627,8 +1651,9 @@ zpool_import(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
 	if (altroot != NULL) {
 		if (nvlist_alloc(&props, NV_UNIQUE_NAME, 0) != 0) {
 			return (zfs_error_fmt(hdl, EZFS_NOMEM,
-			    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.import.pool rname=%s msg=cannot import '%s'"),
-			    newname, newname));
+			    dgettext(TEXT_DOMAIN,
+			    "ecode=cstor.cannot.import.pool rname=%s "
+			    "msg=cannot import '%s'"), newname, newname));
 		}
 
 		if (nvlist_add_string(props,
@@ -1637,8 +1662,9 @@ zpool_import(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
 		    zpool_prop_to_name(ZPOOL_PROP_CACHEFILE), "none") != 0) {
 			nvlist_free(props);
 			return (zfs_error_fmt(hdl, EZFS_NOMEM,
-			    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.import.pool rname=%s msg=cannot import '%s'"),
-			    newname, newname));
+			    dgettext(TEXT_DOMAIN,
+			    "ecode=cstor.cannot.import.pool rname=%s "
+			    "msg=cannot import '%s'"), newname, newname));
 		}
 	}
 
@@ -1725,12 +1751,15 @@ zpool_import_props(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
 	    &origname) == 0);
 
 	(void) snprintf(errbuf, sizeof (errbuf), dgettext(TEXT_DOMAIN,
-	    "ecode=cstor.cannot.import.pool rname=%s msg=cannot import pool '%s'"), origname, origname);
+	    "ecode=cstor.cannot.import.pool rname=%s "
+	    "msg=cannot import pool '%s'"), origname, origname);
 
 	if (newname != NULL) {
 		if (!zpool_name_valid(hdl, B_FALSE, newname))
 			return (zfs_error_fmt(hdl, EZFS_INVALIDNAME,
-			    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.import.pool rname=%s msg=cannot import '%s'"),
+			    dgettext(TEXT_DOMAIN,
+			    "ecode=cstor.cannot.import.pool rname=%s "
+			    "msg=cannot import '%s'"),
 			    newname, newname));
 		thename = (char *)newname;
 	} else {
@@ -1802,11 +1831,15 @@ zpool_import_props(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
 
 		if (newname == NULL)
 			(void) snprintf(desc, sizeof (desc),
-			    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.import.pool rname=%s msg=cannot import '%s'"),
+			    dgettext(TEXT_DOMAIN,
+			    "ecode=cstor.cannot.import.pool rname=%s "
+			    "msg=cannot import '%s'"),
 			    thename, thename);
 		else
 			(void) snprintf(desc, sizeof (desc),
-			    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.import.pool rname=%s msg=cannot import '%s' as '%s'"),
+			    dgettext(TEXT_DOMAIN,
+			    "ecode=cstor.cannot.import.pool "
+			    "rname=%s msg=cannot import '%s' as '%s'"),
 			    origname, origname, thename);
 
 		switch (error) {
@@ -1814,14 +1847,19 @@ zpool_import_props(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
 			if (nv != NULL && nvlist_lookup_nvlist(nv,
 			    ZPOOL_CONFIG_LOAD_INFO, &nvinfo) == 0 &&
 			    nvlist_exists(nvinfo, ZPOOL_CONFIG_UNSUP_FEAT)) {
-				(void) printf(dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.import.pool rname=%s msg=cannot import '%s' reason=This "
-				    "pool uses the following feature(s) not "
-				    "supported by this system: "), thename, thename);
+				(void) printf(dgettext(TEXT_DOMAIN,
+				    "ecode=cstor.cannot.import.pool "
+				    "rname=%s msg=cannot import '%s' "
+				    "reason=This pool uses "
+				    "the following feature(s) not "
+				    "supported by this system: "),
+				    thename, thename);
 				zpool_print_unsup_feat(nv);
 				if (nvlist_exists(nvinfo,
 				    ZPOOL_CONFIG_CAN_RDONLY)) {
 					(void) printf(dgettext(TEXT_DOMAIN,
-					    "All unsupported features are only "
+					    "einfo=All unsupported features "
+					    "are only "
 					    "required for writing to the pool."
 					    " The pool can be imported using "
 					    "'-o readonly=on'. "));
@@ -1855,18 +1893,29 @@ zpool_import_props(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
 
 				if (mmp_state == MMP_STATE_ACTIVE) {
 					(void) snprintf(aux, sizeof (aux),
-					    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.import.pool rname=%s msg=cannot import '%s' reason=pool is imp"
-					    "orted on host '%s' (hostid=%lx).\n"
-					    "Export the pool on the other "
+					    dgettext(TEXT_DOMAIN,
+					    "ecode=cstor.cannot.import.pool "
+					    "rname=%s "
+					    "msg=cannot import '%s' "
+					    "reason=pool is imported "
+					    "on host '%s' (hostid=%lx). "
+					    "einfo=Export the pool on the "
+					    "other "
 					    "system, then run 'zpool import'."),
-					    thename, thename, hostname, (unsigned long) hostid);
+					    thename, thename, hostname,
+					    (unsigned long) hostid);
 				} else if (mmp_state == MMP_STATE_NO_HOSTID) {
 					(void) snprintf(aux, sizeof (aux),
-					    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.import.pool rname=%s msg=cannot import '%s' reason=pool has "
+					    dgettext(TEXT_DOMAIN,
+					    "ecode=cstor.cannot.import.pool "
+					    "rname=%s msg=cannot import '%s' "
+					    "reason=pool has "
 					    "the multihost property on and "
 					    "the system's hostid is not set. "
-					    "Set a unique system hostid with "
-					    "the zgenhostid(8) command. "), thename, thename);
+					    "einfo=Set a unique system hostid "
+					    "with "
+					    "the zgenhostid(8) command. "),
+					    thename, thename);
 				}
 
 				(void) zfs_error_aux(hdl, aux);
@@ -1890,8 +1939,12 @@ zpool_import_props(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
 			    nvlist_lookup_nvlist(nvinfo,
 			    ZPOOL_CONFIG_MISSING_DEVICES, &missing) == 0) {
 				(void) printf(dgettext(TEXT_DOMAIN,
-				    "ecode=cstor.cannot.import.pool rname=%s msg=cannot import '%s' reason=The devices below are missing, use "
-				    "'-m' to import the pool anyway: "), thename, thename);
+				    "ecode=cstor.cannot.import.pool "
+				    "rname=%s msg=cannot import '%s' "
+				    "reason=The devices below are missing "
+				    "einfo=use '-m' to import the pool "
+				    "anyway: "),
+				    thename, thename);
 				print_vdev_tree(hdl, NULL, missing, 2);
 				(void) printf(" ");
 			}
@@ -1909,8 +1962,8 @@ zpool_import_props(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
 			break;
 		case ENAMETOOLONG:
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "reason=new name of at least one dataset is longer than "
-			    "the maximum allowable length"));
+			    "reason=new name of at least one dataset is longer"
+			    " than the maximum allowable length"));
 			(void) zfs_error(hdl, EZFS_NAMETOOLONG, desc);
 			break;
 		default:
@@ -1975,16 +2028,21 @@ zpool_scan(zpool_handle_t *zhp, pool_scan_func_t func, pool_scrub_cmd_t cmd)
 	if (func == POOL_SCAN_SCRUB) {
 		if (cmd == POOL_SCRUB_PAUSE) {
 			(void) snprintf(msg, sizeof (msg), dgettext(TEXT_DOMAIN,
-			    "cannot pause scrubbing %s"), zc.zc_name);
+			    "ecode=cstor.cannot.pause.scrubbing "
+			    "rname=%s msg=cannot pause scrubbing %s"),
+			    zc.zc_name, zc.zc_name);
 		} else {
 			assert(cmd == POOL_SCRUB_NORMAL);
 			(void) snprintf(msg, sizeof (msg), dgettext(TEXT_DOMAIN,
-			    "cannot scrub %s"), zc.zc_name);
+			    "ecode=cstor.cannot.scrub "
+			    "rname=%s msg=cannot scrub %s"),
+			    zc.zc_name, zc.zc_name);
 		}
 	} else if (func == POOL_SCAN_NONE) {
 		(void) snprintf(msg, sizeof (msg),
-		    dgettext(TEXT_DOMAIN, "cannot cancel scrubbing %s"),
-		    zc.zc_name);
+		    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.cancel.scrubbing "
+		    "rname=%s msg=cannot cancel scrubbing %s"),
+		    zc.zc_name, zc.zc_name);
 	} else {
 		assert(!"unexpected result");
 	}
@@ -2413,8 +2471,10 @@ zpool_relabel_disk(libzfs_handle_t *hdl, const char *path, const char *msg)
 	int fd, error;
 
 	if ((fd = open(path, O_RDWR|O_DIRECT)) < 0) {
-		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "cannot "
-		    "relabel '%s': unable to open device: %d"), path, errno);
+		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
+		    "ecode=cstor.cannot.relabel.disk rname=%s msg=cannot "
+		    "relabel '%s' reason=unable to open device: %d"),
+		    path, path, errno);
 		return (zfs_error(hdl, EZFS_OPENFAILED, msg));
 	}
 
@@ -2434,8 +2494,10 @@ zpool_relabel_disk(libzfs_handle_t *hdl, const char *path, const char *msg)
 
 	(void) close(fd);
 	if (error && error != VT_ENOSPC) {
-		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "cannot "
-		    "relabel '%s': unable to read disk capacity"), path);
+		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
+		    "ecode=cstor.cannot.relabel.disk rname=%s msg=cannot "
+		    "relabel '%s' reason=unable to read disk capacity"),
+		    path, path);
 		return (zfs_error(hdl, EZFS_NOCAP, msg));
 	}
 
@@ -2496,10 +2558,14 @@ zpool_vdev_online(zpool_handle_t *zhp, const char *path, int flags,
 
 	if (flags & ZFS_ONLINE_EXPAND) {
 		(void) snprintf(msg, sizeof (msg),
-		    dgettext(TEXT_DOMAIN, "cannot expand %s"), path);
+		    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.expand.vdev "
+		    "rname=%s msg=cannot expand %s"),
+		    path, path);
 	} else {
 		(void) snprintf(msg, sizeof (msg),
-		    dgettext(TEXT_DOMAIN, "cannot online %s"), path);
+		    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.make.vdev.online "
+		    "rname=%s msg=cannot online %s"),
+		    path, path);
 	}
 
 	(void) strlcpy(zc.zc_name, zhp->zpool_name, sizeof (zc.zc_name));
@@ -2524,7 +2590,8 @@ zpool_vdev_online(zpool_handle_t *zhp, const char *path, int flags,
 		 */
 		if (l2cache) {
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "cannot expand cache devices"));
+			    "ecode=cstor.cannot.expand.cache.devices "
+			    "msg=cannot expand cache devices"));
 			return (zfs_error(hdl, EZFS_VDEVNOTSUP, msg));
 		}
 
@@ -2553,8 +2620,9 @@ zpool_vdev_online(zpool_handle_t *zhp, const char *path, int flags,
 
 	if (zfs_ioctl(hdl, ZFS_IOC_VDEV_SET_STATE, &zc) != 0) {
 		if (errno == EINVAL) {
-			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "was split "
-			    "from this pool into a new one.  Use '%s' "
+			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
+			    "reason=was split "
+			    "from this pool into a new one.  einfo=Use '%s' "
 			    "instead"), "zpool detach");
 			return (zfs_error(hdl, EZFS_POSTSPLIT_ONLINE, msg));
 		}
@@ -2578,7 +2646,9 @@ zpool_vdev_offline(zpool_handle_t *zhp, const char *path, boolean_t istmp)
 	libzfs_handle_t *hdl = zhp->zpool_hdl;
 
 	(void) snprintf(msg, sizeof (msg),
-	    dgettext(TEXT_DOMAIN, "cannot offline %s"), path);
+	    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.make.vdev.offline "
+	    "rname=%s msg=cannot offline %s"),
+	    path, path);
 
 	(void) strlcpy(zc.zc_name, zhp->zpool_name, sizeof (zc.zc_name));
 	if ((tgt = zpool_find_vdev(zhp, path, &avail_spare, &l2cache,
@@ -2626,7 +2696,9 @@ zpool_vdev_fault(zpool_handle_t *zhp, uint64_t guid, vdev_aux_t aux)
 	libzfs_handle_t *hdl = zhp->zpool_hdl;
 
 	(void) snprintf(msg, sizeof (msg),
-	    dgettext(TEXT_DOMAIN, "cannot fault %llu"), (u_longlong_t)guid);
+	    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.make.vdev.faulted "
+	    "rname=%llu msg=cannot fault %llu"),
+	    (u_longlong_t)guid, (u_longlong_t)guid);
 
 	(void) strlcpy(zc.zc_name, zhp->zpool_name, sizeof (zc.zc_name));
 	zc.zc_guid = guid;
@@ -2661,7 +2733,9 @@ zpool_vdev_degrade(zpool_handle_t *zhp, uint64_t guid, vdev_aux_t aux)
 	libzfs_handle_t *hdl = zhp->zpool_hdl;
 
 	(void) snprintf(msg, sizeof (msg),
-	    dgettext(TEXT_DOMAIN, "cannot degrade %llu"), (u_longlong_t)guid);
+	    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.make.vdev.degraded "
+	    "rname=%llu msg=cannot degrade %llu"),
+	    (u_longlong_t)guid, (u_longlong_t)guid);
 
 	(void) strlcpy(zc.zc_name, zhp->zpool_name, sizeof (zc.zc_name));
 	zc.zc_guid = guid;
@@ -2725,10 +2799,14 @@ zpool_vdev_attach(zpool_handle_t *zhp,
 
 	if (replacing)
 		(void) snprintf(msg, sizeof (msg), dgettext(TEXT_DOMAIN,
-		    "cannot replace %s with %s"), old_disk, new_disk);
+		    "ecode=cstor.cannot.replace.disk rname=%s "
+		    "msg=cannot replace %s with %s"),
+		    old_disk, old_disk, new_disk);
 	else
 		(void) snprintf(msg, sizeof (msg), dgettext(TEXT_DOMAIN,
-		    "cannot attach %s to %s"), new_disk, old_disk);
+		    "ecode=cstor.cannot.attach.disk rname=%s "
+		    "msg=cannot attach %s to %s"),
+		    new_disk, new_disk, old_disk);
 
 	(void) strlcpy(zc.zc_name, zhp->zpool_name, sizeof (zc.zc_name));
 	if ((tgt = zpool_find_vdev(zhp, old_disk, &avail_spare, &l2cache,
@@ -2747,7 +2825,7 @@ zpool_vdev_attach(zpool_handle_t *zhp,
 	if (nvlist_lookup_nvlist_array(nvroot, ZPOOL_CONFIG_CHILDREN,
 	    &child, &children) != 0 || children != 1) {
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-		    "new device must be a single disk"));
+		    "reason=new device must be a single disk"));
 		return (zfs_error(hdl, EZFS_INVALCONFIG, msg));
 	}
 
@@ -2767,7 +2845,7 @@ zpool_vdev_attach(zpool_handle_t *zhp,
 	    NULL) == NULL || !avail_spare) &&
 	    is_replacing_spare(config_root, tgt, 1)) {
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-		    "can only be replaced by another hot spare"));
+		    "reason=can only be replaced by another hot spare"));
 		free(newname);
 		return (zfs_error(hdl, EZFS_BADTARGET, msg));
 	}
@@ -2787,7 +2865,8 @@ zpool_vdev_attach(zpool_handle_t *zhp,
 			 * XXX need a better way to prevent user from
 			 * booting up a half-baked vdev.
 			 */
-			(void) fprintf(stderr, dgettext(TEXT_DOMAIN, "Make "
+			(void) fprintf(stderr, dgettext(TEXT_DOMAIN,
+			    "einfo=Make "
 			    "sure to wait until resilver is done "
 			    "before rebooting.\n"));
 		}
@@ -2805,17 +2884,20 @@ zpool_vdev_attach(zpool_handle_t *zhp,
 
 			if (islog)
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "cannot replace a log with a spare"));
+				    "reason=cannot replace a log with "
+				    "a spare"));
 			else if (version >= SPA_VERSION_MULTI_REPLACE)
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "already in replacing/spare config; wait "
+				    "reason=already in replacing/spare config; "
+				    "einfo=wait "
 				    "for completion or use 'zpool detach'"));
 			else
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "cannot replace a replacing device"));
+				    "reason=cannot replace a "
+				    "replacing device"));
 		} else {
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "can only attach to mirrors and top-level "
+			    "reason=can only attach to mirrors and top-level "
 			    "disks"));
 		}
 		(void) zfs_error(hdl, EZFS_BADTARGET, msg);
@@ -2826,12 +2908,12 @@ zpool_vdev_attach(zpool_handle_t *zhp,
 		 * The new device must be a single disk.
 		 */
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-		    "new device must be a single disk"));
+		    "reason=new device must be a single disk"));
 		(void) zfs_error(hdl, EZFS_INVALCONFIG, msg);
 		break;
 
 	case EBUSY:
-		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "%s is busy"),
+		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "reason=%s is busy"),
 		    new_disk);
 		(void) zfs_error(hdl, EZFS_BADDEV, msg);
 		break;
@@ -2841,7 +2923,7 @@ zpool_vdev_attach(zpool_handle_t *zhp,
 		 * The new device is too small.
 		 */
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-		    "device is too small"));
+		    "reason=device is too small"));
 		(void) zfs_error(hdl, EZFS_BADDEV, msg);
 		break;
 
@@ -2850,7 +2932,8 @@ zpool_vdev_attach(zpool_handle_t *zhp,
 		 * The new device has a different optimal sector size.
 		 */
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-		    "new device has a different optimal sector size; use the "
+		    "reason=new device has a different optimal sector size; "
+		    "einfo=use the "
 		    "option '-o ashift=N' to override the optimal size"));
 		(void) zfs_error(hdl, EZFS_BADDEV, msg);
 		break;
@@ -2882,7 +2965,9 @@ zpool_vdev_detach(zpool_handle_t *zhp, const char *path)
 	libzfs_handle_t *hdl = zhp->zpool_hdl;
 
 	(void) snprintf(msg, sizeof (msg),
-	    dgettext(TEXT_DOMAIN, "cannot detach %s"), path);
+	    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.detach.vdev "
+	    "rname=%s msg=cannot detach %s"),
+	    path, path);
 
 	(void) strlcpy(zc.zc_name, zhp->zpool_name, sizeof (zc.zc_name));
 	if ((tgt = zpool_find_vdev(zhp, path, &avail_spare, &l2cache,
@@ -2906,7 +2991,7 @@ zpool_vdev_detach(zpool_handle_t *zhp, const char *path)
 		/*
 		 * Can't detach from this type of vdev.
 		 */
-		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "only "
+		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "reason=only "
 		    "applicable to mirror and replacing vdevs"));
 		(void) zfs_error(hdl, EZFS_BADTARGET, msg);
 		break;
@@ -2984,14 +3069,18 @@ zpool_vdev_split(zpool_handle_t *zhp, char *newname, nvlist_t **newroot,
 	int retval = 0;
 
 	(void) snprintf(msg, sizeof (msg),
-	    dgettext(TEXT_DOMAIN, "Unable to split %s"), zhp->zpool_name);
+	    dgettext(TEXT_DOMAIN, "ecode=cstor.unable.to.split.pool "
+	    "rname=%s msg=Unable to split %s"),
+	    zhp->zpool_name, zhp->zpool_name);
 
 	if (!zpool_name_valid(hdl, B_FALSE, newname))
 		return (zfs_error(hdl, EZFS_INVALIDNAME, msg));
 
 	if ((config = zpool_get_config(zhp, NULL)) == NULL) {
-		(void) fprintf(stderr, gettext("Internal error: unable to "
-		    "retrieve pool configuration\n"));
+		(void) fprintf(stderr,
+		    gettext("ecode=cstor.unable.to.split.pool "
+		    "rname=%s msg=Internal error: unable to "
+		    "retrieve pool configuration\n"), zhp->zpool_name);
 		return (-1);
 	}
 
@@ -3009,7 +3098,7 @@ zpool_vdev_split(zpool_handle_t *zhp, char *newname, nvlist_t **newroot,
 	if (nvlist_lookup_nvlist_array(tree, ZPOOL_CONFIG_CHILDREN, &child,
 	    &children) != 0) {
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-		    "Source pool is missing vdev tree"));
+		    "reason=Source pool is missing vdev tree"));
 		nvlist_free(zc_props);
 		return (-1);
 	}
@@ -3059,7 +3148,8 @@ zpool_vdev_split(zpool_handle_t *zhp, char *newname, nvlist_t **newroot,
 		    == 0);
 		if (strcmp(type, VDEV_TYPE_MIRROR) != 0) {
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "Source pool must be composed only of mirrors\n"));
+			    "reason=Source pool must be composed "
+			    "only of mirrors\n"));
 			retval = zfs_error(hdl, EZFS_INVALCONFIG, msg);
 			goto out;
 		}
@@ -3085,7 +3175,8 @@ zpool_vdev_split(zpool_handle_t *zhp, char *newname, nvlist_t **newroot,
 
 	/* did we find every disk the user specified? */
 	if (found != newchildren) {
-		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "Device list must "
+		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
+		    "reason=Device list must "
 		    "include at most one disk from each mirror"));
 		retval = zfs_error(hdl, EZFS_INVALCONFIG, msg);
 		goto out;
@@ -3189,7 +3280,9 @@ zpool_vdev_remove(zpool_handle_t *zhp, const char *path)
 	uint64_t version;
 
 	(void) snprintf(msg, sizeof (msg),
-	    dgettext(TEXT_DOMAIN, "cannot remove %s"), path);
+	    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.remove.vdev "
+	    "rname=%s, msg=cannot remove %s"),
+	    path, path);
 
 	(void) strlcpy(zc.zc_name, zhp->zpool_name, sizeof (zc.zc_name));
 	if ((tgt = zpool_find_vdev(zhp, path, &avail_spare, &l2cache,
@@ -3200,7 +3293,7 @@ zpool_vdev_remove(zpool_handle_t *zhp, const char *path)
 	 */
 	if (!avail_spare && !l2cache && !islog) {
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-		    "only inactive hot spares, cache, "
+		    "reason=only inactive hot spares, cache, "
 		    "or log devices can be removed"));
 		return (zfs_error(hdl, EZFS_NODEVICE, msg));
 	}
@@ -3208,7 +3301,7 @@ zpool_vdev_remove(zpool_handle_t *zhp, const char *path)
 	version = zpool_get_prop_int(zhp, ZPOOL_PROP_VERSION, NULL);
 	if (islog && version < SPA_VERSION_HOLES) {
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-		    "pool must be upgrade to support log removal"));
+		    "reason=pool must be upgrade to support log removal"));
 		return (zfs_error(hdl, EZFS_BADVERSION, msg));
 	}
 
@@ -3237,12 +3330,14 @@ zpool_clear(zpool_handle_t *zhp, const char *path, nvlist_t *rewindnvl)
 
 	if (path)
 		(void) snprintf(msg, sizeof (msg),
-		    dgettext(TEXT_DOMAIN, "cannot clear errors for %s"),
-		    path);
+		    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.clear.pool "
+		    "rname=%s msg=cannot clear errors for %s"),
+		    path, path);
 	else
 		(void) snprintf(msg, sizeof (msg),
-		    dgettext(TEXT_DOMAIN, "cannot clear errors for %s"),
-		    zhp->zpool_name);
+		    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.clear.pool "
+		    "rname=%s msg=cannot clear errors for %s"),
+		    zhp->zpool_name, zhp->zpool_name);
 
 	(void) strlcpy(zc.zc_name, zhp->zpool_name, sizeof (zc.zc_name));
 	if (path) {
@@ -3307,8 +3402,9 @@ zpool_vdev_clear(zpool_handle_t *zhp, uint64_t guid)
 	libzfs_handle_t *hdl = zhp->zpool_hdl;
 
 	(void) snprintf(msg, sizeof (msg),
-	    dgettext(TEXT_DOMAIN, "cannot clear errors for %llx"),
-	    (u_longlong_t)guid);
+	    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.clear.vdev "
+	    "rname=%llx msg=cannot clear errors for %llx"),
+	    (u_longlong_t)guid, (u_longlong_t)guid);
 
 	(void) strlcpy(zc.zc_name, zhp->zpool_name, sizeof (zc.zc_name));
 	zc.zc_guid = guid;
@@ -3331,7 +3427,9 @@ zpool_reguid(zpool_handle_t *zhp)
 	zfs_cmd_t zc = {"\0"};
 
 	(void) snprintf(msg, sizeof (msg),
-	    dgettext(TEXT_DOMAIN, "cannot reguid '%s'"), zhp->zpool_name);
+	    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.reguid.pool "
+	    "rname=%s msg=cannot reguid '%s'"),
+	    zhp->zpool_name, zhp->zpool_name);
 
 	(void) strlcpy(zc.zc_name, zhp->zpool_name, sizeof (zc.zc_name));
 	if (zfs_ioctl(hdl, ZFS_IOC_POOL_REGUID, &zc) == 0)
@@ -3351,8 +3449,9 @@ zpool_reopen(zpool_handle_t *zhp)
 	libzfs_handle_t *hdl = zhp->zpool_hdl;
 
 	(void) snprintf(msg, sizeof (msg),
-	    dgettext(TEXT_DOMAIN, "cannot reopen '%s'"),
-	    zhp->zpool_name);
+	    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.reopen.pool "
+	    "rname=%s msg=cannot reopen '%s'"),
+	    zhp->zpool_name, zhp->zpool_name);
 
 	(void) strlcpy(zc.zc_name, zhp->zpool_name, sizeof (zc.zc_name));
 	if (zfs_ioctl(hdl, ZFS_IOC_POOL_REOPEN, &zc) == 0)
@@ -3374,7 +3473,9 @@ zpool_sync_one(zpool_handle_t *zhp, void *data)
 	if ((ret = lzc_sync(pool_name, innvl, NULL)) != 0) {
 		nvlist_free(innvl);
 		return (zpool_standard_error_fmt(hdl, ret,
-		    dgettext(TEXT_DOMAIN, "sync '%s' failed"), pool_name));
+		    dgettext(TEXT_DOMAIN, "ecode=cstor.pool.sync.failed "
+		    "rname=%s msg=sync '%s' failed"),
+		    pool_name, pool_name));
 	}
 	nvlist_free(innvl);
 
@@ -3814,8 +3915,9 @@ zpool_upgrade(zpool_handle_t *zhp, uint64_t new_version)
 
 	if (zfs_ioctl(hdl, ZFS_IOC_POOL_UPGRADE, &zc) != 0)
 		return (zpool_standard_error_fmt(hdl, errno,
-		    dgettext(TEXT_DOMAIN, "cannot upgrade '%s'"),
-		    zhp->zpool_name));
+		    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.upgrade.pool "
+		    "rname=%s msg=cannot upgrade '%s'"),
+		    zhp->zpool_name, zhp->zpool_name));
 	return (0);
 }
 
@@ -3874,20 +3976,28 @@ get_history(zpool_handle_t *zhp, char *buf, uint64_t *off, uint64_t *len)
 		case EPERM:
 			return (zfs_error_fmt(hdl, EZFS_PERM,
 			    dgettext(TEXT_DOMAIN,
-			    "cannot show history for pool '%s'"),
-			    zhp->zpool_name));
+			    "ecode=cstor.cannot.get.pool.history "
+			    "rname=%s msg=cannot show history for pool '%s'"),
+			    zhp->zpool_name, zhp->zpool_name));
 		case ENOENT:
 			return (zfs_error_fmt(hdl, EZFS_NOHISTORY,
-			    dgettext(TEXT_DOMAIN, "cannot get history for pool "
-			    "'%s'"), zhp->zpool_name));
+			    dgettext(TEXT_DOMAIN,
+			    "ecode=cstor.cannot.get.pool.history "
+			    "rname=%s msg=cannot get history for pool "
+			    "'%s'"), zhp->zpool_name, zhp->zpool_name));
 		case ENOTSUP:
 			return (zfs_error_fmt(hdl, EZFS_BADVERSION,
-			    dgettext(TEXT_DOMAIN, "cannot get history for pool "
-			    "'%s', pool must be upgraded"), zhp->zpool_name));
+			    dgettext(TEXT_DOMAIN,
+			    "ecode=cstor.cannot.get.pool.history "
+			    "rname=%s msg=cannot get history for pool "
+			    "'%s', pool must be upgraded"),
+			    zhp->zpool_name, zhp->zpool_name));
 		default:
 			return (zpool_standard_error_fmt(hdl, errno,
 			    dgettext(TEXT_DOMAIN,
-			    "cannot get history for '%s'"), zhp->zpool_name));
+			    "ecode=cstor.cannot.get.pool.history rname=%s "
+			    "msg=cannot get history for '%s'"),
+			    zhp->zpool_name, zhp->zpool_name));
 		}
 	}
 
@@ -4313,7 +4423,9 @@ zpool_label_disk(libzfs_handle_t *hdl, zpool_handle_t *zhp, char *name)
 
 	/* prepare an error message just in case */
 	(void) snprintf(errbuf, sizeof (errbuf),
-	    dgettext(TEXT_DOMAIN, "cannot label '%s'"), name);
+	    dgettext(TEXT_DOMAIN,
+	    "ecode=cstor.cannot.label.disk rname=%s msg=cannot label '%s'"),
+	    name, name);
 
 	if (zhp) {
 		nvlist_t *nvroot;
@@ -4338,8 +4450,10 @@ zpool_label_disk(libzfs_handle_t *hdl, zpool_handle_t *zhp, char *name)
 		 * This shouldn't happen.  We've long since verified that this
 		 * is a valid device.
 		 */
-		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "cannot "
-		    "label '%s': unable to open device: %d"), path, errno);
+		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
+		    "ecode=cstor.cannot.label.disk rname=%s msg=cannot "
+		    "label '%s' reason=unable to open device: %d"),
+		    path, path, errno);
 		return (zfs_error(hdl, EZFS_OPENFAILED, errbuf));
 	}
 
@@ -4352,8 +4466,10 @@ zpool_label_disk(libzfs_handle_t *hdl, zpool_handle_t *zhp, char *name)
 			(void) no_memory(hdl);
 
 		(void) close(fd);
-		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "cannot "
-		    "label '%s': unable to read disk capacity"), path);
+		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
+		    "ecode=cstor.cannot.label.disk rname=%s msg=cannot "
+		    "label '%s' reason=unable to read disk capacity"),
+		    path, path);
 
 		return (zfs_error(hdl, EZFS_NOCAP, errbuf));
 	}
@@ -4401,7 +4517,7 @@ zpool_label_disk(libzfs_handle_t *hdl, zpool_handle_t *zhp, char *name)
 		(void) close(fd);
 		efi_free(vtoc);
 
-		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "try using "
+		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "einfo=try using "
 		    "parted(8) and then provide a specific slice: %d"), rval);
 		return (zfs_error(hdl, EZFS_LABELFAILED, errbuf));
 	}
@@ -4415,7 +4531,7 @@ zpool_label_disk(libzfs_handle_t *hdl, zpool_handle_t *zhp, char *name)
 	/* Wait to udev to signal use the device has settled. */
 	rval = zpool_label_disk_wait(path, DISK_LABEL_WAIT);
 	if (rval) {
-		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "failed to "
+		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "reason=failed to "
 		    "detect device partitions on '%s': %d"), path, rval);
 		return (zfs_error(hdl, EZFS_LABELFAILED, errbuf));
 	}
@@ -4424,8 +4540,9 @@ zpool_label_disk(libzfs_handle_t *hdl, zpool_handle_t *zhp, char *name)
 	(void) snprintf(path, sizeof (path), "%s/%s", DISK_ROOT, name);
 	rval = zpool_label_disk_check(path);
 	if (rval) {
-		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "freshly written "
-		    "EFI label on '%s' is damaged.  Ensure\nthis device "
+		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
+		    "einfo=freshly written "
+		    "EFI label on '%s' is damaged.  Ensure this device "
 		    "is not in in use, and is functioning properly: %d"),
 		    path, rval);
 		return (zfs_error(hdl, EZFS_LABELFAILED, errbuf));

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -950,7 +950,7 @@ zpool_name_valid(libzfs_handle_t *hdl, boolean_t isopen, const char *pool)
 	    strcmp(pool, "log") == 0)) {
 		if (hdl != NULL)
 			zfs_error_aux(hdl,
-			    dgettext(TEXT_DOMAIN, "name is reserved"));
+			    dgettext(TEXT_DOMAIN, "reason=name is reserved"));
 		return (B_FALSE);
 	}
 
@@ -960,59 +960,59 @@ zpool_name_valid(libzfs_handle_t *hdl, boolean_t isopen, const char *pool)
 			switch (why) {
 			case NAME_ERR_TOOLONG:
 				zfs_error_aux(hdl,
-				    dgettext(TEXT_DOMAIN, "name is too long"));
+				    dgettext(TEXT_DOMAIN, "reason=name is too long"));
 				break;
 
 			case NAME_ERR_INVALCHAR:
 				zfs_error_aux(hdl,
-				    dgettext(TEXT_DOMAIN, "invalid character "
+				    dgettext(TEXT_DOMAIN, "reason=invalid character "
 				    "'%c' in pool name"), what);
 				break;
 
 			case NAME_ERR_NOLETTER:
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "name must begin with a letter"));
+				    "reason=name must begin with a letter"));
 				break;
 
 			case NAME_ERR_RESERVED:
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "name is reserved"));
+				    "reason=name is reserved"));
 				break;
 
 			case NAME_ERR_DISKLIKE:
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "pool name is reserved"));
+				    "reason=pool name is reserved"));
 				break;
 
 			case NAME_ERR_LEADING_SLASH:
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "leading slash in name"));
+				    "reason=leading slash in name"));
 				break;
 
 			case NAME_ERR_EMPTY_COMPONENT:
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "empty component in name"));
+				    "reason=empty component in name"));
 				break;
 
 			case NAME_ERR_TRAILING_SLASH:
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "trailing slash in name"));
+				    "reason=trailing slash in name"));
 				break;
 
 			case NAME_ERR_MULTIPLE_DELIMITERS:
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "multiple '@' and/or '#' delimiters in "
+				    "reason=multiple '@' and/or '#' delimiters in "
 				    "name"));
 				break;
 
 			case NAME_ERR_NO_AT:
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "permission set is missing '@'"));
+				    "reason=permission set is missing '@'"));
 				break;
 
 			default:
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "(%d) not defined"), why);
+				    "reason=(%d) not defined"), why);
 				break;
 			}
 		}
@@ -1164,7 +1164,7 @@ zpool_create(libzfs_handle_t *hdl, const char *pool, nvlist_t *nvroot,
 	int ret = -1;
 
 	(void) snprintf(msg, sizeof (msg), dgettext(TEXT_DOMAIN,
-	    "cannot create '%s'"), pool);
+	    "ecode=cstor.cannot.create.pool rname=%s msg=cannot create '%s'"), pool, pool);
 
 	if (!zpool_name_valid(hdl, B_FALSE, pool))
 		return (zfs_error(hdl, EZFS_INVALIDNAME, msg));
@@ -1224,8 +1224,8 @@ zpool_create(libzfs_handle_t *hdl, const char *pool, nvlist_t *nvroot,
 			 * part of an active md or lvm device.
 			 */
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "one or more vdevs refer to the same device, or "
-			    "one of\nthe devices is part of an active md or "
+			    "reason=one or more vdevs refer to the same device, or "
+			    "one of the devices is part of an active md or "
 			    "lvm device"));
 			return (zfs_error(hdl, EZFS_BADDEV, msg));
 
@@ -1241,7 +1241,7 @@ zpool_create(libzfs_handle_t *hdl, const char *pool, nvlist_t *nvroot,
 			 * from the pool.
 			 */
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "record size invalid"));
+			    "reason=record size invalid"));
 			return (zfs_error(hdl, EZFS_BADPROP, msg));
 
 		case EOVERFLOW:
@@ -1258,19 +1258,19 @@ zpool_create(libzfs_handle_t *hdl, const char *pool, nvlist_t *nvroot,
 				    sizeof (buf));
 
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "one or more devices is less than the "
+				    "reason=one or more devices is less than the "
 				    "minimum size (%s)"), buf);
 			}
 			return (zfs_error(hdl, EZFS_BADDEV, msg));
 
 		case ENOSPC:
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "one or more devices is out of space"));
+			    "reason=one or more devices is out of space"));
 			return (zfs_error(hdl, EZFS_BADDEV, msg));
 
 		case ENOTBLK:
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "cache device must be a disk or disk slice"));
+			    "reason=cache device must be a disk or disk slice"));
 			return (zfs_error(hdl, EZFS_BADDEV, msg));
 
 		default:
@@ -1306,11 +1306,11 @@ zpool_destroy(zpool_handle_t *zhp, const char *log_str)
 
 	if (zfs_ioctl(hdl, ZFS_IOC_POOL_DESTROY, &zc) != 0) {
 		(void) snprintf(msg, sizeof (msg), dgettext(TEXT_DOMAIN,
-		    "cannot destroy '%s'"), zhp->zpool_name);
+		    "ecode=cstor.cannot.destroy.pool rname=%s msg=cannot destroy '%s'"), zhp->zpool_name, zhp->zpool_name);
 
 		if (errno == EROFS) {
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "one or more devices is read only"));
+			    "reason=one or more devices is read only"));
 			(void) zfs_error(hdl, EZFS_BADDEV, msg);
 		} else {
 			(void) zpool_standard_error(hdl, errno, msg);
@@ -1344,13 +1344,13 @@ zpool_add(zpool_handle_t *zhp, nvlist_t *nvroot)
 	uint_t nspares, nl2cache;
 
 	(void) snprintf(msg, sizeof (msg), dgettext(TEXT_DOMAIN,
-	    "cannot add to '%s'"), zhp->zpool_name);
+	    "ecode=cstor.cannot.add.to.pool rname=%s msg=cannot add to '%s'"), zhp->zpool_name, zhp->zpool_name);
 
 	if (zpool_get_prop_int(zhp, ZPOOL_PROP_VERSION, NULL) <
 	    SPA_VERSION_SPARES &&
 	    nvlist_lookup_nvlist_array(nvroot, ZPOOL_CONFIG_SPARES,
 	    &spares, &nspares) == 0) {
-		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "pool must be "
+		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "reason=pool must be "
 		    "upgraded to add hot spares"));
 		return (zfs_error(hdl, EZFS_BADVERSION, msg));
 	}
@@ -1359,7 +1359,7 @@ zpool_add(zpool_handle_t *zhp, nvlist_t *nvroot)
 	    SPA_VERSION_L2CACHE &&
 	    nvlist_lookup_nvlist_array(nvroot, ZPOOL_CONFIG_L2CACHE,
 	    &l2cache, &nl2cache) == 0) {
-		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "pool must be "
+		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "reason=pool must be "
 		    "upgraded to add cache devices"));
 		return (zfs_error(hdl, EZFS_BADVERSION, msg));
 	}
@@ -1378,7 +1378,7 @@ zpool_add(zpool_handle_t *zhp, nvlist_t *nvroot)
 			 * label.
 			 */
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "one or more vdevs refer to the same device"));
+			    "reason=one or more vdevs refer to the same device"));
 			(void) zfs_error(hdl, EZFS_BADDEV, msg);
 			break;
 
@@ -1396,7 +1396,7 @@ zpool_add(zpool_handle_t *zhp, nvlist_t *nvroot)
 				    sizeof (buf));
 
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "device is less than the minimum "
+				    "reason=device is less than the minimum "
 				    "size (%s)"), buf);
 			}
 			(void) zfs_error(hdl, EZFS_BADDEV, msg);
@@ -1404,13 +1404,13 @@ zpool_add(zpool_handle_t *zhp, nvlist_t *nvroot)
 
 		case ENOTSUP:
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "pool must be upgraded to add these vdevs"));
+			    "reason=pool must be upgraded to add these vdevs"));
 			(void) zfs_error(hdl, EZFS_BADVERSION, msg);
 			break;
 
 		case ENOTBLK:
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "cache device must be a disk or disk slice"));
+			    "reason=cache device must be a disk or disk slice"));
 			(void) zfs_error(hdl, EZFS_BADDEV, msg);
 			break;
 
@@ -1627,8 +1627,8 @@ zpool_import(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
 	if (altroot != NULL) {
 		if (nvlist_alloc(&props, NV_UNIQUE_NAME, 0) != 0) {
 			return (zfs_error_fmt(hdl, EZFS_NOMEM,
-			    dgettext(TEXT_DOMAIN, "cannot import '%s'"),
-			    newname));
+			    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.import.pool rname=%s msg=cannot import '%s'"),
+			    newname, newname));
 		}
 
 		if (nvlist_add_string(props,
@@ -1637,8 +1637,8 @@ zpool_import(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
 		    zpool_prop_to_name(ZPOOL_PROP_CACHEFILE), "none") != 0) {
 			nvlist_free(props);
 			return (zfs_error_fmt(hdl, EZFS_NOMEM,
-			    dgettext(TEXT_DOMAIN, "cannot import '%s'"),
-			    newname));
+			    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.import.pool rname=%s msg=cannot import '%s'"),
+			    newname, newname));
 		}
 	}
 
@@ -1725,13 +1725,13 @@ zpool_import_props(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
 	    &origname) == 0);
 
 	(void) snprintf(errbuf, sizeof (errbuf), dgettext(TEXT_DOMAIN,
-	    "cannot import pool '%s'"), origname);
+	    "ecode=cstor.cannot.import.pool rname=%s msg=cannot import pool '%s'"), origname, origname);
 
 	if (newname != NULL) {
 		if (!zpool_name_valid(hdl, B_FALSE, newname))
 			return (zfs_error_fmt(hdl, EZFS_INVALIDNAME,
-			    dgettext(TEXT_DOMAIN, "cannot import '%s'"),
-			    newname));
+			    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.import.pool rname=%s msg=cannot import '%s'"),
+			    newname, newname));
 		thename = (char *)newname;
 	} else {
 		thename = origname;
@@ -1802,29 +1802,29 @@ zpool_import_props(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
 
 		if (newname == NULL)
 			(void) snprintf(desc, sizeof (desc),
-			    dgettext(TEXT_DOMAIN, "cannot import '%s'"),
-			    thename);
+			    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.import.pool rname=%s msg=cannot import '%s'"),
+			    thename, thename);
 		else
 			(void) snprintf(desc, sizeof (desc),
-			    dgettext(TEXT_DOMAIN, "cannot import '%s' as '%s'"),
-			    origname, thename);
+			    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.import.pool rname=%s msg=cannot import '%s' as '%s'"),
+			    origname, origname, thename);
 
 		switch (error) {
 		case ENOTSUP:
 			if (nv != NULL && nvlist_lookup_nvlist(nv,
 			    ZPOOL_CONFIG_LOAD_INFO, &nvinfo) == 0 &&
 			    nvlist_exists(nvinfo, ZPOOL_CONFIG_UNSUP_FEAT)) {
-				(void) printf(dgettext(TEXT_DOMAIN, "This "
+				(void) printf(dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.import.pool rname=%s msg=cannot import '%s' reason=This "
 				    "pool uses the following feature(s) not "
-				    "supported by this system:\n"));
+				    "supported by this system: "), thename, thename);
 				zpool_print_unsup_feat(nv);
 				if (nvlist_exists(nvinfo,
 				    ZPOOL_CONFIG_CAN_RDONLY)) {
 					(void) printf(dgettext(TEXT_DOMAIN,
 					    "All unsupported features are only "
 					    "required for writing to the pool."
-					    "\nThe pool can be imported using "
-					    "'-o readonly=on'.\n"));
+					    " The pool can be imported using "
+					    "'-o readonly=on'. "));
 				}
 			}
 			/*
@@ -1855,18 +1855,18 @@ zpool_import_props(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
 
 				if (mmp_state == MMP_STATE_ACTIVE) {
 					(void) snprintf(aux, sizeof (aux),
-					    dgettext(TEXT_DOMAIN, "pool is imp"
+					    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.import.pool rname=%s msg=cannot import '%s' reason=pool is imp"
 					    "orted on host '%s' (hostid=%lx).\n"
 					    "Export the pool on the other "
 					    "system, then run 'zpool import'."),
-					    hostname, (unsigned long) hostid);
+					    thename, thename, hostname, (unsigned long) hostid);
 				} else if (mmp_state == MMP_STATE_NO_HOSTID) {
 					(void) snprintf(aux, sizeof (aux),
-					    dgettext(TEXT_DOMAIN, "pool has "
+					    dgettext(TEXT_DOMAIN, "ecode=cstor.cannot.import.pool rname=%s msg=cannot import '%s' reason=pool has "
 					    "the multihost property on and "
-					    "the\nsystem's hostid is not set. "
+					    "the system's hostid is not set. "
 					    "Set a unique system hostid with "
-					    "the zgenhostid(8) command.\n"));
+					    "the zgenhostid(8) command. "), thename, thename);
 				}
 
 				(void) zfs_error_aux(hdl, aux);
@@ -1880,7 +1880,7 @@ zpool_import_props(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
 
 		case EROFS:
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "one or more devices is read only"));
+			    "reason=one or more devices is read only"));
 			(void) zfs_error(hdl, EZFS_BADDEV, desc);
 			break;
 
@@ -1890,10 +1890,10 @@ zpool_import_props(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
 			    nvlist_lookup_nvlist(nvinfo,
 			    ZPOOL_CONFIG_MISSING_DEVICES, &missing) == 0) {
 				(void) printf(dgettext(TEXT_DOMAIN,
-				    "The devices below are missing, use "
-				    "'-m' to import the pool anyway:\n"));
+				    "ecode=cstor.cannot.import.pool rname=%s msg=cannot import '%s' reason=The devices below are missing, use "
+				    "'-m' to import the pool anyway: "), thename, thename);
 				print_vdev_tree(hdl, NULL, missing, 2);
-				(void) printf("\n");
+				(void) printf(" ");
 			}
 			(void) zpool_standard_error(hdl, error, desc);
 			break;
@@ -1904,12 +1904,12 @@ zpool_import_props(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
 
 		case EBUSY:
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "one or more devices are already in use\n"));
+			    "reason=one or more devices are already in use\n"));
 			(void) zfs_error(hdl, EZFS_BADDEV, desc);
 			break;
 		case ENAMETOOLONG:
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "new name of at least one dataset is longer than "
+			    "reason=new name of at least one dataset is longer than "
 			    "the maximum allowable length"));
 			(void) zfs_error(hdl, EZFS_NAMETOOLONG, desc);
 			break;


### PR DESCRIPTION
zpool logs with ecode, msg and reason
Logging format changed for supporting automatic alert generation through elastalert

Signed-off-by: moteesh <moteesh@gmail.com>


