### PR TITLE
refact(build): fixing git-release file to ignore error if tag already exists

### DIFF
--- a/buildscripts/git-release
+++ b/buildscripts/git-release
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2020 The OpenEBS Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -e
 
 if [ "$#" -ne 3 ]; then
@@ -46,6 +60,24 @@ RELEASE_CREATE_JSON=$(echo \
 TEMP_RESP_FILE=temp-curl-response.txt
 rm -rf ${TEMP_RESP_FILE}
 
+#is_release_already_exist verifies the output of API for error message
+#return 0 -- if release already exist
+#return 1 -- if release doesn't exist
+is_release_already_exist() {
+	dfile=$1
+
+	msg=$(cat $dfile | jq -r '.message')
+	code=$(cat $dfile | jq -r '.errors[0].code')
+	resource=$(cat $dfile | jq -r '.errors[0].resource')
+	error_len=$(cat $dfile | jq '.errors | length')
+
+	[[ "$msg" == "Validation Failed" ]] && \
+		[[ "$code" == "already_exists" ]] && \
+		[[ "$resource" -eq "Release" ]] && \
+		[[ $error_len -eq 1 ]] && \
+		echo 0 || echo 1
+}
+
 response_code=$(curl -u ${GIT_NAME}:${GIT_TOKEN} \
  -w "%{http_code}" \
  --silent \
@@ -62,7 +94,7 @@ rc_code=0
 #Github returns 201 Created on successfully creating a new release
 #201 means the request has been fulfilled and has resulted in one 
 #or more new resources being created.
-if [ $response_code != "201" ]; then
+if [ $response_code != "201" ] && [[ $(is_release_already_exist $TEMP_RESP_FILE) -ne 0 ]]; then
     echo "Error: Unable to create release. See below response for more details"
     #The GitHub error response is pretty well formatted.
     #Printing the body gives all the details to fix the errors
@@ -84,6 +116,8 @@ else
     #knowing that creation worked is all that matters now.
     echo "Successfully tagged $1 with release tag ${C_GIT_TAG_NAME} on branch ${C_GIT_TAG_BRANCH}"
 fi
+
+
 cat ${TEMP_RESP_FILE}
 
 #delete the temporary response file


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
git-release script returns error if release at targeted branch already exists. This PR address this issue.

**What this PR does?**:
Fix the git-release to validate the error message and return error only if tag creation failed.

**Does this PR require any upgrade changes?**:


**If the changes in this PR are manually verified, list down the scenarios covered and commands you used for testing with logs:**


**Any additional information for your reviewer?**:
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:

Signed-off-by: mayank <mayank.patel@mayadata.io>
