### PR TITLE
fix(core): disabling dumping cores

### DIFF
--- a/docker/entrypoint-poolimage.sh
+++ b/docker/entrypoint-poolimage.sh
@@ -14,6 +14,11 @@ echo "reference: "  $0
 if [ -z "$LOGLEVEL" ]; then
 	LOGLEVEL=info
 fi
+
+# Disabling coredumps by default in the shell where zrepl runs
+ulimit -c 0
+# Being ulimit shell specific, ulimit -c in container shows as unlimited
+
 echo "sleeping for 2 sec"
 sleep 2
 ARCH=$(uname -m)

--- a/docker/entrypoint-poolimage.sh
+++ b/docker/entrypoint-poolimage.sh
@@ -16,7 +16,9 @@ if [ -z "$LOGLEVEL" ]; then
 fi
 
 # Disabling coredumps by default in the shell where zrepl runs
-ulimit -c 0
+if [ -z "$ENABLE_COREDUMP" ]; then
+	ulimit -c 0
+fi
 # Being ulimit shell specific, ulimit -c in container shows as unlimited
 
 echo "sleeping for 2 sec"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
Coredumps are enabled by default in cstor-pool container. It consumes space on OS disk.
This PR is to disable dumping cores by default. Added env variable "ENABLE_COREDUMP". Setting this to 1 starts dumping the cores on zrepl crash.

Signed-off-by: Vitta <vitta@mayadata.io>