### PR TITLE
fix(arm,build): changing ubuntu version in ARM cstor-base image

### DIFF
--- a/docker/Dockerfile.base.arm64
+++ b/docker/Dockerfile.base.arm64
@@ -3,7 +3,7 @@
 # libraries.
 #
 
-FROM arm64v8/ubuntu:18.04
+FROM arm64v8/ubuntu:16.04
 
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \ 

--- a/docker/Dockerfile.base.arm64
+++ b/docker/Dockerfile.base.arm64
@@ -3,7 +3,7 @@
 # libraries.
 #
 
-FROM arm64v8/ubuntu:16.04
+FROM openebs/arm64v8-ubuntu:xenial-20200326
 
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \ 


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
This PR is required to fix the issue https://github.com/openebs/openebs/issues/3037.

We are building ARM images for cstor from ubuntu:18.04, which is using libjson-c.3, while we are building cstor binaries in travis ARM machine, which is using ubuntu:16.04. Due to this image conflict between host and docker, we are facing issue with libjson-c library, while running cstor arm image. 

**What this PR does?**:
This PR changes docker file for ARM build, to user ubuntu version 16.04 from 18.04.

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered and commands you used for testing with logs:**


**Any additional information for your reviewer?**:
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes #https://github.com/openebs/openebs/issues/3037
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests

Signed-off-by: mynktl <mayank.patel@mayadata.io>
