### PR TITLE
fix(core): dump cores on persistent location based on env

### DIFF
--- a/docker/entrypoint-poolimage.sh
+++ b/docker/entrypoint-poolimage.sh
@@ -22,7 +22,8 @@ if [ -z "$ENABLE_COREDUMP" ]; then
 else
 	echo "Enabling coredumps"
 	ulimit -c unlimited
-	cd /var/openebs/sparse || exit
+	## dump the core on PERSISTENT_STORAGE_PATH in host machine
+	cd $PERSISTENT_STORAGE_PATH || exit
 fi
 # ulimit being shell specific, ulimit -c in container shows as unlimited
 

--- a/docker/entrypoint-poolimage.sh
+++ b/docker/entrypoint-poolimage.sh
@@ -22,8 +22,12 @@ if [ -z "$ENABLE_COREDUMP" ]; then
 else
 	echo "Enabling coredumps"
 	ulimit -c unlimited
-	## dump the core on PERSISTENT_STORAGE_PATH in host machine
-	cd $PERSISTENT_STORAGE_PATH || exit
+	## /var/openebs is mounted as persistent directory on
+	## host machine
+	cd /var/openebs || exit
+	mkdir -p core
+	cd core
+
 fi
 # ulimit being shell specific, ulimit -c in container shows as unlimited
 


### PR DESCRIPTION
This PR dumps the core on persistent location i.e /var/openebs/core which is mounted on
host path(OPENEBS_BASE_DIR/cstor-pool/<SPC_NAME>).

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
