### PR TITLE
fix(travis): fix lint errors in Travis yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,13 +96,10 @@ install:
         make --no-print-directory -s pkg-utils pkg-kmod || travis_terminate 1;
         sudo dpkg -i *.deb || travis_terminate 1;
       fi
+    # If build is to build uZFS feature then go to zrepl in libcstor and build zrepl binary
     - if [ $ZFS_BUILD_TAGS = 1 ]; then
-        # Return to libcstor code to complie zrepl which is responsible for uZFS feature.
-        # Save the current location to get back
         pushd .;
-        # Go to zrepl directory to build zrepl
         cd ../libcstor/cmd/zrepl && make || travis_terminate 1;
-        # return to cstor code
         popd;
       fi
 before_script:


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

## Pull Request template

Please, go through these steps before you submit a PR. ## Remove this line

**Why is this PR required? What issue does it fix?**:
This is required to trigger Travis on cstor repo.
Currently, cStor is not able to Trigger Travis because
of parsing errors in .travis.yml because travis doesn't
support comments in if block.
For more info about the issue please refer: https://github.com/travis-ci/travis-ci/issues/3990  

**What this PR does?**:
This PR is to fixes lint errors in Travis yml.

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered and commands you used for testing with logs:**
 - Verified the changes using `travis lint .travis.yaml`
   ```sh
   sai@cstor: travis lint .travis.yml
   Warnings for .travis.yml:
   [x] [warn] on root: deprecated key: sudo (The key \`sudo\` has no effect anymore.)
   ```
- Verified by copy-pasting the changes in online travis config [validator](https://config.travis-ci.com/explore). 

**Any additional information for your reviewer?**:
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: