### PR TITLE
add(stats): add quorum property to zfs stats cmd

### DIFF
--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -392,6 +392,8 @@ uzfs_ioc_stats(zfs_cmd_t *zc, nvlist_t *nvl)
 			    zv->checkpointed_time);
 			fnvlist_add_uint64(innvl, "zvol_workers",
 			    zv->main_zv->zvol_workers);
+			fnvlist_add_uint64(innvl, "quorum",
+			    uzfs_zinfo_get_quorum(zv));
 
 			fnvlist_add_uint64(innvl, "rebuildBytes",
 			    zv->main_zv->rebuild_info.rebuild_bytes);

--- a/tests/cstor/gtest/test_zrepl_prot.cc
+++ b/tests/cstor/gtest/test_zrepl_prot.cc
@@ -1041,6 +1041,10 @@ TEST_F(ZreplDataTest, RebuildFlag) {
 	output = execCmd("zfs", std::string("stats ") + m_zvol_name1);
 	ASSERT_NE(output.find("Degraded"), std::string::npos);
 
+	/* volume is created with quorum off */
+	output = execCmd("zfs", std::string("stats ") + m_zvol_name1);
+	ASSERT_NE(output.find("\"quorum\":0"), std::string::npos);
+
 	/* transition the zvol to online state */
 	transition_zvol_to_online(m_ioseq1, m_control_fd1, m_zvol_name1);
 
@@ -1056,6 +1060,10 @@ TEST_F(ZreplDataTest, RebuildFlag) {
 
 	output = execCmd("zfs", std::string("stats ") + m_zvol_name1);
 	ASSERT_NE(output.find("Healthy"), std::string::npos);
+
+	/* Volume became healthy so quorum is expected to be 1 from stats*/
+	output = execCmd("zfs", std::string("stats ") + m_zvol_name1);
+	ASSERT_NE(output.find("\"quorum\":1"), std::string::npos);
 
 	/* read the block without rebuild flag */
 	read_data_start(m_datasock1.fd(), m_ioseq1, 0, sizeof (buf), &hdr_in, &read_hdr);


### PR DESCRIPTION
This commit adds quorum property to zfs stats command

Sample output:
```sh
{"stats":[{"name":"ihandshake\/ivol1","status":"Degraded","rebuildStatus":"INIT","isIOAckSenderCreated":1,"isIOReceiverCreated":1,"runningIONum":654,"checkpointedIONum":0,"degradedCheckpointedIONum":333,"checkpointedTime":0,"zvol_workers":4,"quorum":0,"rebuildBytes":0,"rebuildCnt":0,"rebuildDoneCnt":0,"rebuildFailedCnt":0,"readCount":7,"readLatency":2331975,"readByte":20544,"writeCount":7,"writeLatency":2516642,"writeByte":24672,"syncCount":1,"syncLatency":105875256,"inflightIOCnt":0,"dispatchedIOCnt":0,"ruio":{"32KB":"20544\/7\/2331975"},"wuio":{"32KB":"24672\/7\/2516642"}}]}
```

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
