### PR TITLE
fix(entrypoint): dump cores on persistent location

### DIFF
--- a/docker/entrypoint-poolimage.sh
+++ b/docker/entrypoint-poolimage.sh
@@ -17,9 +17,15 @@ fi
 
 # Disabling coredumps by default in the shell where zrepl runs
 if [ -z "$ENABLE_COREDUMP" ]; then
+	echo "Disabling dumping core"
 	ulimit -c 0
+else
+	echo "Enabling coredumps"
+	ulimit -c unlimited
+	cd /var/openebs/sparse || exit
 fi
-# Being ulimit shell specific, ulimit -c in container shows as unlimited
+# ulimit being shell specific, ulimit -c in container shows as unlimited
+
 
 echo "sleeping for 2 sec"
 sleep 2


### PR DESCRIPTION
This is continuation to https://github.com/openebs/cstor/pull/282

In this PR, on enabling coredumps, coredumps gets collected onto hostpath "/var/openebs/sparse" which is persistent storage.

Without any directory set in core pattern, core dumps gets collected to the CWD of the shell from which child process got started.

Tested with command like: `docker run --env ENABLE_COREDUMP=1 --mount 'type=bind,src=/home/vitta/Desktop,dst=/var/openebs/sparse' openebs/cstor-pool:ulimit5` 

Signed-off-by: Vitta <vitta@mayadata.io>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
