### PR TITLE
fix(build): error in tagging the downstream repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -136,8 +136,14 @@ script:
     # but, release on downstream repository is triggered 
     # after `amd` images have been created. This is controlled
     # by ENV RELEASE_TAG_DOWNSTREAM.
+    #
+    # $TRAVIS_BRANCH contains the same value as $TRAVIS_TAG.
+    # Example: 1.9.0-RC1 tag and 1.9.0-RC1 branch. 
+    # OpenEBS release are done from branches named as v1.9.x. 
+    # Convert the TRAVIS_TAG to the corresponding release branch.
     - if [ ! -z $TRAVIS_TAG ] && [ $RELEASE_TAG_DOWNSTREAM = 1 ] && [ "$TRAVIS_REPO_SLUG" == "openebs/cstor" ]; then
-        ./buildscripts/git-release "openebs/istgt" "$TRAVIS_TAG" "$TRAVIS_BRANCH" || travis_terminate 1;
+        REL_BRANCH=$(echo v$(echo "$TRAVIS_TAG" | cut -d'-' -f1 | rev | cut -d'.' -f2- | rev).x) ;
+        ./buildscripts/git-release "openebs/istgt" "$TRAVIS_TAG" "$REL_BRANCH" || travis_terminate 1;
       fi
 after_failure:
     - find /var/tmp/test_results/current/log -type f -name '*' -printf "%f\n" -exec cut -c -$ZFS_TEST_TRAVIS_LOG_MAX_LENGTH {} \;


### PR DESCRIPTION
In case of travis, the $TRAVIS_BRANCH contains
the same value as $TRAVIS_TAG.

Example: 1.9.0-RC1 tag and 1.9.0-RC1 branch.

Due to this the git-release script failed.

This commit adds a step to convert the TRAVIS_TAG
to corresponding release branch.
Example: 1.9.0-RC1 should happen from v1.9.x

Note: OpenEBS release follow the SemVer release format
of major.minor.patch[-build-meta]

Tested the script with the following options:
```
$ echo v$(echo "1.9.0-RC1" | cut -d'-' -f1 | rev | cut -d'.' -f2- | rev).x
v1.9.x

$ echo v$(echo "1.9.0" | cut -d'-' -f1 | rev | cut -d'.' -f2- | rev).x
v1.9.x
```

Verified on travis using a test repo build/tag at: https://travis-ci.org/github/kmova/bootstrap/builds/672357252


Signed-off-by: kmova <kiran.mova@mayadata.io>

<!--- Provide a general summary of your changes in the Title above -->
<!--- Explain how the fix was tested -->
