### PR TITLE
feat(list_snap): `zfs listsnap` CLI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ branches:
   only:
     - develop
     - zfs-0.7-release
+    - listsnap
     - /^\d+\.\d+(\.\d+)?(-\S*)?$/
     - /^v\d+\.\d+(\.\S*)?$/
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ install:
       fi
     - cd ..
     # Build libcstor for uzfs feature
-    - git clone https://github.com/openebs/libcstor.git
+    - git clone https://github.com/vishnuitta/libcstor.git
     - cd libcstor
     - if [ ${TRAVIS_BRANCH} == "develop" ]; then git checkout master; else git checkout ${TRAVIS_BRANCH} || git checkout master; fi
     - sh autogen.sh;

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ branches:
   only:
     - develop
     - zfs-0.7-release
-    - listsnap
     - /^\d+\.\d+(\.\d+)?(-\S*)?$/
     - /^v\d+\.\d+(\.\S*)?$/
 env:
@@ -63,7 +62,7 @@ install:
       fi
     - cd ..
     # Build libcstor for uzfs feature
-    - git clone https://github.com/vishnuitta/libcstor.git
+    - git clone https://github.com/openebs/libcstor.git
     - cd libcstor
     - if [ ${TRAVIS_BRANCH} == "develop" ]; then git checkout master; else git checkout ${TRAVIS_BRANCH} || git checkout master; fi
     - sh autogen.sh;

--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -7095,12 +7095,12 @@ zfs_do_list_snap(int argc, char **argv)
 	char *str_val;
 
 	if (argc != 2) {
-		fprintf(stderr, "got list snap command %d\n", argc);
+		fprintf(stderr, "got listsnap command %d\n", argc);
 		usage(B_FALSE);
 	}
 
 	if ((error = lzc_list_snap(argv[1], NULL, &outnvl)) != 0) {
-		fprintf(stderr, "failed list snap command for %s with err %d\n",
+		fprintf(stderr, "failed listsnap command for %s with err %d\n",
 		    argv[1], error);
 		return (error);
 	}
@@ -7109,11 +7109,10 @@ zfs_do_list_snap(int argc, char **argv)
 		switch (nvpair_type(elem)) {
 			case DATA_TYPE_STRING:
 				nvpair_value_string(elem, &str_val);
-				fprintf(stdout, "%s: %s\n", nvpair_name(elem),
-				    str_val);
+				fprintf(stdout, "%s\n", str_val);
 				break;
 			default:
-				error = 2;
+				error = EAGAIN;
 				fprintf(stderr, "nvpair type : %d name:%s\n",
 				    nvpair_type(elem), nvpair_name(elem));
 		}

--- a/include/libzfs_core.h
+++ b/include/libzfs_core.h
@@ -96,6 +96,7 @@ int lzc_rollback_to(const char *, const char *);
 int lzc_sync(const char *, nvlist_t *, nvlist_t **);
 
 int lzc_stats(const char *dataset, nvlist_t *innvl, nvlist_t **outnvl);
+int lzc_list_snap(const char *dataset, nvlist_t *innvl, nvlist_t **outnvl);
 
 #ifdef	__cplusplus
 }

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -1071,6 +1071,7 @@ typedef enum zfs_ioc {
 	ZFS_IOC_RECV_NEW,
 	ZFS_IOC_POOL_SYNC,
 	ZFS_IOC_STATS,
+	ZFS_IOC_LIST_SNAP,
 
 	/*
 	 * Linux - 3/64 numbers reserved.

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -406,6 +406,12 @@ lzc_stats(const char *dataset, nvlist_t *innvl, nvlist_t **outnvl)
 	return (lzc_ioctl(ZFS_IOC_STATS, dataset, NULL, outnvl));
 }
 
+int
+lzc_list_snap(const char *dataset, nvlist_t *innvl, nvlist_t **outnvl)
+{
+	return (lzc_ioctl(ZFS_IOC_LIST_SNAP, dataset, NULL, outnvl));
+}
+
 /*
  * Create "user holds" on snapshots.  If there is a hold on a snapshot,
  * the snapshot can not be destroyed.  (However, it can be marked for deletion

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -7484,6 +7484,14 @@ uzfs_handle_ioctl(const char *pool, zfs_cmd_t *zc, uzfs_info_t *ucmd_info)
 		nvlist_free(outnvl);
 		break;
 	}
+	case ZFS_IOC_LIST_SNAP: {
+		nvlist_t *outnvl = fnvlist_alloc();
+		err = uzfs_ioc_list_snap(zc, outnvl);
+		if (err == 0)
+			err = put_nvlist(zc, outnvl);
+		nvlist_free(outnvl);
+		break;
+	}
 #endif
 	case ZFS_IOC_CLEAR: {
 		err = zfs_ioc_clear(zc);

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -354,17 +354,9 @@ uzfs_ioc_list_snap(zfs_cmd_t *zc, nvlist_t *nvl)
 	zvol_info_t *zinfo;
 	int error;
 
-	mutex_enter(&zvol_list_mutex);
-	SLIST_FOREACH(zinfo, &zvol_list, zinfo_next) {
-		if (uzfs_zvol_name_compare(zinfo, zc->zc_name) == 0) {
-			uzfs_zinfo_take_refcnt(zinfo);
-			break;
-		}
-	}
-	mutex_exit(&zvol_list_mutex);
-
+	zvol_info_t *zinfo = uzfs_zinfo_lookup(zc->zc_name);
 	if (zinfo == NULL)
-		return (0);
+		return (ENOENT);
 
 	error = uzfs_zvol_add_nvl_snapshot_list(zinfo, nvl);
 

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -354,7 +354,7 @@ uzfs_ioc_list_snap(zfs_cmd_t *zc, nvlist_t *nvl)
 	zvol_info_t *zinfo;
 	int error;
 
-	zvol_info_t *zinfo = uzfs_zinfo_lookup(zc->zc_name);
+	zinfo = uzfs_zinfo_lookup(zc->zc_name);
 	if (zinfo == NULL)
 		return (ENOENT);
 

--- a/tests/cstor/gtest/test_zrepl_prot.cc
+++ b/tests/cstor/gtest/test_zrepl_prot.cc
@@ -1856,7 +1856,6 @@ static void verify_listsnap_details(std::string zvol_name) {
 	while (!json_object_iter_equal(&it, &itEnd)) {
 		snapname = json_object_iter_peek_name(&it);
 		snapshot_output = execCmd("zfs", std::string("list -t snapshot -Ho name " + zvol_name + std::string("@") + snapname));
-		printf("%s\n", snapshot_output.c_str());
 		ASSERT_EQ(zvol_name + std::string("@") + snapname, snapshot_output);
 		json_object_iter_next(&it);
 	}


### PR DESCRIPTION
This PR adds the `zfs listsnap <dataset>` CLI.
For this command, output will be in json format as:
```
vitta@vitta-laptop:~/openebs/lzfs$ ./cmd/zfs/zfs listsnap pool1/ds0 | jq
{
  "name": "pool1/ds0",
  "snaplist": {
    "istgt1": null,
    "snap4": null,
    "istgt2": null,
    "snap1": null,
    "snap2": null,
    "istgt3": null,
    "snap3": null
  }
}
```
This will NOT list the snapshots created through 'zfs snapshot' until the zrepl is restarted. However, it lists the snapshots created through istgt iscsi target.

Even though existing `zfs list -t snapshot` gives the list of snapshots, difference with this CLI is just NOT about printing in json format. Main difference is in caching the response. This command implementation will NOT read the contents from disk for every trigger of the command. It does read from disk one time, and keeps updating it with the new snapshots name whenever istgt sends SNAP_CREATE command.

Working on testcases.

Signed-off-by: Vitta <vitta@mayadata.io>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->