### PR TITLE
refactor[gitlab-yaml]: Updated the branch name for packet platform

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -172,6 +172,6 @@ baseline-image:
      - git commit -m "updated $CI_PROJECT_NAME commit:$COMMIT"
      - git push  https://$user:$pass@github.com/$REPO/e2e-infrastructure.git --all
      - if [[ "$BRANCH" == "develop" ]] ; then export INFRA="master" ; else export INFRA=$BRANCH ; fi
-     - curl -X POST -F variable[INFRA_BRANCH]=$INFRA -F token=$PACKET -F ref=k8s-1-13 https://gitlab.openebs.ci/api/v4/projects/27/trigger/pipeline
-     - curl -X POST -F variable[INFRA_BRANCH]=$INFRA -F token=$PACKET -F ref=k8s-1-14 https://gitlab.openebs.ci/api/v4/projects/27/trigger/pipeline
-     - curl -X POST -F variable[INFRA_BRANCH]=$INFRA -F token=$PACKET -F ref=k8s-1-15 https://gitlab.openebs.ci/api/v4/projects/27/trigger/pipeline
+     - curl -X POST -F variable[INFRA_BRANCH]=$INFRA -F token=$PACKET -F ref=k8s-ultimate https://gitlab.openebs.ci/api/v4/projects/27/trigger/pipeline
+     - curl -X POST -F variable[INFRA_BRANCH]=$INFRA -F token=$PACKET -F ref=k8s-penultimate https://gitlab.openebs.ci/api/v4/projects/27/trigger/pipeline
+     - curl -X POST -F variable[INFRA_BRANCH]=$INFRA -F token=$PACKET -F ref=k8s-antepenultimate https://gitlab.openebs.ci/api/v4/projects/27/trigger/pipeline


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Modified the Branch names for packet platform. For a every K8s release we were creating a new branch in gitlab repo and we have to modify the branch name in gitlab ci yaml. To avoid this branch name has been changed as a generic name. As for now.
```
k8s-ultimate means last newer release version [1.16]
k8s-penultimate - second last [1.15]
k8s-antepenultimate - Third last [1.14]
```