### PR TITLE
fix(cstor): Fix the value of CPU_SEQID. Fixes crash on arm64, optimization on amd64.

### DIFF
--- a/changelogs/unreleased/309-sgielen
+++ b/changelogs/unreleased/309-sgielen
@@ -1,0 +1,1 @@
+Fix wrong value of CPU_SEQID causing a crash on arm64

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -664,7 +664,7 @@ extern void delay(clock_t ticks);
 #define	maxclsyspri	-20
 #define	defclsyspri	0
 
-#define	CPU_SEQID	((uintptr_t)pthread_self() & (max_ncpus - 1))
+#define	CPU_SEQID	(((uintptr_t)pthread_self() >> 16) % boot_ncpus)
 
 #define	kcred		NULL
 #define	CRED()		NULL


### PR DESCRIPTION
Within the kernel, CPU_SEQID is defined to smp_processor_id, which returns the
ID of the current processor, between 0 and NR_CPUS. It's used in the ZFS code
to reduce lock contention.

In userspace, it is also intended to be used to reduce lock contention, but not
by defining it to the current CPU ID, since there's no portable and fast way to
get the ID of the current CPU. Instead, it is set using the last bits of
pthread_self() to find a value that will hopefully differ per thread. Since the
resulting value is used to index into arrays of size boot_ncpus, the amount of
CPUs in the system, the value must be lower than boot_ncpus.

Unintentionally, max_ncpus was used instead of boot_ncpus, causing a
possibility of returning a value outside of the array, causing an array out of
bounds read/write.

This was hidden in almost all cases, since pthread_self() actually seems to
return an aligned address on amd64, meaning the last bits are always zero,
therefore CPU_SEQID was always zero. Next to hiding the bug, this made the lock
contention evasion ineffective.

In this commit, there are three changes to the value of CPU_SEQID. First of
all, instead of using the least significant bits of pthread_self(), the value
is shifted right to skip the least significant bits. This ensures that even
with aligned addresses, the outcome will differ per thread. Then, instead of
using max_ncpus, boot_ncpus is used to bound by the actual number of CPUs in
the system, preventing array out-of-bounds. And, since we can't ensure that
boot_ncpus is a power of two, we can't use the bitwise AND, so we use the
modulus to reach the intended effect. This is somewhat slower, but since lock
contention has a much more beneficial effect, I expect performance will improve
overall.

For more background, also see https://github.com/openebs/openebs/issues/3028.

**Checklist:**
- [ ] Fixes #<issue number>
- [X] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [X] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: