### PR TITLE
fix(tests): replace writer thread with reader in tests

### DIFF
--- a/tests/cstor/gtest/test_uzfs.cc
+++ b/tests/cstor/gtest/test_uzfs.cc
@@ -2344,7 +2344,7 @@ TEST(uZFSRebuild, TestErroredRebuild) {
 	reader_thread = zk_thread_create(NULL, 0,
 	    verify_ios_from_two_replica, &wargs, 0, NULL, TS_RUN,
 	    0, 0);
-	zk_thread_join(writer_thread->t_tid);
+	zk_thread_join(reader_thread->t_tid);
 
 	uint64_t quorum = 0;
 	EXPECT_EQ(0, dsl_prop_get_integer(zinfo->main_zv->zv_name,


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>


**What this PR does?**:
- replace writer_thread with reader_thread as the number is not always the same in all systems


**Does this PR require any upgrade changes?**:


**If the changes in this PR are manually verified, list down the scenarios covered and commands you used for testing with logs:**


**Any additional information for your reviewer?**:
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: