### PR TITLE
fix(core): dump cores on persistent location

### DIFF
--- a/docker/entrypoint-poolimage.sh
+++ b/docker/entrypoint-poolimage.sh
@@ -24,7 +24,7 @@ else
 	ulimit -c unlimited
 	## /var/openebs is mounted as persistent directory on
 	## host machine
-	cd /var/openebs || exit
+	cd /var/openebs/cstor-pool || exit
 	mkdir -p core
 	cd core
 


### PR DESCRIPTION
This PR is continuation of #284. To make a cleaner directory structure on the host machine cstor-pool will dump core on `/var/openebs/cstor-pool` which is mounted on host path i.e `$BASE_DIR/cstor-pool/<cspc_name>`.

Maya PR for mounting in corresponding mount paths: https://github.com/openebs/maya/pull/1589



<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
